### PR TITLE
OM-809 | Minor fixes to connected services page

### DIFF
--- a/src/common/expandingPanel/ExpandingPanel.module.css
+++ b/src/common/expandingPanel/ExpandingPanel.module.css
@@ -2,6 +2,7 @@
     --ep-horizontal-whitespace: var(--spacing-m);
     --ep-vertical-whitespace: var(--spacing-l);
     --ep-background: var(--color-white);
+    --ep-accent-color: var(--color-bus);
     width: 100%;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     background: var(--ep-background);
@@ -29,20 +30,23 @@
 }
 
 .showInformation {
-    margin-right: 15px;
-    font-size: 14px;
+    margin-right: var(--spacing-s);
+    font-size: var(--fontsize-body-small);
     font-weight: bold;
+    color: var(--ep-accent-color);
+}
+
+.icon {
+    height: var(--spacing-s);
+    width: var(--spacing-s);
+    fill: var(--ep-accent-color);
 }
 
 .iconDown {
-    height: 15px;
-    width: 15px;
     transform: rotateZ(90deg);
 }
 
 .iconUp {
-    height: 15px;
-    width: 15px;
     transform: rotateZ(-90deg);
 }
 

--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, PropsWithChildren } from 'react';
 import { IconAngleRight } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
 
 import styles from './ExpandingPanel.module.css';
 
@@ -44,7 +45,10 @@ function ExpandingPanel(props: Props) {
             </p>
           )}
           <IconAngleRight
-            className={expanded ? styles.iconUp : styles.iconDown}
+            className={classNames(
+              styles.icon,
+              expanded ? styles.iconUp : styles.iconDown
+            )}
           />
         </div>
       </div>

--- a/src/profile/components/serviceConnections/ServiceConnections.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnections.tsx
@@ -70,7 +70,7 @@ function ServiceConnections(props: Props) {
               title={service.title || ''}
               showInformationText
             >
-              {service.description}
+              <p>{service.description}</p>
               <p className={styles.serviceInformation}>
                 {t('serviceConnections.servicePersonalData')}
               </p>

--- a/src/profile/components/serviceConnections/ServiceConnections.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnections.tsx
@@ -59,6 +59,7 @@ function ServiceConnections(props: Props) {
         <Explanation
           main={t('serviceConnections.title')}
           small={t('serviceConnections.explanation')}
+          titleVariant="h2"
         />
         {hasNoServices && (
           <p className={styles.empty}>{t('serviceConnections.empty')}</p>

--- a/src/profile/components/viewProfile/ViewProfile.module.css
+++ b/src/profile/components/viewProfile/ViewProfile.module.css
@@ -41,3 +41,10 @@
     padding-left: 10px;
   }
 }
+
+.contentWrapper {
+  flex: 1;
+  padding-top: var(--spacing-l);
+
+  background-color: var(--color-black-5);
+}

--- a/src/profile/components/viewProfile/ViewProfile.tsx
+++ b/src/profile/components/viewProfile/ViewProfile.tsx
@@ -75,39 +75,41 @@ function ViewProfile() {
               </NavLink>
             )}
           </nav>
-          <Switch>
-            <Route path="/connected-services">
-              <ServiceConnections />
-            </Route>
-            {process.env.REACT_APP_ENVIRONMENT !== 'production' && (
-              <Route path="/subscriptions">
-                <Subscriptions />
+          <div className={styles.contentWrapper}>
+            <Switch>
+              <Route path="/connected-services">
+                <ServiceConnections />
               </Route>
-            )}
-            <Route path="/">
-              <div className={styles.profileContent}>
-                <div className={responsive.maxWidthCentered}>
-                  <Explanation
-                    main={t('profileInformation.title')}
-                    titleVariant="h2"
-                  />
-                  {!isEditing ? (
-                    <ProfileInformation
-                      data={data}
-                      loading={loading}
-                      isEditing={isEditing}
-                      setEditing={toggleEditing}
+              {process.env.REACT_APP_ENVIRONMENT !== 'production' && (
+                <Route path="/subscriptions">
+                  <Subscriptions />
+                </Route>
+              )}
+              <Route path="/">
+                <div className={styles.profileContent}>
+                  <div className={responsive.maxWidthCentered}>
+                    <Explanation
+                      main={t('profileInformation.title')}
+                      titleVariant="h2"
                     />
-                  ) : (
-                    <EditProfile
-                      setEditing={toggleEditing}
-                      profileData={data}
-                    />
-                  )}
+                    {!isEditing ? (
+                      <ProfileInformation
+                        data={data}
+                        loading={loading}
+                        isEditing={isEditing}
+                        setEditing={toggleEditing}
+                      />
+                    ) : (
+                      <EditProfile
+                        setEditing={toggleEditing}
+                        profileData={data}
+                      />
+                    )}
+                  </div>
                 </div>
-              </div>
-            </Route>
-          </Switch>
+              </Route>
+            </Switch>
+          </div>
         </React.Fragment>
       )}
 

--- a/src/profile/components/viewProfile/ViewProfile.tsx
+++ b/src/profile/components/viewProfile/ViewProfile.tsx
@@ -87,7 +87,10 @@ function ViewProfile() {
             <Route path="/">
               <div className={styles.profileContent}>
                 <div className={responsive.maxWidthCentered}>
-                  <Explanation main={t('profileInformation.title')} />
+                  <Explanation
+                    main={t('profileInformation.title')}
+                    titleVariant="h2"
+                  />
                   {!isEditing ? (
                     <ProfileInformation
                       data={data}

--- a/src/subscriptions/components/subsciptions/Subscriptions.tsx
+++ b/src/subscriptions/components/subsciptions/Subscriptions.tsx
@@ -166,6 +166,7 @@ function Subscriptions() {
           <Explanation
             main={t('subscriptions.title')}
             small={t('subscriptions.explanation')}
+            titleVariant="h2"
           />
 
           {subscriptionData?.length === 0 && (


### PR DESCRIPTION
Most of the considerations had been addressed in OM-807 because the components were shared. I looked through the designs for this page and there were some differences between the same components in these pages. I used the styles from the connected services page, because I assumed that it was more up to date.

<img width="1680" alt="Screenshot 2020-05-22 at 11 19 08" src="https://user-images.githubusercontent.com/9090689/82647409-d84b8000-9c1e-11ea-9fc6-f366ceb0ce06.png">
<img width="264" alt="Screenshot 2020-05-22 at 11 19 44" src="https://user-images.githubusercontent.com/9090689/82647418-daadda00-9c1e-11ea-970d-a72f0b71f4d6.png">
