### PR TITLE
OM-869 | Add link back to account management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Support for authorization code generation for GDPR API related calls (profile download and deletion) [#108](https://github.com/City-of-Helsinki/open-city-profile-ui/pull/108)
+- Link to authentication method account management [#114](https://github.com/City-of-Helsinki/open-city-profile-ui/pull/114)
 
 ### Fixed
 - Focus indicator being partially hidden with elements used for downloading and deleting profile

--- a/README.md
+++ b/README.md
@@ -60,12 +60,20 @@ Since this app uses react-scripts (Create React App) the env-files work a bit di
 
 The following envs are used:
 
-- REACT_APP_OIDC_AUTHORITY - this is the URL to tunnistamo
-- REACT_APP_OIDC_CLIENT_ID - ID of the client that has to be configured in tunnistamo
-- REACT_APP_PROFILE_AUDIENCE - name of the api-token that client uses profile-api with
-- REACT_APP_PROFILE_GRAPHQL - URL to the profile graphql
-- REACT_APP_OIDC_SCOPE - which scopes the app requires
-- REACT_APP_SENTRY_DSN - sentry public dns-key
+| Name  | Description |
+| --- | ------------- |
+| `REACT_APP_HELSINKI_ACCOUNT_AMR` | Authentication method reference for Helsinki account. </br> **default:** `helusername` |
+| `REACT_APP_IPD_MANAGEMENT_URL_HELSINKI_ACCOUNT` | Account management url for Helsinki account. </br> **default:** `https://salasana.hel.ninja/auth/realms/helsinki-salasana/account` |
+| `REACT_APP_IPD_MANAGEMENT_URL_GITHUB` | Account management url for GitHub. </br> **default:** `https://github.com/settings/profile` |
+| `REACT_APP_IPD_MANAGEMENT_URL_GOOGLE` | Account management url for Google. </br> **default:** `https://myaccount.google.com` |
+| `REACT_APP_IPD_MANAGEMENT_URL_FACEBOOK` | Account management url for Facebook.  </br> **default:** `http://facebook.com/settings` |
+| `REACT_APP_IPD_MANAGEMENT_URL_YLE` | Account management url for Yle. </br> **default:** `https://tunnus.yle.fi/#omat-tiedot` |
+| `REACT_APP_OIDC_AUTHORITY` | This is the URL to tunnistamo. |
+| `REACT_APP_OIDC_CLIENT_ID` | ID of the client that has to be configured in tunnistamo. |
+| `REACT_APP_OIDC_SCOPE` | Which scopes the app requires. |
+| `REACT_APP_PROFILE_AUDIENCE` | Name of the api-token that client uses profile-api with. |
+| `REACT_APP_PROFILE_GRAPHQL` | URL to the profile graphql. |
+| `REACT_APP_SENTRY_DSN` | Sentry public dns-key. |
 
 
 ## Setting up local development environment with Docker

--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import getAuthenticatedUser from './getAuthenticatedUser';
+import config from '../config';
+
+export type AMR =
+  | 'github'
+  | 'google'
+  | 'facebook'
+  | 'yle'
+  | typeof config.helsinkiAccountAMR;
+
+export type AMRStatic =
+  | 'github'
+  | 'google'
+  | 'facebook'
+  | 'yle'
+  | 'helsinkiAccount';
+
+export interface Profile {
+  amr: AMR;
+  auth_time: number;
+  email: string;
+  email_verified: boolean;
+  family_name: string;
+  given_name: string;
+  name: string;
+  nickname: string;
+  sub: string;
+}
+
+interface ProfileState {
+  profile: Profile | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+function useProfile(): ProfileState {
+  const [profile, setProfile] = React.useState<Profile | null>(null);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    function getUser() {
+      setIsLoading(true);
+
+      getAuthenticatedUser()
+        .then(user => {
+          if (ignore) {
+            return;
+          }
+
+          setProfile(user.profile);
+        })
+        .catch(() => {
+          if (ignore) {
+            return;
+          }
+
+          setError(Error('User was not found'));
+        })
+        .finally(() => {
+          if (ignore) {
+            return;
+          }
+
+          setIsLoading(false);
+        });
+    }
+
+    getUser();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return {
+    profile,
+    loading: isLoading,
+    error,
+  };
+}
+
+export default useProfile;

--- a/src/common/expandingPanel/ExpandingPanel.module.css
+++ b/src/common/expandingPanel/ExpandingPanel.module.css
@@ -5,7 +5,6 @@
     --ep-accent-color: var(--color-bus);
     width: 100%;
     background: var(--ep-background);
-    margin: 0 0 var(--spacing-m) 0;
 }
 
 .title {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+import defaultTo from 'lodash/defaultTo';
+
+export default {
+  clientId: process.env.REACT_APP_OIDC_CLIENT_ID,
+  environment: process.env.REACT_APP_ENVIRONMENT,
+  helsinkiAccountAMR: defaultTo(
+    process.env.REACT_APP_HELSINKI_ACCOUNT_AMR,
+    'helusername'
+  ),
+  oidcAuthority: process.env.REACT_APP_OIDC_AUTHORITY,
+  oidcScope: process.env.REACT_APP_OIDC_SCOPE,
+  profileAudience: process.env.REACT_APP_PROFILE_AUDIENCE,
+  profileGraphQl: process.env.REACT_APP_PROFILE_GRAPHQL,
+  sentryDsn: process.env.REACT_APP_SENTRY_DSN,
+  identityProviderManagementUrlHelsinki: defaultTo(
+    process.env.REACT_APP_IPD_MANAGEMENT_URL_HELSINKI_ACCOUNT,
+    'https://salasana.hel.ninja/auth/realms/helsinki-salasana/account'
+  ),
+  identityProviderManagementUrlGithub: defaultTo(
+    process.env.REACT_APP_IPD_MANAGEMENT_URL_GITHUB,
+    'https://github.com/settings/profile'
+  ),
+  identityProviderManagementUrlGoogle: defaultTo(
+    process.env.REACT_APP_IPD_MANAGEMENT_URL_GOOGLE,
+    'https://myaccount.google.com'
+  ),
+  identityProviderManagementUrlFacebook: defaultTo(
+    process.env.REACT_APP_IPD_MANAGEMENT_URL_FACEBOOK,
+    'http://facebook.com/settings'
+  ),
+  identityProviderManagementUrlYle: defaultTo(
+    process.env.REACT_APP_IPD_MANAGEMENT_URL_YLE,
+    'https://tunnus.yle.fi/#omat-tiedot'
+  ),
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -122,7 +122,9 @@
     "personalData": "Personal data",
     "phone": "Phone",
     "title": "My information",
-    "visibility": "The following information about you is stored in Helsinki profile."
+    "visibility": "The following information about you is stored in Helsinki profile.",
+    "doGoToAccountManagement": "Go to account management",
+    "authenticationMethod": "Authentication method"
   },
   "sanityCheck": "open-city-profile.en",
   "serviceConnections": {
@@ -147,5 +149,12 @@
     "maxLength": "This field can be max {{max}} characters.",
     "phoneMin": "The number must be at least {{min}} characters long.",
     "required": "This field is required."
+  },
+  "identityProvider": {
+    "helsinkiAccount": "Helsinki account",
+    "github": "GitHub",
+    "google": "Google",
+    "facebook": "Facebook",
+    "yle": "Yle"
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -122,7 +122,9 @@
     "personalData": "Henkilötiedot",
     "phone": "Puhelinnumero",
     "title": "Omat tiedot",
-    "visibility": "Helsinki-profiiliin on tallennettu sinusta alla olevat tiedot."
+    "visibility": "Helsinki-profiiliin on tallennettu sinusta alla olevat tiedot.",
+    "doGoToAccountManagement": "Siirry tunnuksen hallintaan",
+    "authenticationMethod": "Tunnistautumistapa"
   },
   "sanityCheck": "open-city-profile.fi",
   "serviceConnections": {
@@ -147,5 +149,12 @@
     "maxLength": "Kentän maksimipituus on {{max}} merkkiä.",
     "phoneMin": "Puhelinnumeron pitää olla vähintään {{min}} merkkiä pitkä.",
     "required": "Tämä kenttä on pakollinen."
+  },
+  "identityProvider": {
+    "helsinkiAccount": "Helsinki-tunnus",
+    "github": "GitHub",
+    "google": "Google",
+    "facebook": "Facebook",
+    "yle": "Yle"
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -122,7 +122,9 @@
     "personalData": "Personuppgifter",
     "phone": "Telefonnummer",
     "title": "Min information",
-    "visibility": "Följande information om dig lagras i Helsingfors profilen."
+    "visibility": "Följande information om dig lagras i Helsingfors profilen.",
+    "doGoToAccountManagement": "Gå till kontohantering",
+    "authenticationMethod": "Autentiseringsmetod"
   },
   "sanityCheck": "open-city-profile.sv",
   "serviceConnections": {
@@ -147,5 +149,12 @@
     "maxLength": "Fältet får vara högst {{max}} tecken långt.",
     "phoneMin": "Telefonnumret måste vara mint {{min}} tecken långt.",
     "required": "Detta fält krävs."
+  },
+  "identityProvider": {
+    "helsinkiAccount": "Helsinfors-kontot",
+    "github": "GitHub",
+    "google": "Google",
+    "facebook": "Facebook",
+    "yle": "Yle"
   }
 }

--- a/src/profile/components/profileInformation/ProfileInformation.module.css
+++ b/src/profile/components/profileInformation/ProfileInformation.module.css
@@ -20,3 +20,9 @@
 .title {
   font-size: var(--fontsize-h-3);
 }
+
+.boxGrid {
+  display: grid;
+  grid-row-gap: var(--spacing-m);
+  grid-template-rows: auto;
+}

--- a/src/profile/components/profileInformation/ProfileInformation.tsx
+++ b/src/profile/components/profileInformation/ProfileInformation.tsx
@@ -31,6 +31,7 @@ import useDownloadProfile from '../../../gdprApi/useDownloadProfile';
 import useDeleteProfile from '../../../gdprApi/useDeleteProfile';
 import checkBerthError from '../../helpers/checkBerthError';
 import BerthErrorModal from '../modals/berthError/BerthErrorModal';
+import ProfileInformationAccountManagementLink from './ProfileInformationAccountManagementLink';
 
 const ALL_DATA = loader('../../graphql/DownloadMyProfileQuery.graphql');
 
@@ -190,6 +191,7 @@ function ProfileInformation(props: Props) {
         )}
       </ProfileSection>
       <div className={styles.boxGrid}>
+        <ProfileInformationAccountManagementLink />
         <DownloadData
           isDownloadingData={isDownloadingProfile}
           isOpenByDefault={isDownloadingProfile}

--- a/src/profile/components/profileInformation/ProfileInformation.tsx
+++ b/src/profile/components/profileInformation/ProfileInformation.tsx
@@ -189,15 +189,17 @@ function ProfileInformation(props: Props) {
           </Fragment>
         )}
       </ProfileSection>
