### PR TITLE
Add z-index to header

### DIFF
--- a/src/common/header/Header.module.css
+++ b/src/common/header/Header.module.css
@@ -2,6 +2,7 @@
   background: var(--hds-ui-color-white);
   height: 64px;
   position: sticky;
+  z-index: 1;
 }
 
 


### PR DESCRIPTION
This is so that FullscreenNavigation stays on top of the page (when opened) so position: relatives etc from headers siblings don't come through it