### PR TITLE
OM-871 | Provide OAuth/Oidc authorize code as part of the GDPR API related calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+
+## [Unreleased]
+### Added
+- Support for authorization code generation for GDPR API related calls (profile download and deletion) [#108](https://github.com/City-of-Helsinki/open-city-profile-ui/pull/108)
+
+## [1.0.0-rc.1]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The graphql-backend for development is located at https://profiili-api.test.kuva
 
 ## Learn More
 
+To learn more about specific choices in this repository, you can browse the [docs](/docs).
+
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).

--- a/docs/gdpr-api-authorization.md
+++ b/docs/gdpr-api-authorization.md
@@ -1,0 +1,80 @@
+# GDPR API compatibility
+
+The GDPR API requires the user to allow actions on their data. Let's take downloading profile data as an example.
+
+1) User clicks the download button
+2) User is redirected to Tunnistamo which, if necessary, renders an UI the user can use to allow a set of permissions
+3) User is redirected back to Helsinki profile UI and the download action is completed
+
+In essence, we need to request the authorization code in the UI, because the user flow may contain a step that requires user input. Once this code is generated, it must be provided within the download profile query and delete profile mutation when these requests are sent to the profile backend. The backend can then use this code to make requests to all the other services for data or deletion.
+
+## Technical explanation
+
+This flow introduces one difficult step--the exit and re-entry into the profile UI application. This makes the download and deletion code flows more difficult to handle. In comparison, these actions were previously completed with callbacks and promises--which make use of the fact that the "same SPA session" is retained throughout the user action. After we transition into fetching the authorization code, this assumption no longer holds, but instead the application is "hard refreshed" at least once.
+
+Within this application, this behaviour has been managed with the help of `GdprAuthorizationCodeManager`, `useActionResumer` and `useAuthorizationCode`.
+
+### `GdprAuthorizationCodeManager`
+
+This class is responsible for compliance with the `OpenID` protocol. It's responsible for handling the authorization flow. In this capacity it:
+* Stores the application state so that it can be reused when authorization is complete
+* Creates the authorization url
+* Navigates to authorization url
+* Interjects the authorization callback
+* Saves code for use
+* Reloads application state
+* Deletes code and application state from store when it is no longer needed
+
+### `useActionResumer`
+
+This hook is an abstraction which seeks to bridge the "gap" that forms when the user is redirected to Tunnistamo and then finally back into our application. It allows other code within the application to complete actions that span a page refresh while being relatively agnostic about the method by which the application knows what action to resume when the redirection is done.
+
+**Parameters**  
+
+| Name  | Description |
+| ------------- | ------------- |
+| **`deferredAction`**  | Name of action that get _deferred_  until the redirect back into the UI. This is used as an ID which tells `useActionResumer` whether it should run the `callback` parameter.  |
+| **`onActionInitialization`**  | `useActionResumer` begins the action flow by calling this function.  |
+| **`callback`**  | `useActionResumer`** calls this function when the action is resumed.  |
+
+**Humanized explanation**  
+`useActionResumer` provides its user with the `startAction` function. This function can be used to invoke an action that persists over page reloads. `useActionResumer` listens with a `useEffect` in order to notice when it should complete an action. When it determines that it's a suitable time, it invokes `callback`.
+
+**Note:**  
+Currently `useActionResumer` relies on a search parameter to know whether it should invoke a `callback`. The `useEffect` that it uses to determine when an action should be completed is not hooked up to listen to changes in location. This way `useActionResumer` won't work unless the search parameter invoking it is present already when the component calling it is mounted. If the search parameter becomes available after component mount, the callback won't be invoked. Again from another perspective: `useActionResumer` uses the global `location` object to determine whether a search parameter is present. This means that it won't react to location changes completed through react-router for instance.
+
+Using the global location is a sort of anti-pattern which would make it more risky to transition this application into a server rendered application for instance.
+
+### `useAuthorizationCode`
+Combines `GdprAuthorizationCodeManager` and `useActionResumer` into a single API that's easier to consume. Code that needs access to an authorization code can hook up to one with a call like this:
+
+```
+  const [
+    startFetchingAuthorizationCode,
+    isAuthorizing
+  ] = useAuthorizationCode(
+    'useDownloadProfile',
+    handleAuthorizationCodeCallback
+  );
+```
+
+## Technical flow
+
+Here I've explained how the application should act in more technical detail. Developers can make use of this explanation to get a better sense of how the features relying on `authorization code` should work. I'll take the download flow as an example, but the delete flow is mostly the same.
+
+1) User logs in
+2) User expands panel for downloading user profile
+3) User clicks download button
+    1) Download button is disabled and its label is changed
+    1) Current url and the download action are saved into local storage under `kuvaGdprAuthManager` prefix that's tailed by a random UUID
+    1) Tunnistamo authorize URL is built
+    1) User is redirected to Tunnistamo
+6) User allows access to personal information in Tunnistamo
+7) User is redirected back into the application into address `<origin>/gdpr-callback`
+    1) It calls `GdprAuthorizationCodeManager.authorizationTokenFetchCallback`
+        1) Token is saved into localStorage ready for consumption.
+        1) Previous app state is restored. User is redirected to the page the invoked download on and a special search parameter is added to tell `useActionResumer` instances that the one with this id should fire its callback.
+        1) Previous app state is cleared
+8) User lands back on the profile index page based on the redirect.
+    1) The code is consumed--it's requested from `GdprAuthorizationCodeManager` which then clears it from its memory (localStorage).
+    1) The code is used to call `downloadProfile`

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react-modal": "^3.10.1",
     "@types/react-redux": "^7.1.5",
     "@types/react-router-dom": "^5.1.0",
