### PR TITLE
OM-885 | Fix missing login button in build

### DIFF
--- a/src/auth/components/login/Login.module.css
+++ b/src/auth/components/login/Login.module.css
@@ -24,13 +24,13 @@
     background-color: var(--color-white);
 }
 
-.button {
+button.button {
     margin-top: 50px;
     background-color: var(--color-white);
     width: 100%;
 }
 
-.button:hover {
+button.button:hover {
     background-color: var(--color-background-button-secondary-hover);
 }
 
@@ -44,7 +44,7 @@
 }
 
 @media(min-width: 450px) {
-    .button {
+    button.button {
         width: 230px;
     }
 


### PR DESCRIPTION
The specificity of CSS rules changed between development build and
production build. This caused HDS to override some styles in
production, which caused the button to go missing.

In this commit I fixed this issue by adding specificity into the
selectors for our custom rules. I added a question into the HDS repo
in an attempt to uncover a better fix.

This feature can be tested in the PR env as it does not require logging in (once it finishes building).