### PR TITLE
HP-318 step 3: centralise code

### DIFF
--- a/src/common/formikDropdown/FormikDropdown.tsx
+++ b/src/common/formikDropdown/FormikDropdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dropdown, DropdownProps } from 'hds-react';
 import { Field, FieldProps } from 'formik';
 
-import { Language } from '../../graphql/generatedTypes';
+import { Language } from '../../graphql/typings';
 
 type Props = {
   name: string;

--- a/src/common/schemas/schemas.ts
+++ b/src/common/schemas/schemas.ts
@@ -1,0 +1,106 @@
+import * as yup from 'yup';
+import validator from 'validator';
+
+import { formFieldsByDataType } from '../../profile/helpers/formProperties';
+
+type MessageWithOptions = {
+  message: string;
+  options?: Record<string, string>;
+};
+
+const maxLengthValidation = 'validation.maxLength';
+const requiredValidation = 'validation.required';
+
+export const setErrorMessageWithOptions = (
+  messageWithOptions: MessageWithOptions
+): string => {
+  const { message, options } = messageWithOptions;
+  if (!options) {
+    return message;
+  }
+  const optionsString = new URLSearchParams(options).toString();
+  return `${message}?${optionsString}`;
+};
+
+export const getErrorMessageWithOptions = (
+  messageWithOptions: string
+): MessageWithOptions => {
+  const messageWithOptionsArray = messageWithOptions.split('?');
+  const message = messageWithOptionsArray[0];
+  const options = messageWithOptionsArray[1]
+    ? Object.fromEntries(new URLSearchParams(messageWithOptionsArray[1]))
+    : undefined;
+  return { message, options };
+};
+
+const createMaxLengthMessage = (
+  max: number,
+  message = maxLengthValidation
+): string =>
+  setErrorMessageWithOptions({
+    message,
+    options: { max: String(max) },
+  });
+
+const createMinLengthMessage = (min: number, message: string): string =>
+  setErrorMessageWithOptions({
+    message,
+    options: { min: String(min) },
+  });
+
+const addressesProperties = formFieldsByDataType['addresses'];
+const addressMax = addressesProperties.address.max as number;
+const cityMax = addressesProperties.city.max as number;
+const postalCodeMax = addressesProperties.postalCode.max as number;
+export const addressSchema = yup.object().shape({
+  address: yup
+    .string()
+    .required(requiredValidation)
+    .max(addressMax, createMaxLengthMessage(addressMax)),
+  city: yup
+    .string()
+    .required(requiredValidation)
+    .max(cityMax, createMaxLengthMessage(cityMax)),
+  postalCode: yup
+    .string()
+    .required(requiredValidation)
+    .max(postalCodeMax, createMaxLengthMessage(postalCodeMax)),
+});
+
+const basicDataProperties = formFieldsByDataType['basic-data'];
+const firstNameMax = basicDataProperties.firstName.max as number;
+const nicknameMax = basicDataProperties.nickname.max as number;
+const lastNameMax = basicDataProperties.lastName.max as number;
+export const basicDataSchema = yup.object().shape({
+  firstName: yup
+    .string()
+    .required(requiredValidation)
+    .max(firstNameMax, createMaxLengthMessage(firstNameMax)),
+  nickname: yup.string().max(nicknameMax, createMaxLengthMessage(nicknameMax)),
+  lastName: yup
+    .string()
+    .required(requiredValidation)
+    .max(lastNameMax, createMaxLengthMessage(lastNameMax)),
+});
+
+const phonesProperties = formFieldsByDataType['phones'];
+const phonesMin = phonesProperties.value.min as number;
+const phonesMax = phonesProperties.value.max as number;
+export const phoneSchema = yup.object().shape({
+  value: yup
+    .string()
+    .required(requiredValidation)
+    .min(phonesMin, createMinLengthMessage(phonesMin, 'validation.phoneMin'))
+    .max(phonesMax, createMaxLengthMessage(phonesMax)),
+});
+export const createProfilePhoneSchema = yup.object().shape({
+  phone: yup
+    .string()
+    .min(phonesMin, createMinLengthMessage(phonesMin, 'validation.phoneMin'))
+    .max(phonesMax, createMaxLengthMessage(phonesMax)),
+});
+export const emailSchema = yup.object().shape({
+  value: yup.mixed().test('isValidEmail', 'validation.email', function() {
+    return this.parent?.value ? validator.isEmail(this.parent?.value) : false;
+  }),
+});

--- a/src/common/test/subscriptionTestData.ts
+++ b/src/common/test/subscriptionTestData.ts
@@ -1,9 +1,9 @@
 import {
-  QueryMySubscriptions_myProfile_subscriptions_edges as ProfileEdge,
-  QuerySubscriptions_subscriptionTypeCategories_edges as SubscriptionEdge,
-} from '../../graphql/generatedTypes';
+  MySubcriptionsEdge,
+  SubcriptionsTypeCategoriesEdge,
+} from '../../graphql/typings';
 
