### PR TITLE
OM-255 | Change the backend API name

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,8 @@
 REACT_APP_APPLICATION_NAME=$npm_package_name
 REACT_APP_OIDC_AUTHORITY="https://api.hel.fi/sso/openid/"
 REACT_APP_OIDC_CLIENT_ID="https://api.hel.fi/auth/omahelsinki"
-REACT_APP_PROFILE_AUDIENCE="https://api.hel.fi/auth/profiles"
+REACT_APP_PROFILE_AUDIENCE="https://api.hel.fi/auth/helsinkiprofile"
 REACT_APP_PROFILE_GRAPHQL=
 REACT_APP_OIDC_SCOPE="openid profile $REACT_APP_PROFILE_AUDIENCE"
 REACT_APP_SENTRY_DSN=
 REACT_APP_VERSION=$npm_package_version
-#TRANSLATION_LANGUAGES=en,fi,sv
-#TRANSLATIONS_URL=https://docs.google.com/spreadsheets/d/18dpV7aA-t_6zMRUO5hP7DMfx0q4hdu-AlLpRjkB_0zI/gviz/
-#TRANSLATION_PROJECT_NAME=

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After you've got tunnistamo running locally, make sure the automatically created
     Response types: `id_token token` must be enabled
     Redirect URIs: `http://localhost:3000/callback` and `http://localhost:3000/silent_renew` must be in the listed URLs
 
-Then make sure the *https://api.hel.fi/auth/profiles*-scope can be used by the **Project** application. Go to OIDC_APIS -> API Scopes -> https://api.hel.fi/auth/profiles and make sure **Project** is selected in Allowed applications.
+Then make sure the *https://api.hel.fi/auth/helsinkiprofile*-scope can be used by the **Project** application. Go to OIDC_APIS -> API Scopes -> https://api.hel.fi/auth/profiles and make sure **Project** is selected in Allowed applications.
 
 ### Install open-city-profile locally
 Clone the repository (https://github.com/City-of-Helsinki/open-city-profile). Follow the instructions for running open-city-profile with docker. Before running `docker-compose up` set the following settings in open-city-profile roots `docker-compose up`:


### PR DESCRIPTION
The API was previously called "profiles". Changed the configuration files to
reflect the current name "helsinkiprofile".