### PR TITLE
OM-916 | Improve authentication error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,9 +90,7 @@ function App(props: Props) {
               {/* This should be the first focusable element */}
               <AccessibilityShortcuts mainContentId={MAIN_CONTENT_ID} />
               <Switch>
-                <Route path="/callback">
-                  <OidcCallback />
-                </Route>
+                <Route path="/callback" component={OidcCallback} />
                 <Route path="/gdpr-callback">
                   <GdprAuthorizationCodeManagerCallback />
                 </Route>

--- a/src/auth/components/oidcCallback/OidcCallback.tsx
+++ b/src/auth/components/oidcCallback/OidcCallback.tsx
@@ -1,30 +1,70 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CallbackComponent } from 'redux-oidc';
-import { useHistory } from 'react-router';
+import { RouteChildrenProps } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/browser';
 
 import userManager from '../../userManager';
 
-type Props = {};
+type AuthenticationError =
+  | 'deviceTimeError'
+  | 'permissionDeniedByUserError'
+  | 'unknown';
 
-function OidcCallback(props: Props) {
-  const history = useHistory();
-  const onSuccess = (user: object) => {
-    history.push('/');
-  };
-  const onError = (error: object) => {
-    Sentry.captureException(error);
-    history.push('/');
-  };
+function OidcCallback({ history }: RouteChildrenProps) {
   const { t } = useTranslation();
+  const [
+    authenticationError,
+    setAuthenticationError,
+  ] = useState<AuthenticationError | null>(null);
+
+  const onSuccess = () => {
+    // Use replace in order to hide the callback view from history.
+    history.replace('/');
+  };
+
+  const onError = (error: Error) => {
+    // Handle error caused by device time being more than 5 minutes off
+    if (
+      error.message.includes('iat is in the future') ||
+      error.message.includes('exp is in the past')
+    ) {
+      setAuthenticationError('deviceTimeError');
+    } else if (
+      // Handle error caused by end user choosing Deny in Tunnistamo's
+      // permission request
+      error.message ===
+      'The resource owner or authorization server denied the request'
+    ) {
+      setAuthenticationError('permissionDeniedByUserError');
+    } else {
+      // Send other errors to Sentry for analysis
+      Sentry.captureException(error);
+      // Give user a generic error
+      setAuthenticationError('unknown');
+    }
+  };
+
+  const isDeviceTimeError = authenticationError === 'deviceTimeError';
+  const isPermissionDeniedByUserError =
+    authenticationError === 'permissionDeniedByUserError';
+  const isUnknownError = authenticationError === 'unknown';
+
   return (
     <CallbackComponent
       successCallback={onSuccess}
       errorCallback={onError}
       userManager={userManager}
     >
-      <p>{t('oidc.authenticating')}</p>
+      <>
+        {isDeviceTimeError && (
+          <p>{t('authentication.deviceTimeError.message')}</p>
+        )}
+        {isPermissionDeniedByUserError && (
+          <p>{t('authentication.permissionRequestDenied.message')}</p>
+        )}
+        {isUnknownError && <p>{t('authentication.genericError.message')}</p>}
+      </>
     </CallbackComponent>
   );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,16 @@
 {
   "appName": "Profile",
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "permissionRequestDenied": {
+      "message": "You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    },
+    "genericError": {
+      "message": "An error occured while logging in. Please try again"
+    }
+  },
   "berthErrors": {
     "close": "Close",
     "explanation": "You cannot delete your information because Boat berths service needs your information for billing. Contact the customer service of Berth service to terminate your contract. After that has been done, you can try again.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -1,5 +1,16 @@
 {
   "appName": "Profiili",
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Usko tai älä usko, mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan."
+    },
+    "permissionRequestDenied": {
+      "message": "Sinun täytyy hyväksyä pyytämämme oikeudet Tunnistamossa käyttääksesi tätä palvelua. Ole hyvä ja yritä kirjautua uudelleen."
+    },
+    "genericError": {
+      "message": "Tapahtui virhe. Yritä uudestaan"
+    }
+  },
   "berthErrors": {
     "close": "Sulje",
     "explanation": "Et voi poistaa tietojasi, koska Venepaikka-palvelu tarvitsee tietojasi laskutukseen. Ota yhteyttä Venepaikka-palvelun asiakaspalveluun irtisanoaksesi sopimuksesi ja yritä sen jälkeen poistoa uudelleen.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1,5 +1,16 @@
 {
   "appName": "Profil",
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Tro det eller ej, men du kan inte logga in eftersom din enhets klocka går mer än 5 minuter fel. Justera klockan och försök igen."
+    },
+    "permissionRequestDenied": {
+      "message": "Du måste godkänna begäran om åtkomst till din Tunnistamo-profil för att kunna använda den här tjänsten. Försök att logga in igen."
+    },
+    "genericError": {
+      "message": "Ett fel uppstod. Försök igen"
+    }
+  },
   "berthErrors": {
     "close": "Stänga",
     "explanation": "Du kan inte radera din information eftersom Båtplatser-tjänsten behöver din faktureringsinformation. Kontakta Båtplatsers kundservice för att säga upp ditt kontrakt. När det är gjort kan du försöka igen.",
@@ -31,7 +42,7 @@
   },
   "downloadData": {
     "button": "Ladda ner min information",
-    "panelText": "Om du vill se all vår lagrad information om dig, kan du ladda ner dem här. Informationen levereras som en fil i ett fast format så att du kan flytta den till något annat system om du vill.",
+    "panelText": "Om du vill se alla uppgifter som vi lagrat om dig, kan du ladda ned dem här. Informationen levereras som en formbunden fil så att du kan överföra uppgifterna till ett annat system om du vill.",
     "panelTitle": "Vill du ladda ner din information?"
   },
   "expandingPanel": {
@@ -68,7 +79,7 @@
   "nav": {
     "information": "Mina uppgifter",
     "menuButtonLabel": "Profilmeny",
-    "services": "Anslutna servicer",
+    "services": "Anslutna tjänster",
     "signin": "Logga in",
     "signout": "Logga ut",
     "subscriptions": "Prenumerationer"
@@ -131,7 +142,7 @@
     "clock": "kl.",
     "created": "Skapad:",
     "empty": "Du har för närvarande inga tjänster anslutna till din profil.",
-    "explanation": "Din profil har anslutits till Helsingfors stads tjänster listade nedan. Alla ändringar i din information är omedelbart tillgängliga för tjänsterna. Du behöver inte ändra din information separat i varje tjänst.",
+    "explanation": "Din profil har anslutits till Helsingfors stads tjänster som är listade nedan. Alla ändringar i som du gör i dina uppgifter är omedelbart tillgängliga för dessa tjänster. Du behöver inte ändra dina uppgifter separat i varje tjänst.",
     "servicePersonalData": "Information som tjänsten vet om dig:",
     "title": "Anslutna tjänster"
   },


### PR DESCRIPTION
This PR adds the same checks as are used in youth-membership and kukkuu. It also blocks access to the callback view after login by using replace instead of push to redirect the user.

These changes won't remove all the errors OM-916 lists, but may make some cases leading to it less likely.