+    "@types/uuid": "^8.0.0",
     "@types/validator": "^13.0.0",
     "@types/yup": "^0.26.24",
     "apollo-boost": "^0.4.4",
@@ -53,6 +54,7 @@
     "redux-oidc": "^3.1.5",
     "redux-starter-kit": "^1.0.0",
     "typescript": "^3.7.3",
+    "uuid": "^8.1.0",
     "validator": "^13.0.0",
     "yup": "^0.27.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import AppMeta from './AppMeta';
 import authenticate from './auth/authenticate';
 import logout from './auth/logout';
 import authConstants from './auth/constants/authConstants';
+import GdprAuthorizationCodeManagerCallback from './gdprApi/GdprAuthorizationCodeManagerCallback';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -89,6 +90,9 @@ function App(props: Props) {
             <Switch>
               <Route path="/callback">
                 <OidcCallback />
+              </Route>
+              <Route path="/gdpr-callback">
+                <GdprAuthorizationCodeManagerCallback />
               </Route>
               <Route path="/login">
                 <Login />

--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, PropsWithChildren } from 'react';
+import React, { useState, PropsWithChildren, useRef } from 'react';
 import { IconAngleRight } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
@@ -8,10 +8,19 @@ import styles from './ExpandingPanel.module.css';
 type Props = PropsWithChildren<{
   title?: string;
   showInformationText?: boolean;
+  defaultExpanded?: boolean;
+  scrollIntoViewOnMount?: boolean;
 }>;
 
