### PR TITLE
Merge 1.1.2 hotfixes into master

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ env:
   KUBECONFIG_RAW: ${{ secrets.KUBECONFIG_RAW_STABLE }}
   BUILD_ARTIFACT_FOLDER: 'build_artifacts'
   SERVICE_ARTIFACT_FOLDER: 'service_artifacts'
-  SERVICE_PORT: 8080
+  SERVICE_PORT: 80
 
 jobs:
   build:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,6 +28,9 @@ jobs:
         uses: andersinno/kolga-build-action@v2
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
+          DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://api.hel.fi/profiili/graphql/"
 
   production:
     if: startsWith(github.ref, 'refs/tags')
@@ -47,7 +50,3 @@ jobs:
           K8S_ADDITIONAL_HOSTNAMES: ${{ secrets.K8S_ADDITIONAL_HOSTNAMES }}
           ENVIRONMENT_URL: https://${{ secrets.ENVIRONMENT_URL_STABLE }}
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
-          K8S_SECRET_REACT_APP_ENVIRONMENT: 'production'
-          K8S_SECRET_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
-          K8S_SECRET_REACT_APP_PROFILE_GRAPHQL: "https://api.hel.fi/profiili/graphql/"
-


### PR DESCRIPTION
Earlier 1.1.2 hotfixes were deployed using github flow branching model. Fixes were removed when a new version from master was deployed.