### PR TITLE
OM-335 | Fix silent renew

### DIFF
--- a/public/silent_renew.html
+++ b/public/silent_renew.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/oidc-client/1.10.1/oidc-client.min.js"></script>
+<script>
+  var mgr = new Oidc.UserManager();
+  mgr.signinSilentCallback().catch(error => {
+    console.error('silent_renew.html error', error);
+  });
+</script></body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,13 +61,6 @@ function App(props: Props) {
             {/* This should be the first focusable element */}
             <AccessibilityShortcuts mainContentId={MAIN_CONTENT_ID} />
             <Switch>
-              <Route
-                path="/silent_renew"
-                render={() => {
-                  userManager.signinSilentCallback();
-                  return null;
-                }}
-              />
               <Route path="/callback">
                 <OidcCallback />
               </Route>

--- a/src/auth/enableOidcLogging.ts
+++ b/src/auth/enableOidcLogging.ts
@@ -2,4 +2,5 @@ import Oidc from 'oidc-client';
 
 export default function() {
   Oidc.Log.logger = console;
+  Oidc.Log.level = Oidc.Log.INFO;
 }

--- a/src/auth/userManager.ts
+++ b/src/auth/userManager.ts
@@ -5,9 +5,7 @@ import store from '../redux/store';
 import { fetchApiTokenThunk } from './redux';
 import getAuthenticatedUser from './getAuthenticatedUser';
 
-const location = `${window.location.protocol}//${window.location.hostname}${
-  window.location.port ? `:${window.location.port}` : ''
-}`;
+const location = window.location.origin;
 
 /* eslint-disable @typescript-eslint/camelcase */
 const settings: UserManagerSettings = {
@@ -18,8 +16,11 @@ const settings: UserManagerSettings = {
   redirect_uri: `${location}/callback`,
   response_type: 'id_token token',
   scope: process.env.REACT_APP_OIDC_SCOPE,
-  silent_redirect_uri: `${location}/silent_renew`,
+  silent_redirect_uri: `${location}/silent_renew.html`,
   post_logout_redirect_uri: `${location}/`,
+  // This calculates to 1 minute, good for debugging:
+  // https://github.com/City-of-Helsinki/kukkuu-ui/blob/8029ed64c3d0496fa87fa57837c73520e8cbe37f/src/domain/auth/userManager.ts#L18
+  // accessTokenExpiringNotificationTime: 59.65 * 60,
 };
 /* eslint-enable @typescript-eslint/camelcase */
 


### PR DESCRIPTION
Note that in order to have this work, the `silent_redirect_uri` needed to be added into the `redirect_uris` config at Tunnistamo's end (the correct instance of it).

Silent renewal should now work locally. It won't work in the PR build nor will it work in staging (or production yet). I'll ask for the staging configs to be set once I know that these changes are correct so I don't end up bothering Ville too much 😄Prod configs will be deferred for now.