-function ExpandingPanel(props: Props) {
-  const [expanded, setExpanded] = useState(false);
+function ExpandingPanel({
+  children,
+  defaultExpanded,
+  showInformationText,
+  scrollIntoViewOnMount,
+  title,
+}: Props) {
+  const container = useRef<HTMLDivElement | null>(null);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const toggleExpanding = () => setExpanded(prevState => !prevState);
   const { t } = useTranslation();
   const onKeyDown = (event: React.KeyboardEvent) => {
@@ -25,8 +34,18 @@ function ExpandingPanel(props: Props) {
     }
   };
 
+  const handleContainerRef = (ref: HTMLDivElement) => {
+    // If ref is not saved yet we are about in the first render.
+    // In that case we can scroll this element into view.
+    if (!container.current && scrollIntoViewOnMount && ref) {
+      ref.scrollIntoView();
+    }
+
+    container.current = ref;
+  };
+
   return (
-    <div className={styles.container}>
+    <div className={styles.container} ref={handleContainerRef}>
       <div
         className={styles.title}
         onClick={toggleExpanding}
@@ -35,9 +54,9 @@ function ExpandingPanel(props: Props) {
         role="button"
         aria-expanded={expanded ? 'true' : 'false'}
       >
-        <h2>{props.title}</h2>
+        <h2>{title}</h2>
         <div className={styles.rightSideInformation}>
-          {props.showInformationText && (
+          {showInformationText && (
             <p className={styles.showInformation}>
               {expanded
                 ? t('expandingPanel.hideInformation')
@@ -52,7 +71,7 @@ function ExpandingPanel(props: Props) {
           />
         </div>
       </div>
-      {expanded && <div className={styles.content}>{props.children}</div>}
+      {expanded && <div className={styles.content}>{children}</div>}
     </div>
   );
 }

--- a/src/common/header/Header.module.css
+++ b/src/common/header/Header.module.css
@@ -1,6 +1,10 @@
+:root {
+  --header-height: 64px;
+}
+
 .header {
   background: var(--color-white);
-  height: 64px;
+  height: var(--header-height);
   position: sticky;
   z-index: 1;
 }

--- a/src/gdprApi/GdprAuthorizationCodeManager.ts
+++ b/src/gdprApi/GdprAuthorizationCodeManager.ts
@@ -1,0 +1,126 @@
+import { v4 as uuidv4 } from 'uuid';
+
+const PREFIX = 'kuvaGdprAuthManager';
+
+interface GdprAuthorizationCodeManagerConfig {
+  clientId: string;
+  redirectUri: string;
+  oidcAuthority: string;
+}
+
+class GdprAuthorizationCodeManager {
+  config: GdprAuthorizationCodeManagerConfig;
+
+  constructor(config: GdprAuthorizationCodeManagerConfig) {
+    this.config = config;
+  }
+
+  get code(): string | null {
+    return this.get('authorization_code');
+  }
+
+  set code(code: string | null) {
+    if (code === null) {
+      this.clear('authorization_code');
+    } else {
+      this.set('authorization_code', code);
+    }
+  }
+
+  get(key: string) {
+    const value = localStorage.getItem(`${PREFIX}.${key}`);
+
+    if (value === null) {
+      return null;
+    }
+
+    return JSON.parse(value);
+  }
+
+  set(key: string, value: object | string) {
+    localStorage.setItem(`${PREFIX}.${key}`, JSON.stringify(value));
+  }
+
+  clear(key: string) {
+    localStorage.removeItem(`${PREFIX}.${key}`);
+  }
+
+  consumeCode(): string {
+    const code = this.code;
+
+    if (!code) {
+      throw Error('There was no code to consume');
+    }
+
+    this.code = null;
+
+    return code;
+  }
+
+  makeAuthorizationUrlParams(
+    clientId: string,
+    scopes: string[],
+    redirectUri: string,
+    state: string
+  ) {
+    const scope = scopes.join(' ');
+    const params = new URLSearchParams();
+
+    params.append('response_type', 'code');
+    params.append('client_id', clientId);
+    params.append('scope', scope);
+    params.append('redirect_uri', redirectUri);
+    params.append('state', state);
+
+    return params.toString();
+  }
+
+  makeAuthorizationUrl(scopes: string[], state: string) {
+    const params = this.makeAuthorizationUrlParams(
+      this.config.clientId,
+      scopes,
+      this.config.redirectUri,
+      state
+    );
+
+    return `${this.config.oidcAuthority}openid/authorize?${params}`;
+  }
+
+  cacheApplicationState(stateId: string, deferredAction: string) {
+    this.set(stateId, {
+      redirectUrl: window.location.href,
+      deferredAction,
+    });
+  }
+
+  loadApplicationState(stateId: string) {
+    const state = this.get(stateId);
+
+    this.clear(stateId);
+    window.location.href = `${state.redirectUrl}?a=${state.deferredAction}`;
+  }
+
+  fetchAuthorizationCode(deferredAction: string, scopes: string[]) {
+    const codeStateId = uuidv4();
+
+    this.cacheApplicationState(codeStateId, deferredAction);
+
+    const authorizationCodeUrl = this.makeAuthorizationUrl(scopes, codeStateId);
+
+    window.location.href = authorizationCodeUrl;
+  }
+
+  authorizationCodeFetchCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+
+    if (state) {
+      this.loadApplicationState(state);
+    }
+
+    this.code = code;
+  }
+}
+
+export default GdprAuthorizationCodeManager;

--- a/src/gdprApi/GdprAuthorizationCodeManagerCallback.tsx
+++ b/src/gdprApi/GdprAuthorizationCodeManagerCallback.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import gdprAuthCodeManager from './gdprAuthCodeManager';
+import styles from './gdprAuthorizationCodeManagerCallback.module.css';
+
+function GdprAuthorizationCodeManagerCallback() {
+  React.useEffect(() => {
+    gdprAuthCodeManager.authorizationCodeFetchCallback();
+  }, []);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.fakeNavigation} />
+      <div className={styles.fakePageHeading} />
+      <div className={styles.fakeContent} />
+    </div>
+  );
+}
+
+export default GdprAuthorizationCodeManagerCallback;

--- a/src/gdprApi/gdprAuthCodeManager.ts
+++ b/src/gdprApi/gdprAuthCodeManager.ts
@@ -1,0 +1,9 @@
+import GdprAuthorizationTokenManager from './GdprAuthorizationCodeManager';
+
+const authManager = new GdprAuthorizationTokenManager({
+  clientId: process.env.REACT_APP_PROFILE_AUDIENCE as string,
+  redirectUri: `${window.location.origin}/gdpr-callback`,
+  oidcAuthority: process.env.REACT_APP_OIDC_AUTHORITY as string,
+});
+
+export default authManager;

--- a/src/gdprApi/gdprAuthorizationCodeManagerCallback.module.css
+++ b/src/gdprApi/gdprAuthorizationCodeManagerCallback.module.css
@@ -1,0 +1,20 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.fakeNavigation {
+  height: var(--header-height);
+  background: var(--color-white);
+}
+
+.fakePageHeading {
+  height: 170px;
+  background: var(--color-coat-of-arms-blue-light-20);
+}
+
+.fakeContent {
+  flex-grow: 1;
+  background: var(--color-black-5);
+}

--- a/src/gdprApi/graphql/GdprDeleteMyProfileMutation.graphql
+++ b/src/gdprApi/graphql/GdprDeleteMyProfileMutation.graphql
@@ -1,0 +1,5 @@
+mutation GdprDeleteMyProfileMutation($input:DeleteMyProfileMutationInput!) {
+  deleteMyProfile(input: $input) {
+    clientMutationId
+  }
+}

--- a/src/gdprApi/graphql/GdprServiceConnectionsQuery.graphql
+++ b/src/gdprApi/graphql/GdprServiceConnectionsQuery.graphql
@@ -1,0 +1,16 @@
+query GdprServiceConnectionsQuery {
+  myProfile {
+    id
+    serviceConnections {
+      edges {
+        node {
+          service {
+            type
+            gdprQueryScope
+            gdprDeleteScope
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/gdprApi/useActionResumer.ts
+++ b/src/gdprApi/useActionResumer.ts
@@ -1,0 +1,64 @@
+import React from 'react';
+
+function getActionFromParams() {
+  return new URLSearchParams(window.location.search).get('a');
+}
+
+function getIsActionSearchParamEvoked(deferredAction: string): boolean {
+  const actionToComplete = getActionFromParams();
+
+  return actionToComplete === deferredAction;
+}
+
+function removeActionFromParams() {
+  const url = new URL(window.location.href);
+  const search = new URLSearchParams(window.location.search);
+
+  search.delete('a');
+  url.search = search.toString();
+
+  window.history.replaceState(null, '', url.toString());
+}
+
+function useActionResumer(
+  deferredAction: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onActionInitialization: (...args: any[]) => void,
+  callback: () => void
+): [() => void, boolean] {
+  const isActionSearchParamEvoked = getIsActionSearchParamEvoked(
+    deferredAction
+  );
+  const [isActionOngoing, setIsActionOngoing] = React.useState(
+    isActionSearchParamEvoked
+  );
+
+  const startAction = React.useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (...args: any[]) => {
+      setIsActionOngoing(true);
+
+      onActionInitialization(...args);
+    },
+    [onActionInitialization]
+  );
+
+  React.useEffect(() => {
+    function finishAction() {
+      const actionToComplete = getActionFromParams();
+      const shouldTryToCompleteAction = actionToComplete === deferredAction;
+
+      if (shouldTryToCompleteAction) {
+        callback();
+        removeActionFromParams();
+        setIsActionOngoing(false);
+      }
+    }
+
+    finishAction();
+  }, [callback, deferredAction]);
+
+  return [startAction, isActionOngoing];
+}
+
+export default useActionResumer;

--- a/src/gdprApi/useAuthorizationCode.ts
+++ b/src/gdprApi/useAuthorizationCode.ts
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import useActionResumer from './useActionResumer';
+import gdprAuthCodeManager from './gdprAuthCodeManager';
+
+function useAuthorizationCode(
+  deferredAction: string,
+  callback: (authorizationToken: string | null) => void
+): [(additionalScopes: string[]) => void, boolean] {
+  const startAuthorizationCodeRetrievalFlow = React.useCallback(
+    (additionalScopes: string[]) => {
+      const scopes = ['openid', ...additionalScopes];
+
+      gdprAuthCodeManager.fetchAuthorizationCode(deferredAction, scopes);
+    },
+    [deferredAction]
+  );
+
+  const endAuthorizationCodeRetrievalFlow = React.useCallback(() => {
+    try {
+      const code = gdprAuthCodeManager.consumeCode();
+
+      callback(code);
+    } catch {
+      callback(null);
+    }
+  }, [callback]);
+
+  const [
+    startFetchingAuthorizationCode,
+    isFetchingAuthorizationCode,
+  ] = useActionResumer(
+    deferredAction,
+    startAuthorizationCodeRetrievalFlow,
+    endAuthorizationCodeRetrievalFlow
+  );
+
+  return [startFetchingAuthorizationCode, isFetchingAuthorizationCode];
+}
+
+export default useAuthorizationCode;

--- a/src/gdprApi/useDeleteProfile.ts
+++ b/src/gdprApi/useDeleteProfile.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  useQuery,
+  useMutation,
+  MutationHookOptions,
+} from '@apollo/react-hooks';
+import { MutationResult } from '@apollo/react-common';
+import { loader } from 'graphql.macro';
+
+import {
+  GdprDeleteMyProfileMutation,
+  GdprDeleteMyProfileMutationVariables,
+  GdprServiceConnectionsQuery,
+} from '../graphql/generatedTypes';
+import { getDeleteScopes } from './utils';
+import useAuthorizationCode from './useAuthorizationCode';
+
+const DELETE_PROFILE = loader('./graphql/GdprDeleteMyProfileMutation.graphql');
+const SERVICE_CONNECTIONS = loader(
+  './graphql/GdprServiceConnectionsQuery.graphql'
+);
+
+function useDeleteProfile(
+  options: MutationHookOptions<
+    GdprDeleteMyProfileMutation,
+    GdprDeleteMyProfileMutationVariables
+  >
+): [() => void, MutationResult<GdprDeleteMyProfileMutation>] {
+  const { data } = useQuery<GdprServiceConnectionsQuery>(SERVICE_CONNECTIONS);
+  const [deleteProfile, queryResult] = useMutation<
+    GdprDeleteMyProfileMutation,
+    GdprDeleteMyProfileMutationVariables
+  >(DELETE_PROFILE, options);
+
+  const handleAuthorizationCodeCallback = React.useCallback(
+    (authorizationCode: string | null) => {
+      if (authorizationCode) {
+        const variablesWithAuthorizationCode = {
+          input: {
+            authorizationCode,
+          },
+        };
+
+        deleteProfile({
+          variables: variablesWithAuthorizationCode,
+        });
+      }
+    },
+    [deleteProfile]
+  );
+
+  const [startFetchingAuthorizationCode, isAuthorizing] = useAuthorizationCode(
+    'useDeleteProfile',
+    handleAuthorizationCodeCallback
+  );
+
+  const handleDownloadActionInitialization = React.useCallback(() => {
+    const deleteScopes = getDeleteScopes(data);
+
+    startFetchingAuthorizationCode(deleteScopes);
+  }, [data, startFetchingAuthorizationCode]);
+
+  const injectedMutationResult = {
+    ...queryResult,
+    loading: isAuthorizing || queryResult.loading,
+  };
+
+  return [handleDownloadActionInitialization, injectedMutationResult];
+}
+
+export default useDeleteProfile;

--- a/src/gdprApi/useDownloadProfile.ts
+++ b/src/gdprApi/useDownloadProfile.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  useQuery,
+  useLazyQuery,
+  LazyQueryHookOptions,
+} from '@apollo/react-hooks';
+import { QueryResult } from '@apollo/react-common';
+import { DocumentNode } from 'graphql';
+import { loader } from 'graphql.macro';
+
+import { GdprServiceConnectionsQuery } from '../graphql/generatedTypes';
+import { getQueryScopes } from './utils';
+import useAuthorizationCode from './useAuthorizationCode';
+
+const SERVICE_CONNECTIONS = loader(
+  './graphql/GdprServiceConnectionsQuery.graphql'
+);
+
+type TVariables = Record<string, unknown>;
+
+function useDownloadProfile<TQuery>(
+  query: DocumentNode,
+  options?: LazyQueryHookOptions<TQuery, TVariables>
+): [() => void, QueryResult<TQuery, TVariables>] {
+  const { data } = useQuery<GdprServiceConnectionsQuery>(SERVICE_CONNECTIONS);
+  const [downloadProfile, queryResult] = useLazyQuery<TQuery>(query, {
+    ...options,
+    onCompleted: (...args) => {
+      if (options?.onCompleted) {
+        options.onCompleted(...args);
+      }
+    },
+  });
+
+  const handleAuthorizationCodeCallback = React.useCallback(
+    (authorizationCode: string | null) => {
+      if (authorizationCode) {
+        const variablesWithAuthorizationCode = {
+          authorizationCode,
+        };
+
+        downloadProfile({
+          variables: variablesWithAuthorizationCode,
+        });
+      }
+    },
+    [downloadProfile]
+  );
+
+  const [startFetchingAuthorizationCode, isAuthorizing] = useAuthorizationCode(
+    'useDownloadProfile',
+    handleAuthorizationCodeCallback
+  );
+
+  const handleDownloadActionInitialization = React.useCallback(() => {
+    const queryScopes = getQueryScopes(data);
+
+    startFetchingAuthorizationCode(queryScopes);
+  }, [data, startFetchingAuthorizationCode]);
+
+  const injectedQueryResult = {
+    ...queryResult,
+    loading: isAuthorizing || queryResult.loading,
+  };
+
+  return [handleDownloadActionInitialization, injectedQueryResult];
+}
+
+export default useDownloadProfile;

--- a/src/gdprApi/utils.ts
+++ b/src/gdprApi/utils.ts
@@ -1,0 +1,57 @@
+import { GdprServiceConnectionsQuery } from '../graphql/generatedTypes';
+
+interface GdprServiceConnectionFields {
+  gdprQueryScope: string;
+  gdprDeleteScope: string;
+}
+
+const servicesSelector = (
+  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined | null
+): GdprServiceConnectionFields[] => {
+  if (
+    serviceConnectionsQuery === null ||
+    serviceConnectionsQuery === undefined
+  ) {
+    return [];
+  }
+
+  const serviceConnections =
+    serviceConnectionsQuery.myProfile?.serviceConnections?.edges;
+
+  if (serviceConnections === null || serviceConnections === undefined) {
+    return [];
+  }
+
+  const services = serviceConnections.map(serviceConnection => {
+    const service = serviceConnection?.node?.service;
+
+    if (service === undefined || service === null) {
+      return undefined;
+    }
+
+    return {
+      gdprQueryScope: service.gdprQueryScope,
+      gdprDeleteScope: service.gdprDeleteScope,
+    };
+  });
+
+  return services.filter(
+    (service): service is GdprServiceConnectionFields => service !== undefined
+  );
+};
+
+export function getDeleteScopes(
+  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined
+): string[] {
+  const services = servicesSelector(serviceConnectionsQuery);
+
+  return services.map(service => service.gdprDeleteScope);
+}
+
+export function getQueryScopes(
+  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined
+): string[] {
+  const services = servicesSelector(serviceConnectionsQuery);
+
+  return services.map(service => service.gdprQueryScope);
+}

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -3,6 +3,107 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL mutation operation: GdprDeleteMyProfileMutation
+// ====================================================
+
+export interface GdprDeleteMyProfileMutation_deleteMyProfile {
+  readonly __typename: "DeleteMyProfileMutationPayload";
+  readonly clientMutationId: string | null;
+}
+
+export interface GdprDeleteMyProfileMutation {
+  /**
+   * Deletes the data of the profile which is linked to the currently authenticated user.
+   * 
+   * Requires authentication.
+   * 
+   * Possible error codes:
+   * 
+   * * `CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to Berth service.
+   * 
+   * * `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to the currently authenticated user.
+   * 
+   * * `TODO`
+   */
+  readonly deleteMyProfile: GdprDeleteMyProfileMutation_deleteMyProfile | null;
+}
+
+export interface GdprDeleteMyProfileMutationVariables {
+  readonly input: DeleteMyProfileMutationInput;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GdprServiceConnectionsQuery
+// ====================================================
+
+export interface GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service {
+  readonly __typename: "ServiceNode";
+  readonly type: ServiceType | null;
+  /**
+   * GDPR API query operation scope
+   */
+  readonly gdprQueryScope: string;
+  /**
+   * GDPR API delete operation scope
+   */
+  readonly gdprDeleteScope: string;
+}
+
+export interface GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node {
+  readonly __typename: "ServiceConnectionType";
+  readonly service: GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service;
+}
+
+export interface GdprServiceConnectionsQuery_myProfile_serviceConnections_edges {
+  readonly __typename: "ServiceConnectionTypeEdge";
+  /**
+   * The item at the end of the edge
+   */
+  readonly node: GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node | null;
+}
+
+export interface GdprServiceConnectionsQuery_myProfile_serviceConnections {
+  readonly __typename: "ServiceConnectionTypeConnection";
+  /**
+   * Contains the nodes in this connection.
+   */
+  readonly edges: ReadonlyArray<(GdprServiceConnectionsQuery_myProfile_serviceConnections_edges | null)>;
+}
+
+export interface GdprServiceConnectionsQuery_myProfile {
+  readonly __typename: "ProfileNode";
+  /**
+   * The ID of the object.
+   */
+  readonly id: string;
+  /**
+   * List of the profile's connected services.
+   */
+  readonly serviceConnections: GdprServiceConnectionsQuery_myProfile_serviceConnections | null;
+}
+
+export interface GdprServiceConnectionsQuery {
+  /**
+   * Get the profile belonging to the currently authenticated user.
+   * 
+   * Requires authentication.
+   * 
+   * Possible error codes:
+   * 
+   * * `TODO`
+   */
+  readonly myProfile: GdprServiceConnectionsQuery_myProfile | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL mutation operation: CreateMyProfile
 // ====================================================
 
@@ -49,44 +150,10 @@ export interface CreateMyProfileVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL mutation operation: DeleteMyProfile
+// GraphQL query operation: DownloadMyProfileQuery
 // ====================================================
 
-export interface DeleteMyProfile_deleteMyProfile {
-  readonly __typename: "DeleteMyProfileMutationPayload";
-  readonly clientMutationId: string | null;
-}
-
-export interface DeleteMyProfile {
-  /**
-   * Deletes the data of the profile which is linked to the currently authenticated user.
-   * 
-   * Requires authentication.
-   * 
-   * Possible error codes:
-   * 
-   * * `CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to Berth service.
-   * 
-   * * `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to the currently authenticated user.
-   * 
-   * * `TODO`
-   */
-  readonly deleteMyProfile: DeleteMyProfile_deleteMyProfile | null;
-}
-
-export interface DeleteMyProfileVariables {
-  readonly input: DeleteMyProfileMutationInput;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: DownloadMyProfile
-// ====================================================
-
-export interface DownloadMyProfile {
+export interface DownloadMyProfileQuery {
   /**
    * Get the user information stored in the profile as machine readable JSON.
    * 
@@ -97,6 +164,10 @@ export interface DownloadMyProfile {
    * * `TODO`
    */
   readonly downloadMyProfile: any | null;
+}
+
+export interface DownloadMyProfileQueryVariables {
+  readonly authorizationCode: string;
 }
 
 /* tslint:disable */
@@ -726,6 +797,7 @@ export interface CreatePhoneInput {
 }
 
 export interface DeleteMyProfileMutationInput {
+  readonly authorizationCode: string;
   readonly clientMutationId?: string | null;
 }
 

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -1,41 +1,32 @@
 import React, { useEffect, useState } from 'react';
-import { useQuery, useMutation } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
 import * as Sentry from '@sentry/browser';
-import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { Checkbox } from 'hds-react';
 
-import checkBerthError from '../../helpers/checkBerthError';
 import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
 import NotificationComponent from '../../../common/notification/NotificationComponent';
-import BerthErrorModal from '../modals/berthError/BerthErrorModal';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
 import Button from '../../../common/button/Button';
-import {
-  DeleteMyProfile as DeleteMyProfileData,
-  DeleteMyProfileVariables,
-  ServiceConnectionsQuery,
-} from '../../../graphql/generatedTypes';
+import { ServiceConnectionsQuery } from '../../../graphql/generatedTypes';
 import styles from './deleteProfile.module.css';
 
-const DELETE_PROFILE = loader('../../graphql/DeleteMyProfile.graphql');
 const SERVICE_CONNECTIONS = loader(
   '../../graphql/ServiceConnectionsQuery.graphql'
 );
 
-type Props = {};
+type Props = {
+  isOpenByDefault: boolean;
+  onDelete: () => void;
+};
 
-function DeleteProfile(props: Props) {
+function DeleteProfile({ isOpenByDefault, onDelete }: Props) {
   const [deleteConfirmationModal, setDeleteConfirmationModal] = useState(false);
   const [deleteInstructions, setDeleteInstructions] = useState(false);
-  const [berthError, setBerthError] = useState(false);
   const [showNotification, setShowNotification] = useState(false);
 
-  const history = useHistory();
   const { t, i18n } = useTranslation();
-  const { trackEvent } = useMatomo();
 
   const { data, refetch } = useQuery<ServiceConnectionsQuery>(
     SERVICE_CONNECTIONS,
@@ -46,10 +37,6 @@ function DeleteProfile(props: Props) {
       },
     }
   );
-  const [deleteProfile] = useMutation<
-    DeleteMyProfileData,
-    DeleteMyProfileVariables
-  >(DELETE_PROFILE);
 
   useEffect(() => {
     const cb = () => refetch();
@@ -67,34 +54,25 @@ function DeleteProfile(props: Props) {
     setDeleteConfirmationModal(prevState => !prevState);
   };
 
-  const handleProfileDelete = () => {
+  const handleProfileDelete = async () => {
     setDeleteConfirmationModal(false);
 
-    const variables = {
-      input: {},
-    };
+    if (data === undefined) {
+      throw Error('Could not find services to delete');
+    }
 
-    deleteProfile({ variables })
-      .then(result => {
-        if (result.data) {
-          trackEvent({ category: 'action', action: 'Delete profile' });
-          history.push('/profile-deleted');
-        }
-      })
-      .catch(error => {
-        if (checkBerthError(error.graphQLErrors)) {
-          setBerthError(true);
-        } else {
-          Sentry.captureException(error);
-          setShowNotification(true);
-        }
-      });
+    onDelete();
   };
   const userHasServices =
     data?.myProfile?.serviceConnections?.edges?.length !== 0;
+
   return (
     <React.Fragment>
-      <ExpandingPanel title={t('deleteProfile.title')}>
+      <ExpandingPanel
+        title={t('deleteProfile.title')}
+        defaultExpanded={isOpenByDefault}
+        scrollIntoViewOnMount={isOpenByDefault}
+      >
         <p>{t('deleteProfile.explanation')}</p>
 
         <Checkbox
@@ -129,11 +107,6 @@ function DeleteProfile(props: Props) {
             : t('deleteProfileModal.noServiceExplanation')
         }
         actionButtonText={t('deleteProfileModal.delete')}
-      />
-
-      <BerthErrorModal
-        isOpen={berthError}
-        onClose={() => setBerthError(prevState => !prevState)}
       />
 
       <NotificationComponent

--- a/src/profile/components/downloadData/DownloadData.tsx
+++ b/src/profile/components/downloadData/DownloadData.tsx
@@ -1,60 +1,39 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loader } from 'graphql.macro';
-import { useLazyQuery } from '@apollo/react-hooks';
-import * as Sentry from '@sentry/browser';
-import FileSaver from 'file-saver';
 
 import Button from '../../../common/button/Button';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
-import NotificationComponent from '../../../common/notification/NotificationComponent';
 import styles from './DownloadData.module.css';
-import { DownloadMyProfile } from '../../../graphql/generatedTypes';
 
-const ALL_DATA = loader('../../graphql/DownloadMyProfile.graphql');
+type Props = {
+  isDownloadingData: boolean;
+  isOpenByDefault: boolean;
+  onDownloadClick: () => void;
+};
 
-type Props = {};
-
-function DownloadData(props: Props) {
+function DownloadData({
+  isDownloadingData,
+  isOpenByDefault,
+  onDownloadClick,
+}: Props) {
   const { t } = useTranslation();
-  const [isLoading, setIsLoading] = useState(false);
-  const [showNotification, setShowNotification] = useState(false);
 
-  const [loadData] = useLazyQuery<DownloadMyProfile>(ALL_DATA, {
-    onCompleted: data => {
-      const blob = new Blob([data.downloadMyProfile], {
-        type: 'application/json',
-      });
-      FileSaver.saveAs(blob, 'helsinkiprofile_data.json');
-      setIsLoading(false);
-    },
-    onError: (error: Error) => {
-      Sentry.captureException(error);
-      setShowNotification(true);
-    },
-    fetchPolicy: 'network-only',
-  });
-  const downloadData = () => {
-    setIsLoading(true);
-    loadData();
-  };
   return (
     <React.Fragment>
-      <ExpandingPanel title={t('downloadData.panelTitle')}>
+      <ExpandingPanel
+        title={t('downloadData.panelTitle')}
+        defaultExpanded={isOpenByDefault}
+        scrollIntoViewOnMount={isOpenByDefault}
+      >
         <p>{t('downloadData.panelText')}</p>
         <Button
-          onClick={downloadData}
+          onClick={onDownloadClick}
           className={styles.button}
-          disabled={isLoading}
+          disabled={isDownloadingData}
         >
-          {isLoading ? t('loading') : t('downloadData.button')}
+          {isDownloadingData ? t('loading') : t('downloadData.button')}
         </Button>
       </ExpandingPanel>
-
-      <NotificationComponent
-        show={showNotification}
-        onClose={() => setShowNotification(false)}
-      />
     </React.Fragment>
   );
 }

--- a/src/profile/graphql/DeleteMyProfile.graphql
+++ b/src/profile/graphql/DeleteMyProfile.graphql
@@ -1,5 +1,0 @@
-mutation DeleteMyProfile($input:DeleteMyProfileMutationInput!) {
-  deleteMyProfile(input: $input) {
-    clientMutationId
-  }
-}

--- a/src/profile/graphql/DownloadMyProfile.graphql
+++ b/src/profile/graphql/DownloadMyProfile.graphql
@@ -1,3 +1,0 @@
-query DownloadMyProfile {
-  downloadMyProfile
-}

--- a/src/profile/graphql/DownloadMyProfileQuery.graphql
+++ b/src/profile/graphql/DownloadMyProfileQuery.graphql
@@ -1,0 +1,3 @@
+query DownloadMyProfileQuery($authorizationCode: String!) {
+  downloadMyProfile(authorizationCode: $authorizationCode)
+}

--- a/src/profile/helpers/checkBerthError.ts
+++ b/src/profile/helpers/checkBerthError.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from 'graphql';
 
 import profileConstants from '../constants/profileConstants';
 
-export default function checkBerthError(errors: Array<GraphQLError>) {
+export default function checkBerthError(errors: Readonly<Array<GraphQLError>>) {
   if (!errors) return false;
 
   return errors.find(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
 
+"@types/uuid@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.0.0.tgz#165aae4819ad2174a17476dbe66feebd549556c0"
+  integrity sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
+
 "@types/validator@^13.0.0":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
@@ -10708,6 +10713,11 @@ utils-merge@1.0.1:
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
This PR introduces a mechanism which allows the UI to request authorization codes from Tunnistamo, which profiili backend can then use to make authorized requests to other services.

Let's take downloading profile data as an example.

1) User clicks the download button
2) User is redirected to Tunnistamo which, if necessary, renders an UI the user can use to allow a set of permissions (currently these are empty)
3) User is redirected back to profiili UI and the download action is completed

In essence, we need to request the authorization code in the UI, because the user flow may contain a step that requires user input. Once this code is generated, it must be provided within the download profile query and delete profile mutation when these requests are sent to the profile backend. The backend can then use this code to make requests to all the other services for data or deletion.

## Technical jargon

This flow introduces one difficult step--the exit and re-entry into the profile UI application. This makes the download and deletion code flows more difficult to a degree. In comparison, these actions are currently completed with callbacks and promises--which make use of the fact that the "same SPA session" is retained throughout the user action. After we transition into fetching the authorization code, this assumption no longer holds, but instead the application is "hard refreshed" at least for a single time.

Within these changes, this behaviour has been managed with the help of `GdprAuthorizationManager`, `useActionResumer` and `useAuthorizationCode`.

### `GdprAuthorizationManager`

This class is responsible for compliance with the `OpenID` protocol. It's responsible for handling the authorization flow. In this capacity it:
* Stores the application state so that it can be reused when authorization is complete
* Creates the authorization url
* Navigates to authorization url
* Interjects the authorization callback
* Saves token for use
* Reloads application state
* Deletes token and application state from store when it is no longer needed

### `useActionResumer`

This hook is an abstraction which seeks to bridge the "gap" that forms when the user is redirected to Tunnistamo and then finally back into our application. It allows other code within the application to complete actions that span a page refresh  while being relatively agnostic about the method by which the application knows what action to resume when the redirection is done.

**Parameters** 
`deferredAction` - Name of action that get _deferred_  until the redirect back into the UI. This is used as an ID which tells `useActionResumer` whether it should run the `callback` parameter.
`onActionInitialization` - `useActionResumer` begins the action flow by calling this function
`callback` - `useActionResumer` calls this function when the action is resumed

**Humanized explanation**
`useActionResumer` provides its user with the `startAction` function. This function can be used to invoke an action that persists over page reloads. `useActionResumer` listens with a `useEffect` in order to notice when it should complete an action. When it determines that it's a suitable time, it invokes `callback`.

Currently `useActionResumer` relies on a search parameter to know whether it should invoke a `callback`. The `useEffect` that it uses to determine when an action should be completed is not hooked up to listen to changes in location. This way `useActionResumer` won't work unless the search parameter invoking it is present when the component using it is mounted. If the search parameter becomes available after component mount, the callback won't be invoked. Again from another perspective: `useActionResumer` uses the global `location` object to determine whether a search parameter is present. This means that it won't react to location changes.

Using the global location is a sort of anti-pattern which would make it more risky to transition this application into a server rendered application for instance.

### `useAuthorizationCode`
Combines `GdprAuthorizationManager` and `useActionResumer` into a single API that's easier to consume. Code that needs access to an `authorization_code` can hook up to one with a call like this:

```
  const [startFetchingAuthorizationCode, isAuthorizing] = useAuthorizationCode(
    'useDownloadProfile',
    handleAuthorizationCodeCallback
  );
```

## Technical flow

Here I've explained how the application should act in more technical detail. Developers can make use of this explanation to get a better sense of how the features relying on `authorization code` should work. I'll take the download flow as an example, but the delete flow is mostly the same.

1) User logs in
2) User expands panel for downloading user profile
3) User clicks download button
    1) Download button is disabled and its label is changed
    1) Current url and the download action are saved into local storage under `kuvaGdprAuthManager` prefix that's tailed by a random UUID
    1) Tunnistamo authorize URL is built
    1) User is redirected to tunnistamo
6) User allows access to personal information in tunnistamo
7) User is redirected back into the application into address <origin>/gdpr-callback
    1) This view is styled to mimic the general structure of the application by rendering three boxes that correspond in size and colour to the navigation, page heading and content within the profile index page. This makes the juggling of pages less jarring to the user.
    1) It calls `GdprAuthorizationManager.authorizationTokenFetchCallback`
        1) Token is saved into localStorage ready for consumption.
        1) Previous app state is restored. User is redirected to the page the invoked download on and a special search parameter is added to tell `useActionResumer` instances whether they should fire their callbacks.
        1) Previous app state is cleared
8) User lands back on the profile index page based on the redirect.
    1) The expandable element containing the download button is expanded by default.
    1) The page is scrolled so that the download buttons is in view.
    1) The download button is disabled.
    1) The search parameter denoting which action should be fired is removed.
    1) The token is consumed--it's requested from `GdprAuthorizationManager` which then clears it from its own memory.
    1) The token is used to call `downloadProfile`
    1) Once the request completes, the button is enabled again and the file should download.

