### PR TITLE
OM-696 | Download data button works only once

### DIFF
--- a/src/profile/components/downloadData/DownloadData.tsx
+++ b/src/profile/components/downloadData/DownloadData.tsx
@@ -37,6 +37,7 @@ function DownloadData(props: Props) {
       Sentry.captureException(error);
       setShowNotification(true);
     },
+    fetchPolicy: 'network-only',
   });
   const downloadData = () => {
     setIsLoading(true);


### PR DESCRIPTION
By adding `fetchPolicy: 'network-only'` the onCompleted method is run every time query is called.