### PR TITLE
Fix missing Swedish translation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Rekisteröitymällä pääset käyttämään uusia palveluita yhdellä helpolla kirjautimisella. Yksi yhtenäinen tunnus tekee kaupunkilaisen arjesta helpompaa."
+      content="Rekisteröitymällä Helsingin kaupungin uusiin palveluihin, sinulle luodaan Helsinki-profiili, jonka kautta näet vaivattomasti tietosi, joita sinusta keräämme sekä palvelut joihin olet tunnistautunut."
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Profiili</title>

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -63,9 +63,8 @@
   "login": {
     "description": "Genom att logga in på de nya Helsingfors stadstjänster skapas en Helsingfors-profil för dig. Här kan du enkelt hitta din profilinformation och se alla tjänster du har loggat in med den.",
     "login": "Logga in",
-    "title": ""
+    "title": "Din profilinformation på en adress!"
   },
-  "Din profilinformation på en adress!": "",
   "nav": {
     "information": "Mina uppgifter",
     "menuButtonLabel": "Profilmeny",


### PR DESCRIPTION
- The Swedish translations had become corrupted for some reason. I fixed it by running `yarn update-translations`.
- I updated the content of the meta tag based on a request.