### PR TITLE
OM-807 | Apply confirmation modal fixes

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,6 +7,7 @@
   },
   "confirmationModal": {
     "cancel": "Cancel",
+    "close": "Close",
     "save": "Save",
     "saveMessage": "Saved data will transfer to following services",
     "saveTitle": "Do you want to save your changes"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -7,6 +7,7 @@
   },
   "confirmationModal": {
     "cancel": "Peruuta",
+    "close": "Sulje",
     "save": "Tallenna",
     "saveMessage": "Muutokset välittyvät seuraaviin palveluihin",
     "saveTitle": "Haluatko tallentaa tekemäsi muutokset"
@@ -60,7 +61,7 @@
   },
   "loading": "Ladataan...",
   "login": {
-    "description": "Rekisteröitymällä pääset käyttämään uusia palveluita yhdellä helpolla kirjautimisella. Yksi yhtenäinen tunnus tekee kaupunkilaisen arjesta helpompaa.",
+    "description": "Rekisteröitymällä pääset käyttämään uusia palveluita yhdellä helpolla kirjautumisella. Yksi yhtenäinen tunnus tekee kaupunkilaisen arjesta helpompaa.",
     "login": "Kirjaudu sisään",
     "title": "Yhdellä tunnuksella monta mahdollisuutta"
   },

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -7,6 +7,7 @@
   },
   "confirmationModal": {
     "cancel": "Annullera",
+    "close": "Stäng",
     "save": "Spara",
     "saveMessage": "Sparade data överförs till följande tjänster",
     "saveTitle": "Vill du spara dina ändringar"

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
@@ -71,7 +71,7 @@
     }
 
     .actions {
-        flex-direction: column;
+        flex-direction: column-reverse;
         justify-content: center;
     }
 

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
@@ -24,10 +24,17 @@
     justify-content: center;
 }
 
-.close {
-    width: 100%;
+.titleRow {
     display: flex;
+    align-items: flex-start;
+}
+
+.closeButton {
+    display: flex;
+    align-items: flex-start;
     justify-content: flex-end;
+    width: var(--spacing-layout);
+    height: var(--spacing-layout);
 }
 
 .icon {

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
@@ -45,7 +45,7 @@
 .content {
     width: 100%;
     display: flex;
-    margin: 15px 0;
+    margin: var(--spacing-s) 0 var(--spacing-m) 0;
     flex-direction: column;
 }
 
@@ -75,8 +75,8 @@
         justify-content: center;
     }
 
-    .button {
-        margin: 3px 0;
+    .button:last-of-type {
+        margin: 0 0 var(--spacing-2-xs) 0;
     }
 }
 

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
@@ -37,14 +37,17 @@ function ConfirmationModal({
       overlayClassName={styles.overlay}
       shouldCloseOnOverlayClick
     >
-      <div className={styles.close}>
-        <button type="button" onClick={onClose}>
-          <IconClose className={styles.icon} />
-        </button>
-      </div>
-
       <div className={styles.content}>
-        <h3>{modalTitle}</h3>
+        <div className={styles.titleRow}>
+          <h3>{modalTitle}</h3>
+          <button
+            className={styles.closeButton}
+            type="button"
+            onClick={onClose}
+          >
+            <IconClose className={styles.icon} />
+          </button>
+        </div>
         <p>{modalText}</p>
         <ul>
           {servicesArray.map((service, index) => (

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
@@ -44,6 +44,7 @@ function ConfirmationModal({
             className={styles.closeButton}
             type="button"
             onClick={onClose}
+            aria-label={t('confirmationModal.close')}
           >
             <IconClose className={styles.icon} />
           </button>


### PR DESCRIPTION
Annina asked for 
* the close icon to be aligned with the title
* there to be more margin between the buttons and the content

I also applied these changes which someone will likely request later
* Added a label for the close button for screen readers
* Reordered buttons on mobile so that primary button is first

<img width="571" alt="Screenshot 2020-05-19 at 14 39 56" src="https://user-images.githubusercontent.com/9090689/82322282-ef039400-99de-11ea-988f-5e10203c1ddc.png">
<img width="341" alt="Screenshot 2020-05-19 at 14 40 19" src="https://user-images.githubusercontent.com/9090689/82322286-f0cd5780-99de-11ea-8a89-8784da02f29d.png">
