### PR TITLE
OM-830 | Fix language dropdown when locale data present

### DIFF
--- a/src/common/helpers/__tests__/getLanguageCode.test.ts
+++ b/src/common/helpers/__tests__/getLanguageCode.test.ts
@@ -1,0 +1,8 @@
+import getLanguageCode from '../getLanguageCode';
+
+describe('getLanguageCode', () => {
+  it('should always return language code', () => {
+    expect(getLanguageCode('fi')).toEqual('fi');
+    expect(getLanguageCode('fi-FI')).toEqual('fi');
+  });
+});

--- a/src/common/helpers/getLanguageCode.ts
+++ b/src/common/helpers/getLanguageCode.ts
@@ -1,0 +1,11 @@
+function getLanguageCode(langOrLangAndLocale: string) {
+  const hasLocale = langOrLangAndLocale.includes('-');
+
+  if (hasLocale) {
+    return langOrLangAndLocale.split('-')[0];
+  }
+
+  return langOrLangAndLocale;
+}
+
+export default getLanguageCode;

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -5,6 +5,7 @@ import { Formik, Form, Field, FormikProps } from 'formik';
 import * as yup from 'yup';
 import countries from 'i18n-iso-countries';
 
+import getLanguageCode from '../../../common/helpers/getLanguageCode';
 import { getIsInvalid, getError } from '../../helpers/formik';
 import Select from '../../../common/select/Select';
 import Button from '../../../common/button/Button';
@@ -55,7 +56,8 @@ function EditProfileForm(props: Props) {
   const userHasServices =
     props.services?.myProfile?.serviceConnections?.edges?.length !== 0;
 
-  const countryList = countries.getNames(i18n.languages[0]);
+  const applicationLanguage = getLanguageCode(i18n.languages[0]);
+  const countryList = countries.getNames(applicationLanguage);
   const countryOptions = Object.keys(countryList).map(key => {
     return {
       value: key,

--- a/src/profile/helpers/getAddress.ts
+++ b/src/profile/helpers/getAddress.ts
@@ -1,11 +1,15 @@
 import countries from 'i18n-iso-countries';
 
+import getLanguageCode from '../../common/helpers/getLanguageCode';
 import { MyProfileQuery } from '../../graphql/generatedTypes';
 
 export default function getAddress(data: MyProfileQuery, lang: string) {
   if (data.myProfile?.primaryAddress) {
     const address = data.myProfile.primaryAddress;
-    const country = countries.getName(address.countryCode || 'FI', lang);
+    const country = countries.getName(
+      address.countryCode || 'FI',
+      getLanguageCode(lang)
+    );
 
     return [address.address, address.city, address.postalCode, country]
       .filter(addressPart => addressPart)


### PR DESCRIPTION
Previously the language dropdown would be empty and the country or an address was `undefined` when the current language also contained information about the current locale (`en` vs `en-GB`).