-const subscriptions: SubscriptionEdge[] = [
+const subscriptions: SubcriptionsTypeCategoriesEdge[] = [
   {
     node: {
       id: '123',
@@ -29,7 +29,7 @@ const subscriptions: SubscriptionEdge[] = [
   },
 ];
 
-const profile: ProfileEdge[] = [
+const profile: MySubcriptionsEdge[] = [
   {
     node: {
       id: 'qwerty',

--- a/src/gdprApi/useDeleteProfile.ts
+++ b/src/gdprApi/useDeleteProfile.ts
@@ -10,8 +10,8 @@ import { loader } from 'graphql.macro';
 import {
   GdprDeleteMyProfileMutation,
   GdprDeleteMyProfileMutationVariables,
-  GdprServiceConnectionsQuery,
 } from '../graphql/generatedTypes';
+import { GdprServiceConnectionsRoot } from '../graphql/typings';
 import { getDeleteScopes } from './utils';
 import useAuthorizationCode from './useAuthorizationCode';
 
@@ -26,7 +26,7 @@ function useDeleteProfile(
     GdprDeleteMyProfileMutationVariables
   >
 ): [() => void, MutationResult<GdprDeleteMyProfileMutation>] {
-  const { data } = useQuery<GdprServiceConnectionsQuery>(SERVICE_CONNECTIONS);
+  const { data } = useQuery<GdprServiceConnectionsRoot>(SERVICE_CONNECTIONS);
   const [deleteProfile, queryResult] = useMutation<
     GdprDeleteMyProfileMutation,
     GdprDeleteMyProfileMutationVariables

--- a/src/gdprApi/useDownloadProfile.ts
+++ b/src/gdprApi/useDownloadProfile.ts
@@ -8,7 +8,7 @@ import {
 import { DocumentNode } from 'graphql';
 import { loader } from 'graphql.macro';
 
-import { GdprServiceConnectionsQuery } from '../graphql/generatedTypes';
+import { GdprServiceConnectionsRoot } from '../graphql/typings';
 import { getQueryScopes } from './utils';
 import useAuthorizationCode from './useAuthorizationCode';
 
@@ -22,7 +22,7 @@ function useDownloadProfile<TQuery>(
   query: DocumentNode,
   options?: LazyQueryHookOptions<TQuery, TVariables>
 ): [() => void, LazyQueryResult<TQuery, TVariables>, boolean] {
-  const { data } = useQuery<GdprServiceConnectionsQuery>(SERVICE_CONNECTIONS);
+  const { data } = useQuery<GdprServiceConnectionsRoot>(SERVICE_CONNECTIONS);
   const [downloadProfile, queryResult] = useLazyQuery<TQuery>(query, {
     ...options,
     onCompleted: (...args) => {

--- a/src/gdprApi/utils.ts
+++ b/src/gdprApi/utils.ts
@@ -1,4 +1,4 @@
-import { GdprServiceConnectionsQuery } from '../graphql/generatedTypes';
+import { GdprServiceConnectionsRoot } from '../graphql/typings';
 
 interface GdprServiceConnectionFields {
   gdprQueryScope: string;
@@ -6,7 +6,7 @@ interface GdprServiceConnectionFields {
 }
 
 const servicesSelector = (
-  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined | null
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined | null
 ): GdprServiceConnectionFields[] => {
   if (
     serviceConnectionsQuery === null ||
@@ -41,7 +41,7 @@ const servicesSelector = (
 };
 
 export function getDeleteScopes(
-  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined
 ): string[] {
   const services = servicesSelector(serviceConnectionsQuery);
 
@@ -49,7 +49,7 @@ export function getDeleteScopes(
 }
 
 export function getQueryScopes(
-  serviceConnectionsQuery: GdprServiceConnectionsQuery | undefined
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined
 ): string[] {
   const services = servicesSelector(serviceConnectionsQuery);
 

--- a/src/graphql/typings.ts
+++ b/src/graphql/typings.ts
@@ -1,0 +1,102 @@
+import {
+  MyProfileQuery,
+  MyProfileQuery_myProfile_verifiedPersonalInformation,
+  MyProfileQuery_myProfile,
+  MyProfileQuery_myProfile_addresses,
+  MyProfileQuery_myProfile_addresses_edges,
+  MyProfileQuery_myProfile_addresses_edges_node,
+  MyProfileQuery_myProfile_emails,
+  MyProfileQuery_myProfile_emails_edges,
+  MyProfileQuery_myProfile_emails_edges_node,
+  MyProfileQuery_myProfile_phones,
+  MyProfileQuery_myProfile_phones_edges,
+  MyProfileQuery_myProfile_phones_edges_node,
+  UpdateMyProfile,
+  UpdateMyProfile_updateMyProfile_profile,
+  ProfileInput as ProfileInputInterface,
+  MyProfileQuery_myProfile_verifiedPersonalInformation_permanentForeignAddress,
+  MyProfileQuery_myProfile_verifiedPersonalInformation_permanentAddress,
+  MyProfileQuery_myProfile_verifiedPersonalInformation_temporaryAddress,
+  ServiceConnectionsQuery,
+  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node,
+  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service,
+  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node,
+  GdprServiceConnectionsQuery,
+  MyProfileQuery_myProfile_primaryAddress,
+  MyProfileQuery_myProfile_primaryEmail,
+  MyProfileQuery_myProfile_primaryPhone,
+  QueryMySubscriptions_myProfile_subscriptions_edges,
+  QuerySubscriptions_subscriptionTypeCategories_edges,
+  QueryMySubscriptions_myProfile_subscriptions_edges_node,
+  QueryMySubscriptions,
+  QuerySubscriptions,
+} from './generatedTypes';
+
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+export type ProfileRoot = MyProfileQuery;
+export type ProfileData = MyProfileQuery_myProfile;
+
+export type UpdateProfileRoot = UpdateMyProfile;
+export type UpdateProfileData = UpdateMyProfile_updateMyProfile_profile;
+
+export type VerifiedPersonalInformation = MyProfileQuery_myProfile_verifiedPersonalInformation;
+
+export type Addresses = MyProfileQuery_myProfile_addresses;
+export type AddressEdge = MyProfileQuery_myProfile_addresses_edges;
+export type AddressNode = MyProfileQuery_myProfile_addresses_edges_node;
+
+export type Emails = MyProfileQuery_myProfile_emails;
+export type EmailEdge = MyProfileQuery_myProfile_emails_edges;
+export type EmailNode = MyProfileQuery_myProfile_emails_edges_node;
+
+export type Phones = MyProfileQuery_myProfile_phones;
+export type PhoneEdge = MyProfileQuery_myProfile_phones_edges;
+export type PhoneNode = MyProfileQuery_myProfile_phones_edges_node;
+
+export type PrimaryAddress = MyProfileQuery_myProfile_primaryAddress;
+export type PrimaryEmail = MyProfileQuery_myProfile_primaryEmail;
+export type PrimaryPhone = MyProfileQuery_myProfile_primaryPhone;
+
+export type InsertableEdge = AddressEdge | EmailEdge | PhoneEdge;
+export type InsertableNode = AddressNode | EmailNode | PhoneNode;
+export type EdgeList = (InsertableEdge | null)[];
+
+export type MutableAddresses = Mutable<Addresses> & {
+  edges: (Mutable<AddressEdge> | null)[];
+};
+
+export type MutableEmails = Mutable<Emails> & {
+  edges: (Mutable<EmailEdge> | null)[];
+};
+export type MutablePhones = Mutable<Phones> & {
+  edges: (Mutable<PhoneEdge> | null)[];
+};
+
+export type ProfileInput = ProfileInputInterface;
+
+export type PermanentForeignAddress = MyProfileQuery_myProfile_verifiedPersonalInformation_permanentForeignAddress;
+export type PermanentAddress = MyProfileQuery_myProfile_verifiedPersonalInformation_permanentAddress;
+export type TemporaryAddress = MyProfileQuery_myProfile_verifiedPersonalInformation_temporaryAddress;
+
+export type ServiceConnectionsRoot = ServiceConnectionsQuery;
+export type ServiceConnectionsNode = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node;
+export type Service = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service;
+// eslint-disable-next-line max-len
+export type ServiceAllowedFieldsNode = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node;
+export type GdprServiceConnectionsRoot = GdprServiceConnectionsQuery;
+
+export type SubscriptionsRoot = QuerySubscriptions;
+export type SubcriptionsTypeCategoriesEdge = QuerySubscriptions_subscriptionTypeCategories_edges;
+
+export type MySubscriptionsRoot = QueryMySubscriptions;
+export type MySubcriptionsEdge = QueryMySubscriptions_myProfile_subscriptions_edges;
+export type MySubcriptionsNode = QueryMySubscriptions_myProfile_subscriptions_edges_node;
+
+export {
+  PhoneType,
+  EmailType,
+  AddressType,
+  ServiceType,
+  Language,
+} from './generatedTypes';

--- a/src/profile/components/createProfile/CreateProfile.tsx
+++ b/src/profile/components/createProfile/CreateProfile.tsx
@@ -13,12 +13,10 @@ import PageHeading from '../../../common/pageHeading/PageHeading';
 import styles from './CreateProfile.module.css';
 import responsive from '../../../common/cssHelpers/responsive.module.css';
 import {
-  CreateMyProfile as CreateMyProfileData,
+  CreateMyProfile as CreateMyProfileRoot,
   CreateMyProfileVariables,
-  EmailType,
-  Language,
-  PhoneType,
 } from '../../../graphql/generatedTypes';
+import { EmailType, Language, PhoneType } from '../../../graphql/typings';
 import ProfileSection from '../../../common/profileSection/ProfileSection';
 import useToast from '../../../toast/useToast';
 
@@ -36,7 +34,7 @@ function CreateProfile({
   const { t } = useTranslation();
   const { trackEvent } = useMatomo();
   const [createProfile, { loading }] = useMutation<
-    CreateMyProfileData,
+    CreateMyProfileRoot,
     CreateMyProfileVariables
   >(CREATE_PROFILE);
   const { createToast } = useToast();

--- a/src/profile/components/createProfileForm/CreateProfileForm.tsx
+++ b/src/profile/components/createProfileForm/CreateProfileForm.tsx
@@ -12,6 +12,7 @@ import Button from '../../../common/button/Button';
 import styles from './CreateProfileForm.module.css';
 import profileConstants from '../../constants/profileConstants';
 import { Language } from '../../../graphql/typings';
+import { getFormFields } from '../../helpers/formProperties';
 import {
   basicDataSchema,
   createProfilePhoneSchema,
@@ -44,7 +45,8 @@ type Props = {
 
 function CreateProfileForm(props: Props): React.ReactElement {
   const { t } = useTranslation();
-
+  const formFields = getFormFields('basic-data');
+  const phoneFields = getFormFields('phones');
   const getFieldError = (
     formikProps: FormikProps<FormikFormValues>,
     fieldName: keyof FormikFormValues,
@@ -87,11 +89,11 @@ function CreateProfileForm(props: Props): React.ReactElement {
               className={styles.formField}
               name="firstName"
               id="firstName"
-              maxLength="255"
+              maxLength={formFields.firstName.max as number}
               as={TextInput}
               invalid={getIsInvalid(formikProps, 'firstName')}
               helperText={getFieldError(formikProps, 'firstName', {
-                max: 255,
+                max: formFields.firstName.max as number,
               })}
               labelText={t('profileForm.firstName')}
             />
@@ -99,7 +101,7 @@ function CreateProfileForm(props: Props): React.ReactElement {
               className={styles.formField}
               name="lastName"
               id="lastName"
-              maxLength="255"
+              maxLength={formFields.lastName.max as number}
               as={TextInput}
               invalid={getIsInvalid(formikProps, 'lastName')}
               helperText={getFieldError(formikProps, 'lastName', { max: 255 })}
@@ -126,12 +128,12 @@ function CreateProfileForm(props: Props): React.ReactElement {
               id="phone"
               as={TextInput}
               type="tel"
-              minLength="6"
-              maxLength="255"
+              minLength={phoneFields.value.min as number}
+              maxLength={phoneFields.value.max as number}
               invalid={getIsInvalid(formikProps, 'phone')}
               helperText={getFieldError(formikProps, 'phone', {
-                min: 6,
-                max: 255,
+                min: phoneFields.value.min as number,
+                max: phoneFields.value.max as number,
               })}
               labelText={t('profileForm.phone')}
             />

--- a/src/profile/components/createProfileForm/CreateProfileForm.tsx
+++ b/src/profile/components/createProfileForm/CreateProfileForm.tsx
@@ -12,17 +12,17 @@ import Button from '../../../common/button/Button';
 import styles from './CreateProfileForm.module.css';
 import profileConstants from '../../constants/profileConstants';
 import { Language } from '../../../graphql/typings';
+import {
+  basicDataSchema,
+  createProfilePhoneSchema,
+} from '../../../common/schemas/schemas';
 
-const maxLengthValidation = 'validation.maxLength';
-const schema = yup.object().shape({
-  firstName: yup.string().max(255, maxLengthValidation),
-  lastName: yup.string().max(255, maxLengthValidation),
-  phone: yup
-    .string()
-    .min(6, 'validation.phoneMin')
-    .max(255, maxLengthValidation),
-  terms: yup.boolean().oneOf([true], 'validation.required'),
-});
+const termsSchema = yup
+  .object()
+  .shape({ terms: yup.boolean().oneOf([true], 'validation.required') });
+const schema = basicDataSchema
+  .concat(termsSchema)
+  .concat(createProfilePhoneSchema);
 
 export type FormValues = {
   firstName: string;

--- a/src/profile/components/createProfileForm/CreateProfileForm.tsx
+++ b/src/profile/components/createProfileForm/CreateProfileForm.tsx
@@ -11,7 +11,7 @@ import FormikDropdown, {
 import Button from '../../../common/button/Button';
 import styles from './CreateProfileForm.module.css';
 import profileConstants from '../../constants/profileConstants';
-import { Language } from '../../../graphql/generatedTypes';
+import { Language } from '../../../graphql/typings';
 
 const maxLengthValidation = 'validation.maxLength';
 const schema = yup.object().shape({

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -10,7 +10,7 @@ import { useMatomo } from '@datapunt/matomo-tracker-react';
 import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
 import Button from '../../../common/button/Button';
-import { ServiceConnectionsQuery as ServiceConnectionsRoot } from '../../../graphql/generatedTypes';
+import { ServiceConnectionsRoot } from '../../../graphql/typings';
 import useToast from '../../../toast/useToast';
 import styles from './deleteProfile.module.css';
 import useDeleteProfile from '../../../gdprApi/useDeleteProfile';

--- a/src/profile/components/editProfile/EditProfile.tsx
+++ b/src/profile/components/editProfile/EditProfile.tsx
@@ -8,15 +8,17 @@ import EditProfileForm, {
   FormValues,
 } from '../editProfileForm/EditProfileForm';
 import {
-  Language,
-  MyProfileQuery,
-  MyProfileQuery_myProfile_primaryEmail as PrimaryEmail,
-  MyProfileQuery_myProfile_primaryAddress as PrimaryAddress,
-  MyProfileQuery_myProfile_primaryPhone as PrimaryPhone,
-  ServiceConnectionsQuery,
   UpdateMyProfile as UpdateMyProfileData,
   UpdateMyProfileVariables,
 } from '../../../graphql/generatedTypes';
+import {
+  ProfileRoot,
+  PrimaryEmail,
+  PrimaryAddress,
+  PrimaryPhone,
+  Language,
+  ServiceConnectionsRoot,
+} from '../../../graphql/typings';
 import ProfileSection from '../../../common/profileSection/ProfileSection';
 import getEmailsFromNode from '../../helpers/getEmailsFromNode';
 import getAddressesFromNode from '../../helpers/getAddressesFromNode';
@@ -31,12 +33,12 @@ const SERVICE_CONNECTIONS = loader(
 
 type Props = {
   setEditing: () => void;
-  profileData: MyProfileQuery;
+  profileData: ProfileRoot;
 };
 
 function EditProfile(props: Props): React.ReactElement {
   const { createToast } = useToast();
-  const { data, refetch } = useQuery<ServiceConnectionsQuery>(
+  const { data, refetch } = useQuery<ServiceConnectionsRoot>(
     SERVICE_CONNECTIONS,
     {
       onError: (error: Error) => {

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -46,7 +46,6 @@ export type FormValues = {
   emails: EmailNode[];
   phones: PhoneNode[];
 };
-
 type Props = {
   setEditing: () => void;
   isSubmitting: boolean;

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -9,10 +9,8 @@ import {
   Formik,
   FormikProps,
 } from 'formik';
-import * as yup from 'yup';
 import countries from 'i18n-iso-countries';
 import classNames from 'classnames';
-import validator from 'validator';
 
 import { formConstants } from '../../constants/formConstants';
 import getLanguageCode from '../../../common/helpers/getLanguageCode';
@@ -35,40 +33,7 @@ import FormikDropdown, {
   OptionType,
   HdsOptionType,
 } from '../../../common/formikDropdown/FormikDropdown';
-
-const maxLengthValidation = 'validation.maxLength';
-
-const addressSchema = yup.object().shape({
-  address: yup.string().max(128, maxLengthValidation),
-  city: yup.string().max(64, maxLengthValidation),
-  postalCode: yup.string().max(5, maxLengthValidation),
-});
-
-const phoneSchema = yup.object().shape({
-  phone: yup
-    .string()
-    .min(6, 'validation.phoneMin')
-    .max(255, maxLengthValidation),
-});
-
-const schema = yup.object().shape({
-  firstName: yup.string().max(255, maxLengthValidation),
-  lastName: yup.string().max(255, maxLengthValidation),
-  language: yup.string(),
-  primaryPhone: phoneSchema,
-  primaryAddress: addressSchema,
-  addresses: yup.array().of(addressSchema),
-  emails: yup.array().of(
-    yup.object().shape({
-      email: yup.mixed().test('isValidEmail', 'validation.email', function() {
-        return this.parent?.email
-          ? validator.isEmail(this.parent?.email)
-          : false;
-      }),
-    })
-  ),
-  phones: yup.array().of(phoneSchema),
-});
+import { basicDataSchema } from '../../../common/schemas/schemas';
 
 export type FormValues = {
   firstName: string;
@@ -185,7 +150,7 @@ function EditProfileForm(props: Props): React.ReactElement {
           phones: [...values.phones, values.primaryPhone],
         });
       }}
-      validationSchema={schema}
+      validationSchema={basicDataSchema}
     >
       {(formikProps: FormikProps<FormValues>) => (
         <Fragment>

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
 
 import { formConstants } from '../../constants/formConstants';
 import getLanguageCode from '../../../common/helpers/getLanguageCode';
-import { getError, getIsInvalid } from '../../helpers/formik';
+import { ErrorRenderer, getError, getIsInvalid } from '../../helpers/formik';
 import styles from './EditProfileForm.module.css';
 import {
   AddressNode,
@@ -75,7 +75,8 @@ function EditProfileForm(props: Props): React.ReactElement {
     fieldName: string,
     options: Record<string, unknown>
   ) => {
-    const renderError = (message: string) => t(message, options);
+    const renderError: ErrorRenderer = errorProps =>
+      t(errorProps.message, options);
 
     return getError<FormValues>(formikProps, fieldName, renderError);
   };

--- a/src/profile/components/editProfileForm/EditProfileForm.tsx
+++ b/src/profile/components/editProfileForm/EditProfileForm.tsx
@@ -19,15 +19,15 @@ import getLanguageCode from '../../../common/helpers/getLanguageCode';
 import { getError, getIsInvalid } from '../../helpers/formik';
 import styles from './EditProfileForm.module.css';
 import {
+  AddressNode,
+  PhoneNode,
+  EmailNode,
+  PrimaryEmail,
+  PrimaryAddress,
+  PrimaryPhone,
   Language,
-  MyProfileQuery_myProfile_addresses_edges_node as Address,
-  MyProfileQuery_myProfile_emails_edges_node as Email,
-  MyProfileQuery_myProfile_phones_edges_node as Phone,
-  MyProfileQuery_myProfile_primaryAddress as PrimaryAddress,
-  MyProfileQuery_myProfile_primaryEmail as PrimaryEmail,
-  MyProfileQuery_myProfile_primaryPhone as PrimaryPhone,
-  ServiceConnectionsQuery,
-} from '../../../graphql/generatedTypes';
+  ServiceConnectionsRoot,
+} from '../../../graphql/typings';
 import profileConstants from '../../constants/profileConstants';
 import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
 import AdditionalInformationActions from './AdditionalInformationActions';
@@ -77,9 +77,9 @@ export type FormValues = {
   primaryAddress: PrimaryAddress;
   primaryPhone: PrimaryPhone;
   profileLanguage: Language;
-  addresses: Address[];
-  emails: Email[];
-  phones: Phone[];
+  addresses: AddressNode[];
+  emails: EmailNode[];
+  phones: PhoneNode[];
 };
 
 type Props = {
@@ -87,7 +87,7 @@ type Props = {
   isSubmitting: boolean;
   profile: FormValues;
   onValues: (values: FormValues) => void;
-  services?: ServiceConnectionsQuery;
+  services?: ServiceConnectionsRoot;
 };
 
 export type Primary = 'primaryEmail' | 'primaryAddress' | 'primaryPhone';
@@ -136,9 +136,11 @@ function EditProfileForm(props: Props): React.ReactElement {
     formProps: FormikProps<FormValues>,
     fieldName: keyof FormValues
   ) => {
-    const previous: (Email | Address | Phone)[] = formProps.getFieldProps(
-      fieldName
-    ).value;
+    const previous: (
+      | EmailNode
+      | AddressNode
+      | PhoneNode
+    )[] = formProps.getFieldProps(fieldName).value;
 
     previous.push(formConstants.EMPTY_VALUES[fieldName]);
 
@@ -327,7 +329,7 @@ function EditProfileForm(props: Props): React.ReactElement {
                 <React.Fragment>
                   <div className={styles.formFields}>
                     {formikProps?.values?.emails.map(
-                      (email: Email | PrimaryEmail, index: number) => (
+                      (email: EmailNode | PrimaryEmail, index: number) => (
                         <div key={index} className={styles.formField}>
                           <Field
                             as={TextInput}
@@ -374,7 +376,7 @@ function EditProfileForm(props: Props): React.ReactElement {
                 <React.Fragment>
                   <div className={styles.formFields}>
                     {formikProps.values.phones.map(
-                      (phone: Phone, index: number) => (
+                      (phone: PhoneNode, index: number) => (
                         <div className={styles.formField} key={index}>
                           <Field
                             className={styles.formField}
@@ -425,7 +427,7 @@ function EditProfileForm(props: Props): React.ReactElement {
               render={(arrayHelpers: FieldArrayRenderProps) => (
                 <React.Fragment>
                   {formikProps?.values?.addresses.map(
-                    (address: Address, index: number) => (
+                    (address: AddressNode, index: number) => (
                       <div key={index} className={styles.multipleAddresses}>
                         <div
                           className={classNames(

--- a/src/profile/components/serviceConnections/ServiceConnections.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnections.tsx
@@ -10,7 +10,7 @@ import Explanation from '../../../common/explanation/Explanation';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
 import CheckedLabel from '../../../common/checkedLabel/CheckedLabel';
 import styles from './ServiceConnections.module.css';
-import { ServiceConnectionsQuery } from '../../../graphql/generatedTypes';
+import { ServiceConnectionsRoot } from '../../../graphql/typings';
 import getServices from '../../helpers/getServices';
 import getAllowedDataFieldsFromService from '../../helpers/getAllowedDataFieldsFromService';
 import useToast from '../../../toast/useToast';
@@ -25,7 +25,7 @@ function ServiceConnections(props: Props): React.ReactElement {
   const { t, i18n } = useTranslation();
   const { createToast } = useToast();
 
-  const { data, loading, refetch } = useQuery<ServiceConnectionsQuery>(
+  const { data, loading, refetch } = useQuery<ServiceConnectionsRoot>(
     SERVICE_CONNECTIONS,
     {
       onError: (error: Error) => {

--- a/src/profile/constants/formConstants.ts
+++ b/src/profile/constants/formConstants.ts
@@ -1,15 +1,15 @@
 import {
+  AddressNode,
+  EmailNode,
+  PhoneNode,
   AddressType,
   EmailType,
-  MyProfileQuery_myProfile_phones_edges_node as Phone,
-  MyProfileQuery_myProfile_addresses_edges_node as Address,
-  MyProfileQuery_myProfile_emails_edges_node as Email,
   PhoneType,
-} from '../../graphql/generatedTypes';
+} from '../../graphql/typings';
 
 type FormConstants = {
   EMPTY_VALUES: {
-    [index: string]: Address | Email | Phone;
+    [index: string]: AddressNode | EmailNode | PhoneNode;
   };
 };
 

--- a/src/profile/helpers/__tests__/updateMutationVariables.test.ts
+++ b/src/profile/helpers/__tests__/updateMutationVariables.test.ts
@@ -50,7 +50,7 @@ const getPhoneAsComparisonObject = (source: Phone): Partial<Phone> => {
 const getEmailAsComparisonObject = (source: Email): Partial<Email> => {
   const clone = cloneAndReplace<Email>(source);
   if (source.email && source.id) {
-    clone.id = source.email;
+    clone.id = source.id;
   }
   return clone;
 };

--- a/src/profile/helpers/formProperties.ts
+++ b/src/profile/helpers/formProperties.ts
@@ -1,0 +1,81 @@
+export type FormField = {
+  required: boolean;
+  min?: number;
+  max?: number;
+  translationKey: string;
+};
+
+type DataType =
+  | 'basic-data'
+  | 'additional-information'
+  | 'addresses'
+  | 'phones'
+  | 'emails';
+
+export type DataTypeFormFields = Record<string, FormField>;
+type FormFieldsByDataType = Record<DataType, Record<string, FormField>>;
+export const formFieldsByDataType: FormFieldsByDataType = {
+  addresses: {
+    address: {
+      required: true,
+      max: 128,
+      translationKey: 'profileForm.address',
+    },
+    postalCode: {
+      required: true,
+      max: 5,
+      translationKey: 'profileForm.postalCode',
+    },
+    city: {
+      required: true,
+      max: 64,
+      translationKey: 'profileForm.city',
+    },
+    country: {
+      required: false,
+      translationKey: 'profileForm.country',
+    },
+  },
+  'basic-data': {
+    firstName: {
+      required: true,
+      max: 128,
+      translationKey: 'profileForm.firstName',
+    },
+    nickname: {
+      required: false,
+      max: 64,
+      translationKey: 'profileForm.nickname',
+    },
+    lastName: {
+      required: true,
+      max: 255,
+      translationKey: 'profileForm.lastName',
+    },
+  },
+  phones: {
+    value: {
+      required: true,
+      min: 6,
+      max: 255,
+      translationKey: 'profileForm.phone',
+    },
+  },
+  emails: {
+    value: {
+      required: true,
+      min: 1,
+      max: 255,
+      translationKey: 'profileForm.email',
+    },
+  },
+  'additional-information': {
+    profileLanguage: {
+      required: true,
+      translationKey: 'profileForm.profileLanguage',
+    },
+  },
+};
+
+export const getFormFields = (dataType: DataType): DataTypeFormFields =>
+  formFieldsByDataType[dataType];

--- a/src/profile/helpers/getAddress.ts
+++ b/src/profile/helpers/getAddress.ts
@@ -1,15 +1,10 @@
-import countries from 'i18n-iso-countries';
+import { ProfileRoot } from '../../graphql/typings';
+import getCountry from './getCountry';
 
-import getLanguageCode from '../../common/helpers/getLanguageCode';
-import { MyProfileQuery } from '../../graphql/generatedTypes';
-
-export default function getAddress(data: MyProfileQuery, lang: string): string {
+export default function getAddress(data: ProfileRoot, lang: string): string {
   if (data.myProfile?.primaryAddress) {
     const address = data.myProfile.primaryAddress;
-    const country = countries.getName(
-      address.countryCode || 'FI',
-      getLanguageCode(lang)
-    );
+    const country = getCountry(address.countryCode, lang);
 
     return [address.address, address.city, address.postalCode, country]
       .filter(addressPart => addressPart)

--- a/src/profile/helpers/getAddressesFromNode.ts
+++ b/src/profile/helpers/getAddressesFromNode.ts
@@ -1,9 +1,6 @@
-import {
-  MyProfileQuery,
-  MyProfileQuery_myProfile_addresses_edges_node as Address,
-} from '../../graphql/generatedTypes';
+import { ProfileRoot, AddressNode } from '../../graphql/typings';
 
-const getAddressesFromNode = (data?: MyProfileQuery): Address[] => {
+const getAddressesFromNode = (data?: ProfileRoot): AddressNode[] => {
   const edges = data?.myProfile?.addresses?.edges || [];
   return edges
     .filter(edge => !edge?.node?.primary)
@@ -18,7 +15,7 @@ const getAddressesFromNode = (data?: MyProfileQuery): Address[] => {
           countryCode: edge?.node?.countryCode,
           addressType: edge?.node?.addressType,
           __typename: 'AddressNode',
-        } as Address)
+        } as AddressNode)
     );
 };
 

--- a/src/profile/helpers/getAllowedDataFieldsFromService.ts
+++ b/src/profile/helpers/getAllowedDataFieldsFromService.ts
@@ -1,11 +1,8 @@
-import {
-  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service as Service,
-  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node as Node,
-} from '../../graphql/generatedTypes';
+import { Service, ServiceAllowedFieldsNode } from '../../graphql/typings';
 
 export default function getAllowedDataFieldsFromService(
   service: Service
-): Node[] {
+): ServiceAllowedFieldsNode[] {
   return service.allowedDataFields.edges
     .map(edge => {
       if (edge?.node) {
@@ -13,5 +10,5 @@ export default function getAllowedDataFieldsFromService(
       }
       return false;
     })
-    .filter((node): node is Node => Boolean(node));
+    .filter((node): node is ServiceAllowedFieldsNode => Boolean(node));
 }

--- a/src/profile/helpers/getCountry.ts
+++ b/src/profile/helpers/getCountry.ts
@@ -1,7 +1,7 @@
 import countries from 'i18n-iso-countries';
 
 import getLanguageCode from '../../common/helpers/getLanguageCode';
-import { MyProfileQuery_myProfile_addresses_edges_node as AddressNode } from '../../graphql/generatedTypes';
+import { AddressNode } from '../../graphql/typings';
 
 export default function getCountry(
   countryCode: AddressNode['countryCode'] | undefined,

--- a/src/profile/helpers/getEmailsFromNode.ts
+++ b/src/profile/helpers/getEmailsFromNode.ts
@@ -1,9 +1,6 @@
-import {
-  MyProfileQuery,
-  MyProfileQuery_myProfile_emails_edges_node as Email,
-} from '../../graphql/generatedTypes';
+import { ProfileRoot, EmailNode } from '../../graphql/typings';
 
-const getEmailsFromNode = (data?: MyProfileQuery): Email[] => {
+const getEmailsFromNode = (data?: ProfileRoot): EmailNode[] => {
   const edges = data?.myProfile?.emails?.edges || [];
   return edges
     .filter(edge => !edge?.node?.primary)
@@ -15,7 +12,7 @@ const getEmailsFromNode = (data?: MyProfileQuery): Email[] => {
           primary: edge?.node?.primary,
           emailType: edge?.node?.emailType,
           __typename: 'EmailNode',
-        } as Email)
+        } as EmailNode)
     );
 };
 

--- a/src/profile/helpers/getName.ts
+++ b/src/profile/helpers/getName.ts
@@ -1,6 +1,6 @@
-import { MyProfileQuery } from '../../graphql/generatedTypes';
+import { ProfileRoot } from '../../graphql/typings';
 
-export default function getName(data: MyProfileQuery): string {
+export default function getName(data: ProfileRoot): string {
   if (data.myProfile) {
     const profile = data.myProfile;
     return `${profile.firstName ?? ''} ${profile.lastName ?? ''}`.trim();

--- a/src/profile/helpers/getNicknameOrName.ts
+++ b/src/profile/helpers/getNicknameOrName.ts
@@ -1,6 +1,6 @@
-import { MyProfileQuery } from '../../graphql/generatedTypes';
+import { ProfileRoot } from '../../graphql/typings';
 
-export default function getNicknameOrName(data?: MyProfileQuery): string {
+export default function getNicknameOrName(data?: ProfileRoot): string {
   if (data && data.myProfile) {
     const myProfile = data.myProfile;
     if (myProfile.nickname) {

--- a/src/profile/helpers/getPhonesFromNode.ts
+++ b/src/profile/helpers/getPhonesFromNode.ts
@@ -1,9 +1,6 @@
-import {
-  MyProfileQuery,
-  MyProfileQuery_myProfile_phones_edges_node as Phone,
-} from '../../graphql/generatedTypes';
+import { ProfileRoot, PhoneNode } from '../../graphql/typings';
 
-const getPhonesFromNode = (data?: MyProfileQuery): Phone[] => {
+const getPhonesFromNode = (data?: ProfileRoot): PhoneNode[] => {
   const edges = data?.myProfile?.phones?.edges || [];
   return edges
     .filter(edge => !edge?.node?.primary)
@@ -15,7 +12,7 @@ const getPhonesFromNode = (data?: MyProfileQuery): Phone[] => {
           phone: edge?.node?.phone,
           phoneType: edge?.node?.phoneType,
           __typename: 'PhoneNode',
-        } as Phone)
+        } as PhoneNode)
     );
 };
 

--- a/src/profile/helpers/getServices.ts
+++ b/src/profile/helpers/getServices.ts
@@ -1,10 +1,10 @@
 import {
-  ServiceConnectionsQuery,
-  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service as Service,
+  ServiceConnectionsRoot,
+  Service,
   ServiceType,
-} from '../../graphql/generatedTypes';
+} from '../../graphql/typings';
 
-export default function getServices(data?: ServiceConnectionsQuery): Service[] {
+export default function getServices(data?: ServiceConnectionsRoot): Service[] {
   if (data?.myProfile?.serviceConnections) {
     return data.myProfile.serviceConnections.edges
       .map(edge => {

--- a/src/profile/helpers/getVerifiedPersonalInformation.ts
+++ b/src/profile/helpers/getVerifiedPersonalInformation.ts
@@ -1,10 +1,10 @@
 import {
-  MyProfileQuery,
-  MyProfileQuery_myProfile_verifiedPersonalInformation as VerifiedPersonalInformation,
-} from '../../graphql/generatedTypes';
+  ProfileRoot,
+  VerifiedPersonalInformation,
+} from '../../graphql/typings';
 
 function getVerifiedPersonalInformation(
-  myProfileQuery: MyProfileQuery | undefined
+  myProfileQuery: ProfileRoot | undefined
 ): VerifiedPersonalInformation | null | undefined {
   return (
     myProfileQuery &&

--- a/src/profile/helpers/updateMutationVariables.ts
+++ b/src/profile/helpers/updateMutationVariables.ts
@@ -1,9 +1,6 @@
 import { isEqual } from 'lodash';
 
-import {
-  FormValues,
-  Primary,
-} from '../components/editProfileForm/EditProfileForm';
+import { FormValues } from '../components/editProfileForm/EditProfileForm';
 import {
   CreateAddressInput,
   CreateEmailInput,
@@ -26,6 +23,8 @@ import getPhonesFromNode from './getPhonesFromNode';
 import getEmailsFromNode from './getEmailsFromNode';
 import getAddressesFromNode from './getAddressesFromNode';
 import { formConstants } from '../constants/formConstants';
+
+type Primary = 'primaryEmail' | 'primaryAddress' | 'primaryPhone';
 
 type EmailInputs = {
   addEmails: CreateEmailInput[] | null[];
@@ -83,8 +82,8 @@ const getObjectFields = (value: AddressNode | EmailNode | PhoneNode) => {
   switch (value.__typename) {
     case 'EmailNode': {
       return {
+        id: value.id,
         email: value.email,
-        id: value.email,
         emailType: value.emailType || EmailType.OTHER,
         primary: value.primary,
       };

--- a/src/profile/helpers/updateMutationVariables.ts
+++ b/src/profile/helpers/updateMutationVariables.ts
@@ -5,21 +5,23 @@ import {
   Primary,
 } from '../components/editProfileForm/EditProfileForm';
 import {
-  AddressType,
   CreateAddressInput,
   CreateEmailInput,
   CreatePhoneInput,
-  EmailType,
-  MyProfileQuery,
-  MyProfileQuery_myProfile_addresses_edges_node as Address,
-  MyProfileQuery_myProfile_emails_edges_node as Email,
-  MyProfileQuery_myProfile_phones_edges_node as Phone,
-  PhoneType,
   UpdateAddressInput,
   UpdateEmailInput,
   UpdateMyProfileVariables,
   UpdatePhoneInput,
 } from '../../graphql/generatedTypes';
+import {
+  AddressType,
+  EmailType,
+  PhoneType,
+  ProfileRoot,
+  AddressNode,
+  EmailNode,
+  PhoneNode,
+} from '../../graphql/typings';
 import getPhonesFromNode from './getPhonesFromNode';
 import getEmailsFromNode from './getEmailsFromNode';
 import getAddressesFromNode from './getAddressesFromNode';
@@ -43,7 +45,7 @@ type PhoneInputs = {
   removePhones?: (string | null)[] | null;
 };
 
-const getPrimaryValue = (primary: Primary, profile?: MyProfileQuery) => {
+const getPrimaryValue = (primary: Primary, profile?: ProfileRoot) => {
   const primaryValue = profile?.myProfile && profile.myProfile[primary];
   return primaryValue || { id: '' };
 };
@@ -64,7 +66,7 @@ const getEmptyObject = (primary: Primary) => {
   }
 };
 
-const getNodesFromProfile = (primary: Primary, profile?: MyProfileQuery) => {
+const getNodesFromProfile = (primary: Primary, profile?: ProfileRoot) => {
   switch (primary) {
     case 'primaryPhone':
       return getPhonesFromNode(profile);
@@ -77,7 +79,7 @@ const getNodesFromProfile = (primary: Primary, profile?: MyProfileQuery) => {
   }
 };
 
-const getObjectFields = (value: Address | Email | Phone) => {
+const getObjectFields = (value: AddressNode | EmailNode | PhoneNode) => {
   switch (value.__typename) {
     case 'EmailNode': {
       return {
@@ -111,10 +113,10 @@ const getObjectFields = (value: Address | Email | Phone) => {
   }
 };
 
-function formMutationArrays<T extends Address | Email | Phone>(
+function formMutationArrays<T extends AddressNode | EmailNode | PhoneNode>(
   formValueArray: T[],
   primary: Primary,
-  profile?: MyProfileQuery
+  profile?: ProfileRoot
 ): Record<string, unknown> {
   const profileValues = [
     getPrimaryValue(primary, profile),
@@ -195,20 +197,28 @@ function formMutationArrays<T extends Address | Email | Phone>(
 
 const updateMutationVariables = (
   formValues: FormValues,
-  profile?: MyProfileQuery
+  profile?: ProfileRoot
 ): UpdateMyProfileVariables => ({
   input: {
     profile: {
       firstName: formValues.firstName,
       lastName: formValues.lastName,
       language: formValues.profileLanguage,
-      ...formMutationArrays<Address>(
+      ...formMutationArrays<AddressNode>(
         formValues.addresses,
         'primaryAddress',
         profile
       ),
-      ...formMutationArrays<Phone>(formValues.phones, 'primaryPhone', profile),
-      ...formMutationArrays<Email>(formValues.emails, 'primaryEmail', profile),
+      ...formMutationArrays<PhoneNode>(
+        formValues.phones,
+        'primaryPhone',
+        profile
+      ),
+      ...formMutationArrays<EmailNode>(
+        formValues.emails,
+        'primaryEmail',
+        profile
+      ),
     },
   },
 });

--- a/src/subscriptions/components/subsciptions/Subscriptions.tsx
+++ b/src/subscriptions/components/subsciptions/Subscriptions.tsx
@@ -11,14 +11,16 @@ import Loading from '../../../common/loading/Loading';
 import responsive from '../../../common/cssHelpers/responsive.module.css';
 import styles from './Subscriptions.module.css';
 import {
-  QuerySubscriptions,
-  QueryMySubscriptions,
-  UpdateMyProfile,
   UpdateMyProfileVariables,
   SubscriptionInputType,
 } from '../../../graphql/generatedTypes';
 import getSubscriptionsData from '../../helpers/getSubscriptionsData';
 import useToast from '../../../toast/useToast';
+import {
+  UpdateProfileRoot,
+  SubscriptionsRoot,
+  MySubscriptionsRoot,
+} from '../../../graphql/typings';
 
 const QUERY_SUBSCRIPTIONS = loader('../../graphql/QuerySubscriptions.graphql');
 const QUERY_MY_SUBSCRIPTIONS = loader(
@@ -49,7 +51,7 @@ function Subscriptions(): React.ReactElement {
   const { t, i18n } = useTranslation();
   const { createToast } = useToast();
 
-  const { data, loading, refetch } = useQuery<QuerySubscriptions>(
+  const { data, loading, refetch } = useQuery<SubscriptionsRoot>(
     QUERY_SUBSCRIPTIONS,
     {
       onError: (error: Error) => {
@@ -60,7 +62,7 @@ function Subscriptions(): React.ReactElement {
   );
 
   const { data: profileData, loading: profileLoading } = useQuery<
-    QueryMySubscriptions
+    MySubscriptionsRoot
   >(QUERY_MY_SUBSCRIPTIONS, {
     onError: (error: Error) => {
       Sentry.captureException(error);
@@ -69,7 +71,7 @@ function Subscriptions(): React.ReactElement {
   });
 
   const [updateSubscriptions] = useMutation<
-    UpdateMyProfile,
+    UpdateProfileRoot,
     UpdateMyProfileVariables
   >(UPDATE_PROFILE, {
     refetchQueries: ['QueryMySubscriptions'],

--- a/src/subscriptions/components/subsciptions/__tests__/Subscription.test.tsx
+++ b/src/subscriptions/components/subsciptions/__tests__/Subscription.test.tsx
@@ -5,11 +5,11 @@ import { loader } from 'graphql.macro';
 
 import Subscriptions from '../Subscriptions';
 import {
-  QuerySubscriptions,
-  QueryMySubscriptions,
-  QueryMySubscriptions_myProfile_subscriptions_edges as ProfileEdges,
-  QuerySubscriptions_subscriptionTypeCategories_edges as SubscriptionEdges,
-} from '../../../../graphql/generatedTypes';
+  SubscriptionsRoot,
+  MySubscriptionsRoot,
+  MySubcriptionsEdge,
+  SubcriptionsTypeCategoriesEdge,
+} from '../../../../graphql/typings';
 import {
   subscriptions,
   profile,
@@ -24,8 +24,8 @@ const QUERY_MY_SUBSCRIPTIONS = loader(
 );
 
 const getMocks = (
-  subscriptionEdges: SubscriptionEdges[],
-  profileEdges: ProfileEdges[]
+  subscriptionEdges: SubcriptionsTypeCategoriesEdge[],
+  profileEdges: MySubcriptionsEdge[]
 ) => [
   {
     request: {
@@ -38,7 +38,7 @@ const getMocks = (
           edges: [...subscriptionEdges],
           __typename: 'SubscriptionTypeCategoryNodeConnection',
         },
-      } as QuerySubscriptions,
+      } as SubscriptionsRoot,
     },
   },
   {
@@ -56,7 +56,7 @@ const getMocks = (
           id: '123',
           __typename: 'ProfileNode',
         },
-      } as QueryMySubscriptions,
+      } as MySubscriptionsRoot,
     },
   },
 ];

--- a/src/subscriptions/helpers/getSubscriptionsData.ts
+++ b/src/subscriptions/helpers/getSubscriptionsData.ts
@@ -1,7 +1,4 @@
-import {
-  QueryMySubscriptions,
-  QuerySubscriptions,
-} from '../../graphql/generatedTypes';
+import { MySubscriptionsRoot, SubscriptionsRoot } from '../../graphql/typings';
 
 type SubscriptionsData = {
   id: string | undefined;
@@ -10,8 +7,8 @@ type SubscriptionsData = {
   options: (Record<string, unknown> & { enabled: boolean })[] | undefined;
 };
 export default function getSubscriptionsData(
-  data?: QuerySubscriptions,
-  profileData?: QueryMySubscriptions
+  data?: SubscriptionsRoot,
+  profileData?: MySubscriptionsRoot
 ): SubscriptionsData[] {
   if (
     !data?.subscriptionTypeCategories ||


### PR DESCRIPTION
Centralise typings, schemas and form properties. Also form validation and creating error messages is now simpler and does not require to define data multiple times in different places.

