### PR TITLE
HP-626: Added expiration check to getUser

### DIFF
--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -56,8 +56,11 @@ function useProfile(): ProfileState {
           if (ignore) {
             return;
           }
-
-          setProfile(user ? ((user.profile as unknown) as Profile) : null);
+          setProfile(
+            user && user.expired === false
+              ? ((user.profile as unknown) as Profile)
+              : null
+          );
         })
         .catch(() => {
           if (ignore) {

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -40,7 +40,7 @@ function Profile(): React.ReactElement {
     authService
       .getUser()
       .then(user => {
-        if (!user) {
+        if (!user || user.expired) {
           return history.push('/login');
         }
 


### PR DESCRIPTION
When user has left session open without a logout and returns, the userManager gets user from the localStorage without checking if the user has expired. After that fetching user's profile will return an error. Fetching profile is useless and now avoided by checking also user.expired instead of just existence of user.