-      <DownloadData
-        isDownloadingData={isDownloadingProfile}
-        isOpenByDefault={isDownloadingProfile}
-        onDownloadClick={downloadProfileData}
-      />
-      <DeleteProfile
-        onDelete={deleteProfile}
-        isOpenByDefault={isDeletingProfile}
-      />
+      <div className={styles.boxGrid}>
+        <DownloadData
+          isDownloadingData={isDownloadingProfile}
+          isOpenByDefault={isDownloadingProfile}
+          onDownloadClick={downloadProfileData}
+        />
+        <DeleteProfile
+          onDelete={deleteProfile}
+          isOpenByDefault={isDeletingProfile}
+        />
+      </div>
       <NotificationComponent
         show={showNotification}
         onClose={() => setShowNotification(false)}

--- a/src/profile/components/profileInformation/ProfileInformationAccountManagementLink.tsx
+++ b/src/profile/components/profileInformation/ProfileInformationAccountManagementLink.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { IconAngleRight } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+import useProfile from '../../../auth/useProfile';
+import LabeledValue from '../../../common/labeledValue/LabeledValue';
+import {
+  getAmr,
+  getAmrUrl,
+} from './profileInformationAccountManagementLinkUtils';
+import styles from './profileInformationAccountManagementLink.module.css';
+
+function ProfileInformationAccountManagementLink() {
+  const { t } = useTranslation();
+  const { profile } = useProfile();
+
+  const amr = getAmr(profile);
+
+  if (!amr) {
+    return null;
+  }
+
+  const authenticationMethodReferenceUrl = getAmrUrl(amr);
+  const authenticationMethodReferenceName = t(`identityProvider.${amr}`);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.labelSection}>
+        <LabeledValue
+          label={t('profileInformation.authenticationMethod')}
+          value={authenticationMethodReferenceName}
+        />
+      </div>
+      <div className={styles.link}>
+        <a
+          href={authenticationMethodReferenceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('profileInformation.doGoToAccountManagement')} <IconAngleRight />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default ProfileInformationAccountManagementLink;

