### PR TITLE
HP-42 service view update

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -79,7 +79,7 @@
   "nav": {
     "information": "Information",
     "menuButtonLabel": "Profile menu",
-    "services": "Connected services",
+    "services": "EN: Käyttämäsi palvelut",
     "signin": "Log in",
     "signout": "Sign out",
     "subscriptions": "Subscriptions"
@@ -142,9 +142,9 @@
     "clock": "at",
     "created": "Created:",
     "empty": "You currently don't have any services connected to your profile.",
-    "explanation": "Your profile has been connected to the City of Helsinki services listed below. Any changes in your information are immediately available to the services. You don't have to change your information separately in each service.",
+    "explanation": "EN: Olet antanut seuraaville palveluille oikeuden käyttää Helsinki Profiili -tietojasi.",
     "servicePersonalData": "Information which the service will know about you:",
-    "title": "Connected services"
+    "title": "EN: Palvelut, joilla on lupa käyttää tietojasi"
   },
   "skipToContent": "Skip to content",
   "subscriptions": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -79,7 +79,7 @@
   "nav": {
     "information": "Omat tiedot",
     "menuButtonLabel": "Profiilivalikko",
-    "services": "Yhdistetyt palvelut",
+    "services": "Käyttämäsi palvelut",
     "signin": "Kirjaudu sisään",
     "signout": "Kirjaudu ulos",
     "subscriptions": "Tilaukset"
@@ -142,9 +142,9 @@
     "clock": "klo",
     "created": "Luotu:",
     "empty": "Sinulla ei tällä hetkellä ole palveluita liitettynä profiiliisi.",
-    "explanation": "Profiilisi on yhdistetty alla oleviin Helsingin kaupungin palveluihin. Muutokset omissa tiedoissasi ovat heti palveluiden käytössä. Sinun ei tarvitse muuttaa tietojasi jokaisessa palvelussa erikseen.",
+    "explanation": "Olet antanut seuraaville palveluille oikeuden käyttää Helsinki Profiili -tietojasi.",
     "servicePersonalData": "Palvelu saa tietää sinusta:",
-    "title": "Yhdistetyt palvelut"
+    "title": "Palvelut, joilla on lupa käyttää tietojasi"
   },
   "skipToContent": "Siirry suoraan sisältöön",
   "subscriptions": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -79,7 +79,7 @@
   "nav": {
     "information": "Mina uppgifter",
     "menuButtonLabel": "Profilmeny",
-    "services": "Anslutna tjänster",
+    "services": "SV: Käyttämäsi palvelut",
     "signin": "Logga in",
     "signout": "Logga ut",
     "subscriptions": "Prenumerationer"
@@ -142,9 +142,9 @@
     "clock": "kl.",
     "created": "Skapad:",
     "empty": "Du har för närvarande inga tjänster anslutna till din profil.",
-    "explanation": "Din profil har anslutits till Helsingfors stads tjänster som är listade nedan. Alla ändringar i som du gör i dina uppgifter är omedelbart tillgängliga för dessa tjänster. Du behöver inte ändra dina uppgifter separat i varje tjänst.",
+    "explanation": "SV: Olet antanut seuraaville palveluille oikeuden käyttää Helsinki Profiili -tietojasi.",
     "servicePersonalData": "Information som tjänsten vet om dig:",
-    "title": "Anslutna tjänster"
+    "title": "SV: Palvelut, joilla on lupa käyttää tietojasi"
   },
   "skipToContent": "Hoppa till innehåll",
   "subscriptions": {

--- a/src/profile/components/serviceConnections/ServiceConnections.module.css
+++ b/src/profile/components/serviceConnections/ServiceConnections.module.css
@@ -9,14 +9,12 @@
 }
 
 .serviceInformation {
-  margin-left: 25px;
   margin-top: 20px;
   font-weight: bold;
 }
 
 .allowedDataField {
   display: block;
-  margin-left: 25px;
   margin-bottom: 10px;
 }
 .allowedDataField:first-of-type {
@@ -25,11 +23,10 @@
 
 .createdAt {
   font-weight: bold;
-  margin: 20px 25px 5px;
+  margin: 20px 0 5px;
 }
 
 .dateAndTime {
-  margin-left: 25px;
   margin-top: 0;
 }
 


### PR DESCRIPTION
Changes made according to UX-design in https://helsinkisolutionoffice.atlassian.net/browse/HP-404. KuVa had already made all features.

Just small CSS and translation changes. Only FI-translations exist, so EN and SV have placeholders for translators.

Currently there are no BE end points for removing or getting data of only one service. Therefore links "Poista tietosi tästä palvelusta" / "Lataa kaikki tietosi" were not added.