## Acceptance testing (dev pov)

I've configured the PR environment so that you should be able to use it to complete these acceptance tests:
https://open-city-profile-ui-qa-r-feature-om-8-r1e4rk.test.kuva.hel.ninja/

**EDIT:** It seems that the cert misconfiguration in the infrastructure can lead to a `CERT_ERROR`. You can resolve this error by accessing the API for profiili directly (https://open-city-profile-qa-r-feature-om-8-fe4ln5.test.kuva.hel.ninja/graphql/), and accepting the special dialog Firefox presents.

Before
- Create an account and login
- Open browser console and find panel containing information about `localStorage` (in Chrome Application > Local Storage (on the sidebar on the left) > url of the instance you are testing)

**Downloading profile**  
1) Keep note of local storage--expect to see item with `kuvaGdprAuthManager` once you begin the next step--it's not necessary to try and validate its content
1) Click on the download button
    * Expect to see `kuvaGdprAuthManager` in `localSotrage`
    * Expect button to be disabled
    * Expect to be redirected into Tunnistamo
    * Expect to maybe have to allow permissions
    * Expect to be redirected back to profiili ui
2) Once you are redirected back, expect to land on `/ gdpr-callback` page
    * Expect to see three squares stacked on top of each other reminiscent of the app layout
    * Expect to be redirected into `/` with a search parameter
    * Expect `authorization_code` to be added into `localStorage` (if you are quick enough)
3) Once you are redirected into `/``
    * Expect page to be scrolled to the download button
    * Expect the expandable element containing the download button to be open
    * Expect the download button to be disabled briefly
    * Expect the download to being and complete
    * Expect button to be enabled again
    * Expect the search params to be cleared
    * Expect `localStorage` to be cleared of items beginning with `kuvaGdprAuthManager`

**Deleting profile**

Same as above, but once you are redirected back in step 3, you are redirected again into the deletion page with a timer.