### PR TITLE
OM-722 | Adding address causes backend error

### DIFF
--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -150,12 +150,16 @@ function EditProfileForm(props: Props) {
           address: props.profile.primaryAddress.address || '',
           postalCode: props.profile.primaryAddress.postalCode || '',
           city: props.profile.primaryAddress.city || '',
+          // User can not add address when registering. Set primary field to true by default
+          // so it gets added to correct place
           primary: props.profile.primaryAddress.primary || true,
           countryCode: props.profile.primaryAddress.countryCode || 'FI',
           __typename: props.profile.primaryAddress.__typename || 'AddressNode',
         },
         primaryPhone: {
           ...props.profile.primaryPhone,
+          // Phone is not required while registering. Set primary field to true by default
+          // so it gets added to correct place
           primary: props.profile.primaryPhone.primary || true,
           phone: props.profile.primaryPhone.phone || '',
           __typename: props.profile.primaryPhone.__typename || 'PhoneNode',

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -152,10 +152,13 @@ function EditProfileForm(props: Props) {
           city: props.profile.primaryAddress.city || '',
           primary: props.profile.primaryAddress.primary || true,
           countryCode: props.profile.primaryAddress.countryCode || 'FI',
+          __typename: props.profile.primaryAddress.__typename || 'AddressNode',
         },
         primaryPhone: {
           ...props.profile.primaryPhone,
+          primary: props.profile.primaryPhone.primary || true,
           phone: props.profile.primaryPhone.phone || '',
+          __typename: props.profile.primaryPhone.__typename || 'PhoneNode',
         },
       }}
       onSubmit={values => {

--- a/src/profile/helpers/updateMutationVariables.ts
+++ b/src/profile/helpers/updateMutationVariables.ts
@@ -119,7 +119,6 @@ function formMutationArrays<T extends Address | Email | Phone>(
     getPrimaryValue(primary, profile),
     ...getNodesFromProfile(primary, profile),
   ];
-
   // Filter empty values (e.g user added new phone and pressed save without typing anything)
   const formValues: T[] = formValueArray.filter(
     value => !isEqual(value, getEmptyObject(primary))
@@ -140,9 +139,10 @@ function formMutationArrays<T extends Address | Email | Phone>(
   // From array that contains values that are new
   // Filter values that contain id
   const addValues = formValues
-    .filter(value => !value.id)
+    .filter(value => !value?.id)
     .map(value => {
       const val = getObjectFields(value);
+
       // Sending empty id will cause backend error so we remove it
       delete val.id;
       return val;

--- a/src/profile/helpers/updateMutationVariables.ts
+++ b/src/profile/helpers/updateMutationVariables.ts
@@ -119,6 +119,7 @@ function formMutationArrays<T extends Address | Email | Phone>(
     getPrimaryValue(primary, profile),
     ...getNodesFromProfile(primary, profile),
   ];
+
   // Filter empty values (e.g user added new phone and pressed save without typing anything)
   const formValues: T[] = formValueArray.filter(
     value => !isEqual(value, getEmptyObject(primary))
@@ -139,10 +140,9 @@ function formMutationArrays<T extends Address | Email | Phone>(
   // From array that contains values that are new
   // Filter values that contain id
   const addValues = formValues
-    .filter(value => !value?.id)
+    .filter(value => !value.id)
     .map(value => {
       const val = getObjectFields(value);
-
       // Sending empty id will cause backend error so we remove it
       delete val.id;
       return val;


### PR DESCRIPTION
Added typenames to empty primary and phone objects.  This way `getObjectFields` function will never return default value and cause empty object appearing in `addValues` array.

Also added `primary` field to primaryPhone. This fixed issue where adding a primaryPhone in edit form would cause it to be added as secondary.