### PR TITLE
OM-631 | Add file description link to footer

### DIFF
--- a/src/common/footerLinks/FooterLinks.tsx
+++ b/src/common/footerLinks/FooterLinks.tsx
@@ -12,8 +12,10 @@ function FooterLinks(props: Props) {
   return (
     <span className={props.className}>
       {' '}
-      <a href="/#">{t('footer.privacy')}</a> |{' '}
-      <Link to="/accessibility">{t('footer.accessibility')}</Link>
+      <a href={t('profileForm.termsFileDescriptionLink')}>
+        {t('footer.privacy')}
+      </a>{' '}
+      | <Link to="/accessibility">{t('footer.accessibility')}</Link>
     </span>
   );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -106,8 +106,7 @@
     "postalCode": "Postal code",
     "submit": "Save",
     "terms": "I have read <0>file description</0> and  city's <1>data protection principles</1>",
-    "termsDataProtectionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf",
-    "termsFileDescriptionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection"
+    "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {
     "address": "Address",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -106,6 +106,7 @@
     "postalCode": "Postal code",
     "submit": "Save",
     "terms": "I have read <0>file description</0> and  city's <1>data protection principles</1>",
+    "termsDataProtectionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -106,6 +106,7 @@
     "postalCode": "Postinumero",
     "submit": "Tallenna",
     "terms": "Olen tutustunut palvelun <0>rekisteriselosteeseen</0> ja kaupungin <1>tietosuojakäytäntöön</1> ",
+    "termsDataProtectionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -106,8 +106,7 @@
     "postalCode": "Postinumero",
     "submit": "Tallenna",
     "terms": "Olen tutustunut palvelun <0>rekisteriselosteeseen</0> ja kaupungin <1>tietosuojakäytäntöön</1> ",
-    "termsDataProtectionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf",
-    "termsFileDescriptionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
+    "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {
     "address": "Osoite",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -106,6 +106,7 @@
     "postalCode": "Postnummer",
     "submit": "Spara",
     "terms": "Jag har läst filen <0>beskrivningen</0> och stads <1>sekretesspolicy</1>",
+    "termsDataProtectionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -106,8 +106,7 @@
     "postalCode": "Postnummer",
     "submit": "Spara",
     "terms": "Jag har läst filen <0>beskrivningen</0> och stads <1>sekretesspolicy</1>",
-    "termsDataProtectionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf",
-    "termsFileDescriptionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd"
+    "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profileInformation": {
     "address": "Adress",

--- a/src/profile/components/createProfileForm/CreateProfileForm.tsx
+++ b/src/profile/components/createProfileForm/CreateProfileForm.tsx
@@ -146,13 +146,13 @@ function CreateProfileForm(props: Props) {
                   components={[
                     // eslint-disable-next-line jsx-a11y/anchor-has-content
                     <a
-                      href={t('profileForm.termsDataProtectionLink')}
+                      href={t('profileForm.termsFileDescriptionLink')}
                       target="_blank"
                       rel="noopener noreferrer"
                     />,
                     // eslint-disable-next-line jsx-a11y/anchor-has-content
                     <a
-                      href={t('profileForm.termsFileDescriptionLink')}
+                      href={t('profileForm.termsDataProtectionLink')}
                       target="_blank"
                       rel="noopener noreferrer"
                     />,


### PR DESCRIPTION
- Footer link to file description now points to correct address
- Fixed file description and data protection links. They were wrong way around 🤦‍♂️ 