--- a/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
+++ b/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import enzymeToJson from 'enzyme-to-json';
+
+import ProfileInformationAuthenticationSourceBackLink from '../ProfileInformationAccountManagementLink';
+
+jest.mock('../../../../config', () => ({
+  identityProviderManagementUrlHelsinki: 'https://test-url',
+  helsinkiAccountAMR: 'helusername-test',
+}));
+
+jest.mock('../../../../auth/useProfile', () => () => ({
+  profile: {
+    amr: 'helusername-test',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    auth_time: 1593431180,
+    email: 'email@email.com',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    email_verified: false,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    family_name: 'Betty',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    given_name: 'Smith',
+    name: 'Betty Smith',
+    nickname: 'Betty',
+    sub: 'uuidvalue',
+  },
+}));
+
+describe('<ProfileInformationAuthenticationSourceBackLink />', () => {
+  const defaultProps = {};
+  const getWrapper = props =>
+    mount(
+      <ProfileInformationAuthenticationSourceBackLink
+        {...defaultProps}
+        {...props}
+      />
+    );
+
+  beforeAll(() => {
+    process.env.REACT_APP_HELSINKI_ACCOUNT_AMR = 'helusername-test';
+  });
+
+  afterAll(() => {
+    process.env.REACT_APP_HELSINKI_ACCOUNT_AMR = 'helusername';
+  });
+
+  it('should render helsinki account link as expected based on config', () => {
+    const wrapper = getWrapper();
+
+    expect(enzymeToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/profile/components/profileInformation/__tests__/__snapshots__/ProfileInformationAccountManagementLink.test.jsx.snap
+++ b/src/profile/components/profileInformation/__tests__/__snapshots__/ProfileInformationAccountManagementLink.test.jsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProfileInformationAuthenticationSourceBackLink /> should render helsinki account link as expected based on config 1`] = `
+<ProfileInformationAccountManagementLink>
+  <div
+    className="container"
+  >
+    <div
+      className="labelSection"
+    >
+      <LabeledValue
+        label="profileInformation.authenticationMethod"
+        value="identityProvider.helsinkiAccount"
+      >
+        <div
+          className="wrapper"
+        >
+          <strong
+            className="label"
+          >
+            profileInformation.authenticationMethod
+          </strong>
+          <span
+            className="value"
+          >
+            identityProvider.helsinkiAccount
+          </span>
+        </div>
+      </LabeledValue>
+    </div>
+    <div
+      className="link"
+    >
+      <a
+        href="https://test-url"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        profileInformation.doGoToAccountManagement
+         
+        <IconAngleRight>
+          <svg
+            className="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            style={Object {}}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fillRule="evenodd"
+            >
+              <path
+                d="M0 24V0h24v24z"
+              />
+              <path
+                d="M13 12.5l-5-5L9.5 6l6.5 6.5L9.5 19 8 17.5z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </IconAngleRight>
+      </a>
+    </div>
+  </div>
+</ProfileInformationAccountManagementLink>
+`;

--- a/src/profile/components/profileInformation/profileInformationAccountManagementLink.module.css
+++ b/src/profile/components/profileInformation/profileInformationAccountManagementLink.module.css
@@ -1,0 +1,52 @@
+.container {
+  --padding-v: var(--spacing-m);
+  --padding-h: var(--spacing-m);
+
+  display: flex;
+  flex-direction: column;
+  padding: var(--padding-v) var(--padding-h);
+
+  background: var(--color-white);
+}
+
+.labelSection {
+  flex-grow: 1;
+  margin-bottom: var(--spacing-m);
+}
+.labelSection > div {
+  margin-bottom: 0;
+}
+
+.link {
+  display: flex;
+}
+
+.link > a {
+  display: inline-flex;
+  align-items: center;
+
+  font-size: var(--fontsize-body-default);
+  font-weight: bold;
+  color: var(--color-bus);
+  text-decoration: none;
+}
+
+@media (min-width: 450px) {
+  .container {
+    flex-direction: row;
+  }
+
+  .labelSection {
+    margin-bottom: 0;
+  }
+
+  .link {
+    justify-content: flex-end;
+  }
+}
+
+@media (min-width: 600px) {
+  .container {
+    --padding-h: var(--spacing-xl);
+  }
+}

--- a/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
+++ b/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
@@ -1,0 +1,45 @@
+import { Profile, AMRStatic } from '../../../auth/useProfile';
+import config from '../../../config';
+
+export function getAmr(profile: Profile | null): AMRStatic | null {
+  const amr = profile?.amr;
+
+  // If amr designates helsinki account, switch the value into a static
+  // value. This setup allows the amr for Helsinki account to be
+  // configured, while allowing a static reference we can use for
+  // translations for instance.
+  if (amr === config.helsinkiAccountAMR) {
+    return 'helsinkiAccount';
+  }
+
+  if (
+    amr === 'github' ||
+    amr === 'google' ||
+    amr === 'facebook' ||
+    amr === 'yle'
+  ) {
+    return amr;
+  }
+
+  // If amr doesn't match any of our expectations, return null.
+  return null;
+}
+
+export function getAmrUrl(authenticationMethodReference: AMRStatic): string {
+  switch (authenticationMethodReference) {
+    case 'helsinkiAccount':
+      return config.identityProviderManagementUrlHelsinki;
+    case 'github':
+      return config.identityProviderManagementUrlGithub;
+    case 'google':
+      return config.identityProviderManagementUrlGoogle;
+    case 'facebook':
+      return config.identityProviderManagementUrlFacebook;
+    case 'yle':
+      return config.identityProviderManagementUrlYle;
+    default:
+      throw Error(
+        `Unexpected authentication method reference "${authenticationMethodReference}"`
+      );
+  }
+}

--- a/src/profile/components/serviceConnections/ServiceConnections.module.css
+++ b/src/profile/components/serviceConnections/ServiceConnections.module.css
@@ -34,6 +34,9 @@
 }
 
 .panelContainer {
+  display: grid;
+  grid-row-gap: var(--spacing-m);
+  grid-template-rows: auto;
   margin: 50px 0;
 }
 


### PR DESCRIPTION
Refactors expandable panel to not have bottom margin--this way I could avoid setting bottom margin for this new element, and instead set up a grid in `<ProfileInformation />` which allows a single source of truth for the margin amount.

The urls, and the Helsinki account authentication method references are configurable. I documented these in the readme. All of the new variables have sensible defaults, but at least `REACT_APP_IPD_MANAGEMENT_URL_HELSINKI_ACCOUNT` may need to be configured differently based on environment.

Helsinki account still won't be enabled outside dev environments for a while, but that should not make a difference for the UI as it won't show a link back to Helsinki account unless it is told to do so.