### PR TITLE
OM -553 | Fixed UI breaking with long names.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 REACT_APP_OIDC_AUTHORITY="https://tunnistamo.test.kuva.hel.ninja/"
 REACT_APP_OIDC_CLIENT_ID="https://api.hel.fi/auth/omahelsinki"
-REACT_APP_PROFILE_GRAPHQL="https://profiili-api.test.kuva.hel.ninja//graphql/"
+REACT_APP_PROFILE_GRAPHQL="https://profiili-api.test.kuva.hel.ninja/graphql/"

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 REACT_APP_OIDC_AUTHORITY="https://tunnistamo.test.kuva.hel.ninja/"
 REACT_APP_OIDC_CLIENT_ID="https://api.hel.fi/auth/omahelsinki"
-REACT_APP_PROFILE_GRAPHQL="https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+REACT_APP_PROFILE_GRAPHQL="https://profiili-api.test.kuva.hel.ninja//graphql/"

--- a/src/common/dropdown/Dropdown.module.css
+++ b/src/common/dropdown/Dropdown.module.css
@@ -16,7 +16,15 @@
 }
 
 .navButton {
-    max-width: 160px;
+    max-width: 180px;
+}
+
+.label {
+    max-width: 150px;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .icon {

--- a/src/common/dropdown/Dropdown.tsx
+++ b/src/common/dropdown/Dropdown.tsx
@@ -48,9 +48,7 @@ function Dropdown(props: Props) {
             className={styles.navButton}
             onClick={() => toggleDropdown(prevState => !prevState)}
           >
-            <span className={styles.label}>
-            {navBarItem.label}
-            </span>
+            <span className={styles.label}>{navBarItem.label}</span>
             {navBarItem.icon && (
               <img
                 src={navBarItem.icon}

--- a/src/common/dropdown/Dropdown.tsx
+++ b/src/common/dropdown/Dropdown.tsx
@@ -48,7 +48,9 @@ function Dropdown(props: Props) {
             className={styles.navButton}
             onClick={() => toggleDropdown(prevState => !prevState)}
           >
+            <span className={styles.label}>
             {navBarItem.label}
+            </span>
             {navBarItem.icon && (
               <img
                 src={navBarItem.icon}

--- a/src/common/pageHeading/PageHeading.module.css
+++ b/src/common/pageHeading/PageHeading.module.css
@@ -8,4 +8,37 @@
 
 .pageHeading h1 {
   margin-left: 20px;
+  margin-top: 15px;
 }
+
+.wrapper {
+  max-width: 900px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+/* For some reason setting text overflows from wrapper even it has
+  overflow and text-overflow parameters. These media queries force max width
+  for wrapper which seems to do the trick
+*/
+
+@media (max-width: 1000px) {
+  .wrapper {
+    max-width: 600px;
+  }
+}
+
+@media (max-width: 750px) {
+  .wrapper {
+    max-width: 400px;
+  }
+}
+
+
+@media (max-width: 550px) {
+  .wrapper {
+    max-width: 200px;
+  }
+}
+

--- a/src/common/pageHeading/PageHeading.module.css
+++ b/src/common/pageHeading/PageHeading.module.css
@@ -4,41 +4,25 @@
   display: flex;
   min-height: 120px;
   padding: 20px 10px 10px;
+  font-size: var(--hds-text-xxxl);
+  font-weight: bold;
+  width: 100%;
 }
 
-.pageHeading h1 {
-  margin-left: 20px;
-  margin-top: 15px;
+@media (min-width: 1200px) {
+  .pageHeading {
+    width: 1140px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
-.wrapper {
-  max-width: 900px;
+.titleWrapper {
+  flex: 1;
+  min-width: 0;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-}
-
-/* For some reason setting text overflows from wrapper even it has
-  overflow and text-overflow parameters. These media queries force max width
-  for wrapper which seems to do the trick
-*/
-
-@media (max-width: 1000px) {
-  .wrapper {
-    max-width: 600px;
-  }
-}
-
-@media (max-width: 750px) {
-  .wrapper {
-    max-width: 400px;
-  }
-}
-
-
-@media (max-width: 550px) {
-  .wrapper {
-    max-width: 200px;
-  }
+  margin-left: 20px;
 }
 

--- a/src/common/pageHeading/PageHeading.tsx
+++ b/src/common/pageHeading/PageHeading.tsx
@@ -13,7 +13,9 @@ function PageHeading(props: Props) {
   return (
     <div className={classNames(styles.pageHeading, props.className)}>
       <UserIcon />
-      <h1>{props.text}</h1>
+      <div className={styles.wrapper}>
+        <h1>{props.text}</h1>
+      </div>
     </div>
   );
 }

--- a/src/common/pageHeading/PageHeading.tsx
+++ b/src/common/pageHeading/PageHeading.tsx
@@ -13,9 +13,7 @@ function PageHeading(props: Props) {
   return (
     <div className={classNames(styles.pageHeading, props.className)}>
       <UserIcon />
-      <div className={styles.wrapper}>
-        <h1>{props.text}</h1>
-      </div>
+      <div className={styles.titleWrapper}>{props.text}</div>
     </div>
   );
 }

--- a/src/profile/components/viewProfile/ViewProfile.module.css
+++ b/src/profile/components/viewProfile/ViewProfile.module.css
@@ -1,6 +1,7 @@
 .viewProfile {
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .profileNav {

--- a/src/profile/components/viewProfile/ViewProfile.tsx
+++ b/src/profile/components/viewProfile/ViewProfile.tsx
@@ -34,10 +34,7 @@ function ViewProfile() {
     <div className={styles.viewProfile}>
       {data && (
         <React.Fragment>
-          <PageHeading
-            text={getNicknameOrName(data)}
-            className={responsive.maxWidthCentered}
-          />
+          <PageHeading text={getNicknameOrName(data)} />
           <nav
             className={classNames(
               styles.profileNav,


### PR DESCRIPTION
- Name shown in header is reduced to first name only and about 17 characters.
- Name in pageHeading is also reduced to one line.

Backend url was changed today (26.3), enviroment variable change is included in this PR.