### PR TITLE
HP-318 step 6: add and edit emails, phones and addresses

### DIFF
--- a/src/common/test/ProfileContextAsHTML.tsx
+++ b/src/common/test/ProfileContextAsHTML.tsx
@@ -1,0 +1,36 @@
+import React, { useContext, useEffect, useRef, useState } from 'react';
+
+import { ProfileContext } from '../../profile/context/ProfileContext';
+import { getErrorMessage } from './testingLibraryTools';
+
+function ProfileContextAsHTML(): React.ReactElement {
+  const { data, isComplete, error, fetch, refetch } = useContext(
+    ProfileContext
+  );
+  const [updateTime, setUpdateTime] = useState<number>(-1);
+  const [dataUpdateTime, setDataUpdateTime] = useState<number>(-1);
+  const errorMessage = getErrorMessage(error);
+  const dataTracker = useRef<string>(JSON.stringify(data || {}));
+  useEffect(() => {
+    const dataAsString = JSON.stringify(data || {});
+    if (dataAsString !== dataTracker.current) {
+      dataTracker.current = dataAsString;
+      setDataUpdateTime(Date.now());
+    }
+    setUpdateTime(Date.now());
+  }, [data, errorMessage, isComplete]);
+  const onButtonClick = () => (isComplete ? refetch() : fetch());
+  return (
+    <div data-testid="context-as-html">
+      <div data-testid="context-as-html-isComplete">{String(isComplete)}</div>
+      <div data-testid="context-as-html-error">{errorMessage}</div>
+      <div data-testid="context-as-html-updateTime">{updateTime}</div>
+      <div data-testid="context-as-html-dataUpdateTime">{dataUpdateTime}</div>
+      <button onClick={onButtonClick} data-testid="context-as-html-fetch">
+        Fetch
+      </button>
+    </div>
+  );
+}
+
+export default ProfileContextAsHTML;

--- a/src/common/test/ProfileContextFetcher.tsx
+++ b/src/common/test/ProfileContextFetcher.tsx
@@ -1,0 +1,27 @@
+import React, { useContext, useState } from 'react';
+
+import { ProfileContext } from '../../profile/context/ProfileContext';
+
+function ProfileContextFetcher({
+  children,
+}: {
+  children: React.ReactElement | React.ReactNodeArray;
+}): React.ReactElement {
+  const [fetchStarted, setFetchStarted] = useState(false);
+  const { data, fetch } = useContext(ProfileContext);
+  if (!fetchStarted) {
+    fetch();
+    setFetchStarted(true);
+  }
+
+  if (!data) {
+    return <div data-testid="no-data-fetched"></div>;
+  }
+  return (
+    <div data-testid="test-elements">
+      <div data-testid="component">{children}</div>
+    </div>
+  );
+}
+
+export default ProfileContextFetcher;

--- a/src/common/test/RenderChildrenWhenDataIsComplete.tsx
+++ b/src/common/test/RenderChildrenWhenDataIsComplete.tsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+
+import { ProfileContext } from '../../profile/context/ProfileContext';
+
+function RenderChildrenWhenDataIsComplete({
+  children,
+}: {
+  children: React.ReactElement | React.ReactNodeArray;
+}): React.ReactElement | null {
+  const { isComplete } = useContext(ProfileContext);
+  if (!isComplete) {
+    return null;
+  }
+  return <div data-testid="component-wrapper">{children}</div>;
+}
+
+export default RenderChildrenWhenDataIsComplete;

--- a/src/common/test/exposeHooksForTesting.tsx
+++ b/src/common/test/exposeHooksForTesting.tsx
@@ -1,0 +1,145 @@
+import React, { useContext } from 'react';
+import { renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import _ from 'lodash';
+
+import {
+  ProfileContext,
+  ProfileContextData,
+  Provider as ProfileProvider,
+} from '../../profile/context/ProfileContext';
+import {
+  MockApolloClientProvider,
+  ResponseProvider,
+} from './MockApolloClientProvider';
+import {
+  MutationReturnType,
+  useProfileMutations,
+} from '../../profile/hooks/useProfileMutations';
+import { EditDataType } from '../../profile/helpers/editData';
+import ProfileContextFetcher from './ProfileContextFetcher';
+import { getErrorMessage } from './testingLibraryTools';
+
+export type ElementSelector = {
+  testId?: string;
+  text?: string;
+  valueSelector?: string;
+  id?: string;
+  querySelector?: string;
+  label?: string;
+};
+
+export type RenderHookResultsChildren = {
+  children: React.ReactNodeArray;
+};
+
+export type WaitForElementAndValueProps = {
+  selector: ElementSelector;
+  value: string;
+};
+
+export const exposeProfileContext = (
+  responseProvider: ResponseProvider
+): RenderHookResult<RenderHookResultsChildren, ProfileContextData> & {
+  waitForDataChange: () => Promise<ProfileContextData>;
+  waitForUpdate: () => Promise<ProfileContextData>;
+  waitForErrorChange: () => Promise<ProfileContextData>;
+} => {
+  const wrapper = ({ children }: RenderHookResultsChildren) => (
+    <MockApolloClientProvider responseProvider={responseProvider}>
+      <ProfileProvider>{children}</ProfileProvider>
+    </MockApolloClientProvider>
+  );
+  const createUpdateProps = (
+    contextData: ProfileContextData
+  ): Record<string, unknown> => ({
+    loading: contextData.loading,
+    isComplete: contextData.isComplete,
+  });
+  const lastError = {
+    message: '',
+  };
+  let lastUpdate: Record<string, unknown> = {};
+  let lastData: string | undefined;
+  let updateChangeResolver:
+    | ((newContextData: ProfileContextData) => void)
+    | undefined;
+  let dataChangeResolver:
+    | ((newContextData: ProfileContextData) => void)
+    | undefined;
+  let errorChangeResolver:
+    | ((newContextData: ProfileContextData) => void)
+    | undefined;
+
+  //testing-library has waitForNextUpdate but it does not work properly!
+  const waitForUpdate = () =>
+    new Promise<ProfileContextData>(resolve => {
+      updateChangeResolver = resolve;
+    });
+  const waitForDataChange = () =>
+    new Promise<ProfileContextData>(resolve => {
+      dataChangeResolver = resolve;
+    });
+  const waitForErrorChange = () =>
+    new Promise<ProfileContextData>(resolve => {
+      errorChangeResolver = resolve;
+    });
+
+  const trackUpdateChanges = (newContext: ProfileContextData): void => {
+    const updateProps = createUpdateProps(newContext);
+    if (!_.isEqual(lastUpdate, updateProps)) {
+      lastUpdate = updateProps;
+      updateChangeResolver && updateChangeResolver(newContext);
+    }
+  };
+
+  const trackDataChanges = (newContext: ProfileContextData): void => {
+    const newData = JSON.stringify(newContext.data || {});
+    if (newData !== lastData) {
+      dataChangeResolver && dataChangeResolver(newContext);
+      dataChangeResolver = undefined;
+      lastData = newData;
+    }
+  };
+
+  const trackErrorChanges = (newContext: ProfileContextData): void => {
+    const errorMessage = getErrorMessage(newContext.error);
+    if (errorMessage !== lastError.message) {
+      lastError.message = errorMessage;
+      errorChangeResolver && errorChangeResolver(newContext);
+    }
+  };
+
+  const tracker = (newContextData: ProfileContextData) => {
+    trackDataChanges(newContextData);
+    trackUpdateChanges(newContextData);
+    trackErrorChanges(newContextData);
+    return newContextData;
+  };
+  const callback = () =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    tracker(useContext(ProfileContext));
+
+  const result = renderHook(callback, { wrapper });
+  return { ...result, waitForDataChange, waitForUpdate, waitForErrorChange };
+};
+
+export const exposeProfileMutationsHook = (
+  responseProvider: ResponseProvider,
+  dataType: EditDataType
+): RenderHookResult<RenderHookResultsChildren, MutationReturnType> => {
+  const wrapper = ({ children }: RenderHookResultsChildren) => (
+    <MockApolloClientProvider responseProvider={responseProvider}>
+      <ProfileProvider>
+        <ProfileContextFetcher>{children}</ProfileContextFetcher>
+      </ProfileProvider>
+    </MockApolloClientProvider>
+  );
+
+  const callback = () =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useProfileMutations({
+      dataType,
+    });
+
+  return renderHook(callback, { wrapper });
+};

--- a/src/common/test/renderComponentTestDOM.tsx
+++ b/src/common/test/renderComponentTestDOM.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+import { Provider as ProfileProvider } from '../../profile/context/ProfileContext';
+import {
+  MockApolloClientProvider,
+  ResponseProvider,
+} from './MockApolloClientProvider';
+import ToastProvider from '../../toast/__mocks__/ToastProvider';
+import ProfileContextAsHTML from './ProfileContextAsHTML';
+
+function renderComponentTestDOM(
+  responseProvider: ResponseProvider,
+  children: React.ReactElement
+): RenderResult {
+  return render(
+    <BrowserRouter>
+      <MockApolloClientProvider responseProvider={responseProvider}>
+        <ProfileProvider>
+          <ToastProvider>{children}</ToastProvider>
+          <ProfileContextAsHTML />
+        </ProfileProvider>
+      </MockApolloClientProvider>
+    </BrowserRouter>
+  );
+}
+
+export default renderComponentTestDOM;

--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -1,37 +1,19 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React from 'react';
 import {
   fireEvent,
-  render,
   RenderResult,
   waitFor,
   cleanup,
 } from '@testing-library/react';
 import {
-  renderHook,
   RenderHookResult,
   cleanup as cleanupHooks,
 } from '@testing-library/react-hooks';
-import _ from 'lodash';
 import { GraphQLError } from 'graphql';
-import { BrowserRouter } from 'react-router-dom';
 
-import {
-  ProfileContext,
-  ProfileContextData,
-  Provider as ProfileProvider,
-} from '../../profile/context/ProfileContext';
-import {
-  MockApolloClientProvider,
-  resetApolloMocks,
-  ResponseProvider,
-} from './MockApolloClientProvider';
+import { resetApolloMocks, ResponseProvider } from './MockApolloClientProvider';
 import { AnyObject } from '../../graphql/typings';
-import ToastProvider from '../../toast/__mocks__/ToastProvider';
-import {
-  MutationReturnType,
-  useProfileMutations,
-} from '../../profile/hooks/useProfileMutations';
-import { EditDataType } from '../../profile/helpers/editData';
+import renderComponentTestDOM from './renderComponentTestDOM';
 
 export type ElementSelector = {
   testId?: string;
@@ -109,17 +91,7 @@ export const renderComponentWithMocksAndContexts = async (
   responseProvider: ResponseProvider,
   children: React.ReactElement
 ): Promise<TestTools> => {
-  const renderResult = render(
-    <BrowserRouter>
-      <MockApolloClientProvider responseProvider={responseProvider}>
-        <ProfileProvider>
-          <ToastProvider>{children}</ToastProvider>
-          <ProfileContextAsHTML />
-        </ProfileProvider>
-      </MockApolloClientProvider>
-    </BrowserRouter>
-  );
-
+  const renderResult = renderComponentTestDOM(responseProvider, children);
   const getLastTime = (targetElement: string): number => {
     const lastUpdateElement = renderResult.getByTestId(
       `context-as-html-${targetElement}`
@@ -291,93 +263,7 @@ export const renderComponentWithMocksAndContexts = async (
   });
 };
 
-export const exposeProfileContext = (
-  responseProvider: ResponseProvider
-): RenderHookResult<RenderHookResultsChildren, ProfileContextData> & {
-  waitForDataChange: () => Promise<ProfileContextData>;
-  waitForUpdate: () => Promise<ProfileContextData>;
-  waitForErrorChange: () => Promise<ProfileContextData>;
-} => {
-  const wrapper = ({ children }: RenderHookResultsChildren) => (
-    <MockApolloClientProvider responseProvider={responseProvider}>
-      <ProfileProvider>{children}</ProfileProvider>
-    </MockApolloClientProvider>
-  );
-  const createUpdateProps = (
-    contextData: ProfileContextData
-  ): Record<string, unknown> => ({
-    loading: contextData.loading,
-    isComplete: contextData.isComplete,
-  });
-  const lastError = {
-    message: '',
-  };
-  let lastUpdate: Record<string, unknown> = {};
-  let lastData: string | undefined;
-  let updateChangeResolver:
-    | ((newContextData: ProfileContextData) => void)
-    | undefined;
-  let dataChangeResolver:
-    | ((newContextData: ProfileContextData) => void)
-    | undefined;
-  let errorChangeResolver:
-    | ((newContextData: ProfileContextData) => void)
-    | undefined;
-
-  //testing-library has waitForNextUpdate but it does not work properly!
-  const waitForUpdate = () =>
-    new Promise<ProfileContextData>(resolve => {
-      updateChangeResolver = resolve;
-    });
-  const waitForDataChange = () =>
-    new Promise<ProfileContextData>(resolve => {
-      dataChangeResolver = resolve;
-    });
-  const waitForErrorChange = () =>
-    new Promise<ProfileContextData>(resolve => {
-      errorChangeResolver = resolve;
-    });
-
-  const trackUpdateChanges = (newContext: ProfileContextData): void => {
-    const updateProps = createUpdateProps(newContext);
-    if (!_.isEqual(lastUpdate, updateProps)) {
-      lastUpdate = updateProps;
-      updateChangeResolver && updateChangeResolver(newContext);
-    }
-  };
-
-  const trackDataChanges = (newContext: ProfileContextData): void => {
-    const newData = JSON.stringify(newContext.data || {});
-    if (newData !== lastData) {
-      dataChangeResolver && dataChangeResolver(newContext);
-      dataChangeResolver = undefined;
-      lastData = newData;
-    }
-  };
-
-  const trackErrorChanges = (newContext: ProfileContextData): void => {
-    const errorMessage = getErrorMessage(newContext.error);
-    if (errorMessage !== lastError.message) {
-      lastError.message = errorMessage;
-      errorChangeResolver && errorChangeResolver(newContext);
-    }
-  };
-
-  const tracker = (newContextData: ProfileContextData) => {
-    trackDataChanges(newContextData);
-    trackUpdateChanges(newContextData);
-    trackErrorChanges(newContextData);
-    return newContextData;
-  };
-  const callback = () =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    tracker(useContext(ProfileContext));
-
-  const result = renderHook(callback, { wrapper });
-  return { ...result, waitForDataChange, waitForUpdate, waitForErrorChange };
-};
-
-export const createResultPropertyTracker = <T,>({
+export const createResultPropertyTracker = <T>({
   renderHookResult,
   valuePicker,
 }: {
@@ -402,80 +288,7 @@ export const createResultPropertyTracker = <T,>({
   return [waitForChange];
 };
 
-export const exposeProfileMutationsHook = (
-  responseProvider: ResponseProvider,
-  dataType: EditDataType
-): RenderHookResult<RenderHookResultsChildren, MutationReturnType> => {
-  const wrapper = ({ children }: RenderHookResultsChildren) => (
-    <MockApolloClientProvider responseProvider={responseProvider}>
-      <ProfileProvider>
-        <ProfileContextFetcher>{children}</ProfileContextFetcher>
-      </ProfileProvider>
-    </MockApolloClientProvider>
-  );
-
-  const callback = () =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useProfileMutations({
-      dataType,
-    });
-
-  return renderHook(callback, { wrapper });
-};
-
-export const ProfileContextFetcher = ({
-  children,
-}: {
-  children: React.ReactElement | React.ReactNodeArray;
-}): React.ReactElement => {
-  const [fetchStarted, setFetchStarted] = useState(false);
-  const { data, fetch } = useContext(ProfileContext);
-  if (!fetchStarted) {
-    fetch();
-    setFetchStarted(true);
-  }
-
-  if (!data) {
-    return <div data-testid="no-data-fetched"></div>;
-  }
-  return (
-    <div data-testid="test-elements">
-      <div data-testid="component">{children}</div>
-    </div>
-  );
-};
-
-export const ProfileContextAsHTML = (): React.ReactElement => {
-  const { data, isComplete, error, fetch, refetch } = useContext(
-    ProfileContext
-  );
-  const [updateTime, setUpdateTime] = useState<number>(-1);
-  const [dataUpdateTime, setDataUpdateTime] = useState<number>(-1);
-  const errorMessage = getErrorMessage(error);
-  const dataTracker = useRef<string>(JSON.stringify(data || {}));
-  useEffect(() => {
-    const dataAsString = JSON.stringify(data || {});
-    if (dataAsString !== dataTracker.current) {
-      dataTracker.current = dataAsString;
-      setDataUpdateTime(Date.now());
-    }
-    setUpdateTime(Date.now());
-  }, [data, errorMessage, isComplete]);
-  const onButtonClick = () => (isComplete ? refetch() : fetch());
-  return (
-    <div data-testid="context-as-html">
-      <div data-testid="context-as-html-isComplete">{String(isComplete)}</div>
-      <div data-testid="context-as-html-error">{errorMessage}</div>
-      <div data-testid="context-as-html-updateTime">{updateTime}</div>
-      <div data-testid="context-as-html-dataUpdateTime">{dataUpdateTime}</div>
-      <button onClick={onButtonClick} data-testid="context-as-html-fetch">
-        Fetch
-      </button>
-    </div>
-  );
-};
-
-const getErrorMessage = (error?: Error | GraphQLError): string => {
+export const getErrorMessage = (error?: Error | GraphQLError): string => {
   if (!error) {
     return '';
   }
@@ -484,16 +297,4 @@ const getErrorMessage = (error?: Error | GraphQLError): string => {
     return retypedError.networkError;
   }
   return retypedError.message;
-};
-
-export const RenderChildrenWhenDataIsComplete = ({
-  children,
-}: {
-  children: React.ReactElement | React.ReactNodeArray;
-}): React.ReactElement | null => {
-  const { isComplete } = useContext(ProfileContext);
-  if (!isComplete) {
-    return null;
-  }
-  return <div data-testid="component-wrapper">{children}</div>;
 };

--- a/src/profile/components/basicData/BasicData.tsx
+++ b/src/profile/components/basicData/BasicData.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Field, Formik, FormikProps, Form } from 'formik';
 import { TextInput } from 'hds-react';
@@ -19,7 +19,7 @@ import {
   useProfileDataEditor,
 } from '../../hooks/useProfileDataEditor';
 import { basicDataSchema } from '../../../common/schemas/schemas';
-import { getFieldError, getIsInvalid } from '../../helpers/formik';
+import { createFormFieldHelpers } from '../../helpers/formik';
 import useNotificationContent from '../editingNotifications/useNotificationContent';
 import EditingNotifications from '../editingNotifications/EditingNotifications';
 import EditButtons, { ActionHandler } from '../editButtons/EditButtons';
@@ -50,20 +50,9 @@ function BasicData(): React.ReactElement | null {
   const { firstName, nickname, lastName } = value as BasicDataValue;
   const formFields = getFormFields(basicDataType);
 
-  const hasFieldError = (
-    formikProps: FormikProps<FormikValues>,
-    fieldName: keyof FormikValues
-  ): boolean => getIsInvalid<FormikValues>(formikProps, fieldName, true);
-
-  const getFieldErrorMessage = (
-    formikProps: FormikProps<FormikValues>,
-    fieldName: keyof FormikValues
-  ): ReactNode | undefined => {
-    if (!hasFieldError(formikProps, fieldName)) {
-      return undefined;
-    }
-    return getFieldError<FormikValues>(t, formikProps, fieldName, true);
-  };
+  const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
+    FormikValues
+  >(t, true);
 
   const onAction: ActionListener = async (action, item, newValue) => {
     clearMessage();

--- a/src/profile/components/basicData/__tests__/BasicData.test.tsx
+++ b/src/profile/components/basicData/__tests__/BasicData.test.tsx
@@ -8,13 +8,12 @@ import {
 import {
   renderComponentWithMocksAndContexts,
   TestTools,
-  RenderChildrenWhenDataIsComplete,
   cleanComponentMocks,
   WaitForElementAndValueProps,
   ElementSelector,
   submitButtonSelector,
   waitForElementAttributeValue,
-} from '../../../../common/test/componentMocking';
+} from '../../../../common/test/testingLibraryTools';
 import { ProfileData } from '../../../../graphql/typings';
 import BasicData from '../BasicData';
 import {
@@ -24,6 +23,7 @@ import {
 import { basicDataType, BasicDataValue } from '../../../helpers/editData';
 import i18n from '../../../../common/test/testi18nInit';
 import { getFormFields } from '../../../helpers/formProperties';
+import RenderChildrenWhenDataIsComplete from '../../../../common/test/RenderChildrenWhenDataIsComplete';
 
 describe('<BasicData /> ', () => {
   const responses: MockedResponse[] = [];

--- a/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
+++ b/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
@@ -1,0 +1,199 @@
+import { TextInput } from 'hds-react';
+import React from 'react';
+import { Field, Formik, FormikProps, Form } from 'formik';
+import { useTranslation } from 'react-i18next';
+import countries from 'i18n-iso-countries';
+import classNames from 'classnames';
+
+import commonFormStyles from '../../../common/cssHelpers/form.module.css';
+import { AddressValue } from '../../helpers/editData';
+import { createFormFieldHelpers } from '../../helpers/formik';
+import { addressSchema } from '../../../common/schemas/schemas';
+import FormButtons from '../formButtons/FormButtons';
+import EditButtons from '../editButtons/EditButtons';
+import FormikDropdown, {
+  HdsOptionType,
+} from '../../../common/formikDropdown/FormikDropdown';
+import getLanguageCode from '../../../common/helpers/getLanguageCode';
+import LabeledValue from '../../../common/labeledValue/LabeledValue';
+import getCountry from '../../helpers/getCountry';
+import { getFormFields } from '../../helpers/formProperties';
+import SaveIndicator from '../saveIndicator/SaveIndicator';
+import { useCommonEditHandling } from '../../hooks/useCommonEditHandling';
+import { RowItemProps } from '../multiItemEditor/MultiItemEditor';
+
+type FormikValues = AddressValue;
+
+function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
+  const { data, testId, dataType } = props;
+  const value = data.value as AddressValue;
+  const { address, city, postalCode, countryCode } = value;
+  const { t, i18n } = useTranslation();
+  const lang = i18n.languages[0];
+  const applicationLanguage = getLanguageCode(i18n.languages[0]);
+  const countryList = countries.getNames(applicationLanguage);
+  const countryOptions = Object.keys(countryList)
+    .map(key => ({
+      value: key,
+      label: countryList[key],
+    }))
+    .sort((a, b) => {
+      if (a.label < b.label) {
+        return -1;
+      }
+      if (a.label > b.label) {
+        return 1;
+      }
+      return 0;
+    });
+  const formFields = getFormFields(dataType);
+  const {
+    isNew,
+    isEditing,
+    actionHandler,
+    currentAction,
+  } = useCommonEditHandling(props);
+  const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
+    FormikValues
+  >(t, isNew);
+
+  const { primary } = data;
+
+  if (isEditing) {
+    return (
+      <Formik
+        initialValues={{
+          address,
+          city,
+          postalCode,
+          countryCode,
+        }}
+        onSubmit={async values => {
+          await actionHandler('save', values);
+        }}
+        validationSchema={addressSchema}
+      >
+        {(formikProps: FormikProps<FormikValues>) => (
+          <Form className={commonFormStyles.multiItemForm}>
+            <h4 className={commonFormStyles.sectionTitle}>
+              {primary
+                ? t('profileInformation.primaryAddress')
+                : t('profileInformation.address')}
+            </h4>
+            <div className={commonFormStyles.multiItemWrapper}>
+              <Field
+                name="address"
+                id={`${testId}-address`}
+                maxLength={formFields.address.max as number}
+                as={TextInput}
+                invalid={hasFieldError(formikProps, 'address')}
+                aria-invalid={hasFieldError(formikProps, 'address')}
+                helperText={getFieldErrorMessage(formikProps, 'address')}
+                labelText={t(formFields.address.translationKey)}
+                autoFocus
+                aria-labelledby={`${dataType}-address-helper`}
+              />
+              <Field
+                name="postalCode"
+                id={`${testId}-postalCode`}
+                maxLength={formFields.postalCode.max as number}
+                as={TextInput}
+                invalid={hasFieldError(formikProps, 'postalCode')}
+                aria-invalid={hasFieldError(formikProps, 'postalCode')}
+                helperText={getFieldErrorMessage(formikProps, 'postalCode')}
+                labelText={t(formFields.postalCode.translationKey)}
+                aria-labelledby={`${dataType}-postalCode-helper`}
+              />
+              <Field
+                name="city"
+                id={`${testId}-city`}
+                maxLength={formFields.city.max as number}
+                as={TextInput}
+                invalid={hasFieldError(formikProps, 'city')}
+                aria-invalid={hasFieldError(formikProps, 'city')}
+                helperText={getFieldErrorMessage(formikProps, 'city')}
+                labelText={t(formFields.city.translationKey)}
+                aria-labelledby={`${dataType}-city-helper`}
+              />
+              <div className={commonFormStyles.formField}>
+                <FormikDropdown
+                  name="countryCode"
+                  id={`${testId}-countryCode`}
+                  options={countryOptions}
+                  label={t(formFields.country.translationKey)}
+                  default={countryCode}
+                  onChange={option =>
+                    formikProps.setFieldValue(
+                      'countryCode',
+                      (option as HdsOptionType).value
+                    )
+                  }
+                />
+              </div>
+            </div>
+            <FormButtons
+              handler={actionHandler}
+              disabled={!!currentAction}
+              testId={testId}
+              alignLeft
+            />
+            <SaveIndicator action={currentAction} testId={testId} />
+          </Form>
+        )}
+      </Formik>
+    );
+  }
+  return (
+    <div
+      className={classNames([
+        commonFormStyles.contentWrapper,
+        commonFormStyles.multiItemContentWrapper,
+      ])}
+    >
+      <h4 className={commonFormStyles.sectionTitle}>
+        {primary
+          ? t('profileInformation.primaryAddress')
+          : t('profileInformation.address')}
+      </h4>
+      <div className={commonFormStyles.multiItemWrapper}>
+        <LabeledValue
+          label={t(formFields.address.translationKey)}
+          value={value.address}
+          testId={`${testId}-address`}
+        />
+        <LabeledValue
+          label={t(formFields.postalCode.translationKey)}
+          value={value.postalCode}
+          testId={`${testId}-postalCode`}
+        />
+        <LabeledValue
+          label={t(formFields.city.translationKey)}
+          value={value.city}
+          testId={`${testId}-city`}
+        />
+        <LabeledValue
+          label={t(formFields.country.translationKey)}
+          value={getCountry(value.countryCode, lang)}
+          testId={`${testId}-countryCode`}
+        />
+      </div>
+      <div className={commonFormStyles.actionsWrapper}>
+        <EditButtons
+          handler={actionHandler}
+          actions={{
+            removable: false,
+            primary,
+            setPrimary: false,
+          }}
+          buttonClassNames={commonFormStyles.actionsWrapperButton}
+          editButtonId={`${testId}-edit-button`}
+          disabled={!!currentAction}
+          testId={testId}
+        />
+        <SaveIndicator action={currentAction} testId={testId} />
+      </div>
+    </div>
+  );
+}
+
+export default MultiItemAddressRow;

--- a/src/profile/components/multiItemEditor/MultiItemEditor.tsx
+++ b/src/profile/components/multiItemEditor/MultiItemEditor.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
+import to from 'await-to-js';
+import { Button, IconPlusCircle } from 'hds-react';
+
+import ProfileSection from '../../../common/profileSection/ProfileSection';
+import MultiItemRow from '../multiItemRow/MultiItemRow';
+import MultiItemAddressRow from '../multiItemAddressRow/MultiItemAddressRow';
+import commonFormStyles from '../../../common/cssHelpers/form.module.css';
+import useNotificationContent from '../editingNotifications/useNotificationContent';
+import EditingNotifications from '../editingNotifications/EditingNotifications';
+import {
+  useProfileDataEditor,
+  ActionListener,
+} from '../../hooks/useProfileDataEditor';
+import {
+  EditData,
+  EditDataType,
+  EditDataValue,
+  isNewItem,
+} from '../../helpers/editData';
+
+type Props = {
+  dataType: EditDataType;
+};
+
+export type RowItemProps = {
+  data: EditData;
+  onAction: ActionListener;
+  testId: string;
+  dataType: EditDataType;
+};
+
+function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
+  const {
+    editDataList,
+    save,
+    reset,
+    add,
+    hasNew,
+    remove,
+  } = useProfileDataEditor({
+    dataType,
+  });
+  const { t } = useTranslation();
+  const {
+    content,
+    setErrorMessage,
+    setSuccessMessage,
+    clearMessage,
+  } = useNotificationContent();
+
+  const hasAddressList = dataType === 'addresses';
+  const isAddButtonDisabled = hasNew();
+  const RowComponent = hasAddressList ? MultiItemAddressRow : MultiItemRow;
+  const texts = (function() {
+    if (dataType === 'emails') {
+      return {
+        modalTitle: t('confirmationModal.removeEmail'),
+        title: t('profileInformation.emails'),
+        listAriaLabel: t('profileInformation.ariaListTitleEmails'),
+        listNumberTitle: t('profileInformation.email'),
+        addNew: t('profileForm.addAnotherEmail'),
+        noContent: t('profileInformation.noEmails'),
+      };
+    }
+    if (dataType === 'phones') {
+      return {
+        modalTitle: t('confirmationModal.removePhone'),
+        title: t('profileInformation.phones'),
+        listAriaLabel: t('profileInformation.ariaListTitlePhones'),
+        listNumberTitle: t('profileInformation.phone'),
+        addNew: t('profileForm.addAnotherPhone'),
+        noContent: t('profileInformation.noPhones'),
+      };
+    }
+    return {
+      modalTitle: t('confirmationModal.removeAddress'),
+      title: t('profileInformation.addresses'),
+      listAriaLabel: t('profileInformation.ariaListTitleAddresses'),
+      listNumberTitle: t('profileInformation.address'),
+      addNew: t('profileForm.addAnotherAddress'),
+      noContent: t('profileInformation.noAddresses'),
+    };
+  })();
+
+  const executeActionAndNotifyUser: ActionListener = async (
+    action,
+    item,
+    newValue
+  ) => {
+    const [err] = await to(save(item, newValue as EditDataValue));
+    if (err) {
+      setErrorMessage(action);
+      return Promise.reject(err);
+    }
+    setSuccessMessage(action);
+    return Promise.resolve();
+  };
+
+  const onAction: ActionListener = async (action, item, newValue) => {
+    clearMessage();
+    if (action === 'cancel') {
+      if (isNewItem(item)) {
+        await remove(item);
+      } else {
+        reset(item);
+      }
+    } else if (action === 'save') {
+      return executeActionAndNotifyUser(action, item, newValue);
+    }
+    return Promise.resolve();
+  };
+
+  const NoItemsMessage = () => (
+    <React.Fragment>
+      {dataType === 'addresses' && (
+        <h3 className={commonFormStyles.sectionTitle}>
+          {texts.listNumberTitle}
+        </h3>
+      )}
+      <p>{texts.noContent}</p>
+    </React.Fragment>
+  );
+
+  return (
+    <ProfileSection>
+      <h3
+        className={classNames([
+          commonFormStyles.sectionTitle,
+          hasAddressList && commonFormStyles.visuallyHidden,
+        ])}
+      >
+        {texts.title}
+      </h3>
+
+      {!editDataList || (!editDataList.length && <NoItemsMessage />)}
+      <ul aria-label={texts.listAriaLabel} className={commonFormStyles.list}>
+        {editDataList.map((item, index) => (
+          <li
+            className={commonFormStyles.listItem}
+            aria-label={`${texts.listNumberTitle} ${index + 1}`}
+            key={item.id || 'new'}
+          >
+            <RowComponent
+              data={item}
+              onAction={onAction}
+              testId={`${dataType}-${index}`}
+              dataType={dataType}
+            />
+          </li>
+        ))}
+      </ul>
+      <EditingNotifications content={content} dataType={dataType} />
+      <Button
+        iconLeft={<IconPlusCircle />}
+        onClick={async () => {
+          clearMessage();
+          add();
+        }}
+        variant="secondary"
+        disabled={isAddButtonDisabled}
+        className={commonFormStyles.responsiveButton}
+        id={`${dataType}-add-button`}
+      >
+        {texts.addNew}
+      </Button>
+    </ProfileSection>
+  );
+}
+
+export default MultiItemEditor;

--- a/src/profile/components/multiItemEditor/__tests__/MultiItemEditor.test.tsx
+++ b/src/profile/components/multiItemEditor/__tests__/MultiItemEditor.test.tsx
@@ -8,12 +8,11 @@ import {
 import {
   renderComponentWithMocksAndContexts,
   TestTools,
-  RenderChildrenWhenDataIsComplete,
   cleanComponentMocks,
   WaitForElementAndValueProps,
   ElementSelector,
   waitForElementAttributeValue,
-} from '../../../../common/test/componentMocking';
+} from '../../../../common/test/testingLibraryTools';
 import { ProfileData } from '../../../../graphql/typings';
 import MultiItemEditor from '../MultiItemEditor';
 import {
@@ -26,6 +25,7 @@ import {
   pickSources,
 } from '../../../helpers/editData';
 import i18n from '../../../../common/test/testi18nInit';
+import RenderChildrenWhenDataIsComplete from '../../../../common/test/RenderChildrenWhenDataIsComplete';
 
 describe('<MultiItemEditor /> ', () => {
   const responses: MockedResponse[] = [];

--- a/src/profile/components/multiItemEditor/__tests__/MultiItemEditor.test.tsx
+++ b/src/profile/components/multiItemEditor/__tests__/MultiItemEditor.test.tsx
@@ -1,0 +1,360 @@
+import React from 'react';
+import { act, waitFor } from '@testing-library/react';
+
+import {
+  cloneProfileAndProvideManipulationFunctions,
+  getMyProfile,
+} from '../../../../common/test/myProfileMocking';
+import {
+  renderComponentWithMocksAndContexts,
+  TestTools,
+  RenderChildrenWhenDataIsComplete,
+  cleanComponentMocks,
+  WaitForElementAndValueProps,
+  ElementSelector,
+  waitForElementAttributeValue,
+} from '../../../../common/test/componentMocking';
+import { ProfileData } from '../../../../graphql/typings';
+import MultiItemEditor from '../MultiItemEditor';
+import {
+  MockedResponse,
+  ResponseProvider,
+} from '../../../../common/test/MockApolloClientProvider';
+import {
+  EditDataType,
+  MultiItemProfileNode,
+  pickSources,
+} from '../../../helpers/editData';
+import i18n from '../../../../common/test/testi18nInit';
+
+describe('<MultiItemEditor /> ', () => {
+  const responses: MockedResponse[] = [];
+  const initialProfile = getMyProfile().myProfile as ProfileData;
+  const renderTestSuite = (dataType: EditDataType) => {
+    const responseProvider: ResponseProvider = () =>
+      responses.shift() as MockedResponse;
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <RenderChildrenWhenDataIsComplete>
+        <MultiItemEditor dataType={dataType} />
+      </RenderChildrenWhenDataIsComplete>
+    );
+  };
+  const t = i18n.getFixedT('fi');
+
+  // data may be FormValues or EmailNode, PhoneNode, AddressNode
+  // GeneralData type prevents casting all the time.
+  // Data used in tests is anyway in <string, string> format
+  type GeneralData = Record<string, string>;
+  type TestData = {
+    [x: string]: {
+      fields: string[];
+      formValues: GeneralData;
+    };
+  };
+  const testData: TestData = {
+    addresses: {
+      fields: ['address', 'city', 'postalCode'],
+      formValues: {
+        address: 'test-address',
+        city: 'test-city',
+        postalCode: '99999',
+        countryCode: 'FI',
+      },
+    },
+    phones: {
+      fields: ['phone'],
+      formValues: {
+        phone: '555-555-123',
+      },
+    },
+    emails: {
+      fields: ['email'],
+      formValues: {
+        email: 'test-email@email.com',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    responses.length = 0;
+  });
+  afterEach(() => {
+    cleanComponentMocks();
+  });
+
+  const initTests = async (dataType: EditDataType): Promise<TestTools> => {
+    responses.push({ profileData: initialProfile });
+    const testTools = await renderTestSuite(dataType);
+    await testTools.fetch();
+    return Promise.resolve(testTools);
+  };
+
+  const multiItemDataTypes: EditDataType[] = ['emails', 'phones', 'addresses'];
+  multiItemDataTypes.forEach(dataType => {
+    // test only node at index 0;
+    const testIndex = 0;
+    const editButtonSelector: ElementSelector = {
+      id: `${dataType}-${testIndex}-edit-button`,
+    };
+    const submitButtonSelector: ElementSelector = {
+      testId: `${dataType}-${testIndex}-save-button`,
+    };
+    const cancelButtonSelector: ElementSelector = {
+      testId: `${dataType}-${testIndex}-cancel-button`,
+    };
+    const addButtonSelector: ElementSelector = {
+      id: `${dataType}-add-button`,
+    };
+
+    const { fields, formValues } = testData[dataType];
+    const sourceNodeList = pickSources(
+      initialProfile,
+      dataType
+    ) as MultiItemProfileNode[];
+    const sourceNode = (sourceNodeList[testIndex] as unknown) as GeneralData;
+
+    // verifies rendered data
+    const verifyValues = async (
+      getTextOrInputValue: TestTools['getTextOrInputValue'],
+      source: GeneralData,
+      index: number,
+      targetIsInput = false
+    ) => {
+      const getSelector = (name: string): GeneralData => {
+        if (dataType === 'addresses') {
+          return targetIsInput
+            ? { id: `${dataType}-${index}-${name}` }
+            : { testId: `${dataType}-${index}-${name}-value` };
+        }
+        return targetIsInput
+          ? { id: `${dataType}-${index}-value` }
+          : { testId: `${dataType}-${index}-value` };
+      };
+      // cannot use forEach with async/await
+      for (const field of fields) {
+        const selector = getSelector(field);
+        const value = source[field];
+        await expect(getTextOrInputValue(selector)).resolves.toBe(value);
+      }
+    };
+
+    // sets new data to input fields
+    const setValues = async (
+      setInputValue: TestTools['setInputValue'],
+      source: GeneralData,
+      index: number
+    ) => {
+      // cannot use forEach with async/await
+      for (const field of fields) {
+        const value = source[field];
+        await setInputValue({
+          selector: {
+            id: `${dataType}-${index}-${
+              dataType === 'addresses' ? field : 'value'
+            }`,
+          },
+          newValue: value,
+        });
+      }
+    };
+
+    describe(`Renders ${dataType} and its fields: ${fields.join(',')}`, () => {
+      it(`All fields are rendered in view and in edit mode`, async () => {
+        await act(async () => {
+          const { getTextOrInputValue, clickElement } = await initTests(
+            dataType
+          );
+          await verifyValues(getTextOrInputValue, sourceNode, testIndex);
+          // goto edit mode
+          await clickElement(editButtonSelector);
+          await verifyValues(getTextOrInputValue, sourceNode, testIndex, true);
+        });
+      });
+
+      it('Component sends new data and returns to view mode when saved', async () => {
+        // create graphQL response for the update
+        const updatedProfileData = cloneProfileAndProvideManipulationFunctions(
+          initialProfile
+        )
+          .edit(dataType, {
+            ...formValues,
+            id: sourceNode.id,
+          })
+          .getProfile();
+
+        await act(async () => {
+          const {
+            clickElement,
+            setInputValue,
+            submit,
+            getTextOrInputValue,
+            waitForElement,
+          } = await initTests(dataType);
+          await clickElement(editButtonSelector);
+          await waitForElement(cancelButtonSelector);
+          await setValues(setInputValue, formValues, 0);
+          // add the graphQL response
+          responses.push({
+            updatedProfileData,
+          });
+
+          // when submitting, find these 2 notifications
+          const waitForOnSaveNotification: WaitForElementAndValueProps = {
+            selector: {
+              testId: `${dataType}-${testIndex}-save-indicator`,
+            },
+            value: t('notification.saving'),
+          };
+          const waitForAfterSaveNotification: WaitForElementAndValueProps = {
+            selector: { id: `${dataType}-edit-notifications` },
+            value: t('notification.saveSuccess'),
+          };
+          // submit and wait for saving and success notifications
+          await submit({
+            waitForOnSaveNotification,
+            waitForAfterSaveNotification,
+            optionalSubmitButtonSelector: submitButtonSelector,
+          });
+          await verifyValues(getTextOrInputValue, formValues, testIndex);
+        });
+      });
+
+      it('Clicking "add new" creates new item and Add button is disabled until new item is saved', async () => {
+        // create graphQL response for the update
+        const updatedProfileData = cloneProfileAndProvideManipulationFunctions(
+          initialProfile
+        )
+          .add(dataType, {
+            ...formValues,
+            id: '999',
+          })
+          .getProfile();
+
+        const newItemIndex =
+          pickSources(updatedProfileData, dataType).length - 1;
+        await act(async () => {
+          const {
+            clickElement,
+            setInputValue,
+            submit,
+            getTextOrInputValue,
+            isDisabled,
+          } = await initTests(dataType);
+          const addButton = await clickElement(addButtonSelector);
+          await waitFor(() => {
+            expect(isDisabled(addButton)).toBeTruthy();
+          });
+          await setValues(setInputValue, formValues, newItemIndex);
+          // add the graphQL response
+          responses.push({
+            updatedProfileData,
+          });
+          await submit({
+            optionalSubmitButtonSelector: {
+              testId: `${dataType}-${newItemIndex}-save-button`,
+            },
+          });
+          await waitFor(() => {
+            expect(isDisabled(addButton)).toBeFalsy();
+          });
+          await verifyValues(getTextOrInputValue, formValues, newItemIndex);
+        });
+      });
+
+      it(`Component shows error notification and stays in edit mode when error occurs. 
+      Cancel-button resets data`, async () => {
+        await act(async () => {
+          const {
+            clickElement,
+            setInputValue,
+            submit,
+            getTextOrInputValue,
+            waitForElement,
+          } = await initTests(dataType);
+          await clickElement(editButtonSelector);
+          await waitForElement(cancelButtonSelector);
+          await setValues(setInputValue, formValues, testIndex);
+          // add the graphQL response
+          responses.push({
+            errorType: 'networkError',
+          });
+
+          const waitForAfterSaveNotification: WaitForElementAndValueProps = {
+            selector: { id: `${dataType}-edit-notifications` },
+            value: t('notification.saveError'),
+          };
+          // submit and wait for saving and error notifications
+          await submit({
+            waitForAfterSaveNotification,
+            skipDataCheck: true,
+            optionalSubmitButtonSelector: submitButtonSelector,
+          });
+          // input fields are still rendered
+          await verifyValues(getTextOrInputValue, formValues, testIndex, true);
+          await clickElement(cancelButtonSelector);
+          // values are reset to previous values
+          await verifyValues(getTextOrInputValue, sourceNode, testIndex);
+        });
+      });
+    });
+
+    fields.forEach(field => {
+      describe(`Component indicates invalid values for ${dataType} and setting a valid value removes error `, () => {
+        it(`when field is ${field}`, async () => {
+          await act(async () => {
+            const {
+              clickElement,
+              setInputValue,
+              getElement,
+              waitForElement,
+            } = await initTests(dataType);
+            await clickElement(editButtonSelector);
+            await waitForElement(cancelButtonSelector);
+            const selector = `${dataType}-${testIndex}-${
+              dataType === 'addresses' ? field : 'value'
+            }`;
+
+            const testRun = {
+              validData: formValues,
+              invalidData: { ...formValues, [field]: '' },
+              elementSelector: { id: `${selector}` },
+              errorSelector: {
+                id: `${selector}-helper`,
+              },
+            };
+
+            const {
+              validData,
+              invalidData,
+              elementSelector,
+              errorSelector,
+            } = testRun;
+            const elementGetter = () => getElement(elementSelector);
+            const errorElementGetter = () => getElement(errorSelector);
+
+            // set invalid values
+            await setValues(setInputValue, invalidData, testIndex);
+            // submit also validates the form
+            await clickElement(submitButtonSelector);
+            await waitForElementAttributeValue(
+              elementGetter,
+              'aria-invalid',
+              'true'
+            );
+            // getElement throws if element is not found
+            expect(() => errorElementGetter).not.toThrow();
+            // set valid value
+            await setValues(setInputValue, validData, testIndex);
+            await waitForElementAttributeValue(
+              elementGetter,
+              'aria-invalid',
+              'false'
+            );
+            expect(errorElementGetter).toThrow();
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/profile/components/multiItemRow/MultiItemRow.tsx
+++ b/src/profile/components/multiItemRow/MultiItemRow.tsx
@@ -1,0 +1,125 @@
+import { TextInput } from 'hds-react';
+import React from 'react';
+import { Field, Formik, FormikProps, Form } from 'formik';
+import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
+
+import styles from './multiItemRow.module.css';
+import { EditDataValue, EmailValue, PhoneValue } from '../../helpers/editData';
+import { createFormFieldHelpers } from '../../helpers/formik';
+import { phoneSchema, emailSchema } from '../../../common/schemas/schemas';
+import FormButtons from '../formButtons/FormButtons';
+import EditButtons from '../editButtons/EditButtons';
+import commonFormStyles from '../../../common/cssHelpers/form.module.css';
+import SaveIndicator from '../saveIndicator/SaveIndicator';
+import { useCommonEditHandling } from '../../hooks/useCommonEditHandling';
+import { RowItemProps } from '../multiItemEditor/MultiItemEditor';
+import { getFormFields } from '../../helpers/formProperties';
+
+type EmailAndPhoneFormikValue = { value: string };
+
+function MultiItemRow(props: RowItemProps): React.ReactElement {
+  const {
+    data: { value, primary },
+    testId,
+    dataType,
+  } = props;
+  const { t } = useTranslation();
+  const {
+    isEditing,
+    currentAction,
+    actionHandler,
+    isNew,
+  } = useCommonEditHandling(props);
+  const schema = dataType === 'phones' ? phoneSchema : emailSchema;
+  const inputValue: string =
+    (dataType === 'phones'
+      ? (value as PhoneValue).phone
+      : (value as EmailValue).email) || '';
+
+  const inputId = `${testId}-value`;
+  const formFields = getFormFields(dataType);
+  const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
+    EmailAndPhoneFormikValue
+  >(t, isNew);
+  const convertFormPropsToEditDataValue = (
+    formValues: EmailAndPhoneFormikValue
+  ): Partial<EditDataValue> => {
+    const formValue = formValues.value;
+    const propName = dataType === 'phones' ? 'phone' : 'email';
+    return {
+      [propName]: formValue,
+    };
+  };
+  if (isEditing) {
+    return (
+      <div
+        className={classNames([
+          commonFormStyles.contentWrapper,
+          styles.rowContentWrapper,
+        ])}
+      >
+        <Formik
+          initialValues={{
+            value: inputValue,
+          }}
+          onSubmit={async values => {
+            const editDataValues = convertFormPropsToEditDataValue(values);
+            await actionHandler('save', editDataValues);
+          }}
+          validationSchema={schema}
+        >
+          {(formikProps: FormikProps<EmailAndPhoneFormikValue>) => (
+            <Form>
+              <div className={styles.editableRow}>
+                <Field
+                  name="value"
+                  id={inputId}
+                  maxLength={formFields.value.max as number}
+                  as={TextInput}
+                  invalid={hasFieldError(formikProps, 'value')}
+                  aria-invalid={hasFieldError(formikProps, 'value')}
+                  helperText={getFieldErrorMessage(formikProps, 'value')}
+                  aria-labelledby={`${dataType}-value-helper`}
+                  autoFocus
+                />
+                <FormButtons
+                  handler={actionHandler}
+                  disabled={!!currentAction}
+                  testId={testId}
+                />
+              </div>
+              <SaveIndicator action={currentAction} testId={testId} />
+            </Form>
+          )}
+        </Formik>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={classNames([
+        commonFormStyles.contentWrapper,
+        styles.rowContentWrapper,
+      ])}
+    >
+      <span className={styles.value} data-testid={`${testId}-value`}>
+        {inputValue || '–'}
+      </span>
+      <EditButtons
+        handler={actionHandler}
+        actions={{
+          removable: false,
+          primary,
+          setPrimary: false,
+        }}
+        editButtonId={`${testId}-edit-button`}
+        disabled={!!currentAction}
+        testId={testId}
+      />
+      <SaveIndicator action={currentAction} testId={testId} />
+    </div>
+  );
+}
+
+export default MultiItemRow;

--- a/src/profile/components/multiItemRow/multiItemRow.module.css
+++ b/src/profile/components/multiItemRow/multiItemRow.module.css
@@ -1,0 +1,43 @@
+.rowContentWrapper {
+  background: var(--color-black-ultra-light);
+  margin: 0 0 var(--spacing-m) 0;
+  padding: var(--spacing-m);
+}
+
+.rowContentWrapper form {
+  width: 100%;
+}
+
+.editableRow {
+  display: flex;
+  flex-direction: column;
+}
+
+/* fixes bug in HDS TextInput when it is wrapped to an element with display:flex: */
+.editableRow > div > div {
+  height: auto;
+}
+
+.value {
+  font-size: 18px;
+  padding: 0 0 var(--spacing-m) 0;
+  word-break: break-all;
+}
+
+@media (min-width: 768px) {
+  .rowContentWrapper {
+    flex-direction: row;
+    align-items: center;
+    padding: var(--spacing-m);
+  }
+  .value {
+    padding: 0 var(--spacing-2-xs) 0 0;
+  }
+
+  .editableRow {
+    flex-direction: row;
+  }
+  .editableRow > div:first-child {
+    width: 50%;
+  }
+}

--- a/src/profile/components/profile/__tests__/Profile.test.tsx
+++ b/src/profile/components/profile/__tests__/Profile.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup } from '@testing-library/react';
 import { Route, Switch } from 'react-router';
 
 import { getMyProfile } from '../../../../common/test/myProfileMocking';
-import { renderComponentWithMocksAndContexts } from '../../../../common/test/componentMocking';
+import { renderComponentWithMocksAndContexts } from '../../../../common/test/testingLibraryTools';
 import { ProfileData } from '../../../../graphql/typings';
 import Profile from '../Profile';
 import {

--- a/src/profile/components/profileInformation/ProfileInformation.tsx
+++ b/src/profile/components/profileInformation/ProfileInformation.tsx
@@ -7,6 +7,7 @@ import BerthErrorModal from '../modals/berthError/BerthErrorModal';
 import ProfileInformationAccountManagementLink from './ProfileInformationAccountManagementLink';
 import { ProfileContext } from '../../context/ProfileContext';
 import BasicData from '../basicData/BasicData';
+import MultiItemEditor from '../multiItemEditor/MultiItemEditor';
 
 function ProfileInformation(): React.ReactElement {
   const [berthError, setBerthError] = useState(false);
@@ -16,6 +17,9 @@ function ProfileInformation(): React.ReactElement {
       {data && (
         <Fragment>
           <BasicData />
+          <MultiItemEditor dataType="addresses" />
+          <MultiItemEditor dataType="emails" />
+          <MultiItemEditor dataType="phones" />
         </Fragment>
       )}
       <div className={styles.boxGrid}>

--- a/src/profile/components/verifiedPersonalInformation/__tests__/VerifiedPersonalInformation.test.tsx
+++ b/src/profile/components/verifiedPersonalInformation/__tests__/VerifiedPersonalInformation.test.tsx
@@ -4,7 +4,7 @@ import VerifiedPersonalInformation from '../VerifiedPersonalInformation';
 import {
   emptyResponseProvider,
   renderComponentWithMocksAndContexts,
-} from '../../../../common/test/componentMocking';
+} from '../../../../common/test/testingLibraryTools';
 import {
   getVerifiedData,
   getMyProfile,

--- a/src/profile/components/viewProfile/__tests__/ViewProfile.test.tsx
+++ b/src/profile/components/viewProfile/__tests__/ViewProfile.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act } from '@testing-library/react';
 
 import { getMyProfile } from '../../../../common/test/myProfileMocking';
-import { renderComponentWithMocksAndContexts } from '../../../../common/test/componentMocking';
+import { renderComponentWithMocksAndContexts } from '../../../../common/test/testingLibraryTools';
 import { ProfileData } from '../../../../graphql/typings';
 import ViewProfile from '../ViewProfile';
 import {

--- a/src/profile/context/__tests__/ProfileContext.test.tsx
+++ b/src/profile/context/__tests__/ProfileContext.test.tsx
@@ -2,15 +2,13 @@ import { waitFor } from '@testing-library/react';
 import { act } from '@testing-library/react-hooks';
 
 import { getMyProfile } from '../../../common/test/myProfileMocking';
-import {
-  cleanComponentMocks,
-  exposeProfileContext,
-} from '../../../common/test/componentMocking';
+import { cleanComponentMocks } from '../../../common/test/testingLibraryTools';
 import {
   MockedResponse,
   ResponseProvider,
 } from '../../../common/test/MockApolloClientProvider';
 import { ProfileData } from '../../../graphql/typings';
+import { exposeProfileContext } from '../../../common/test/exposeHooksForTesting';
 
 describe('ProfileContext', () => {
   function createTestEnv(responses: MockedResponse[]) {

--- a/src/profile/helpers/__tests__/editData.test.ts
+++ b/src/profile/helpers/__tests__/editData.test.ts
@@ -190,7 +190,7 @@ describe('editData.ts ', () => {
           const value = item.value as PhoneValue;
           expect(value.phone).toEqual(node.phone);
           expect(item.saving).toEqual(undefined);
-          expect(item.primary).toEqual(!!node.primary);
+          expect(item.primary).toEqual(node.primary);
           expect(item.id).toEqual(node.id);
         });
       }

--- a/src/profile/helpers/__tests__/editData.test.ts
+++ b/src/profile/helpers/__tests__/editData.test.ts
@@ -457,6 +457,64 @@ describe('editData.ts ', () => {
         }).toThrow();
       });
     });
+    describe(`updateItems `, () => {
+      let editorFunctions: EditFunctions;
+      let editDataList: EditData[];
+      let sources: EditDataProfileSource[];
+      beforeEach(() => {
+        editorFunctions = createEditorForDataType(myProfile, dataType);
+        editDataList = editorFunctions.getEditData();
+        sources = pickSources(myProfile.myProfile as ProfileData, dataType);
+      });
+      it(`returns null when edit data has no items with saving set to 'value'`, () => {
+        const nullList = updateItems(editDataList, sources, dataType);
+        expect(nullList).toBeNull();
+      });
+      it(`returns null until item.value and source match and item.saving='value'`, () => {
+        const item = editDataList[0] as Mutable<EditData>;
+        const newValue = createUniqueEditDataValue(item, dataType);
+        const source = sources[0] as Mutable<MultiItemProfileNode>;
+        item.saving = 'value';
+        item.value = newValue;
+        const nullList = updateItems(editDataList, sources, dataType);
+        expect(nullList).toBeNull();
+        const updatedSource = { ...source, ...newValue };
+        sources[0] = updatedSource;
+        const newList = updateItems(
+          editDataList,
+          sources,
+          dataType
+        ) as EditData[];
+        expect(newList).toHaveLength(editDataList.length);
+        const updatedItem = newList[0];
+        // old item has not changed
+        expect(item.saving).toEqual('value');
+        // change saving so item will match updatedItem
+        item.saving = undefined;
+        expect(updatedItem).toEqual(item);
+        expect(updatedItem.saving).toEqual(undefined);
+      });
+      it(`returns null until item.primary and source.primary match and item.saving='set-primary'`, () => {
+        const item = editDataList[0] as Mutable<EditData>;
+        const source = sources[0] as Mutable<PhoneNode>;
+        item.saving = saveTypeSetPrimary;
+        item.primary = true;
+        source.primary = false;
+        const nullList = updateItems(editDataList, sources, dataType);
+        expect(nullList).toBeNull();
+        source.primary = true;
+        const newList = updateItems(
+          editDataList,
+          sources,
+          dataType
+        ) as EditData[];
+        expect(newList).toHaveLength(editDataList.length);
+        const updatedItem = newList[0];
+        // change saving so item will match updatedItem
+        expect(updatedItem).toEqual({ ...item, saving: undefined });
+        expect(updatedItem.saving).toEqual(undefined);
+      });
+    });
   });
   describe(`updateData generally`, () => {
     it(`returns new list when new profile data has no items.'`, () => {
@@ -470,64 +528,7 @@ describe('editData.ts ', () => {
       expect(getEditData()).toHaveLength(0);
     });
   });
-  describe(`updateItems `, () => {
-    const dataType = 'phones';
-    let editorFunctions: EditFunctions;
-    let editDataList: EditData[];
-    let sources: EditDataProfileSource[];
-    beforeEach(() => {
-      editorFunctions = createEditorForDataType(myProfile, dataType);
-      editDataList = editorFunctions.getEditData();
-      sources = pickSources(myProfile.myProfile as ProfileData, dataType);
-    });
-    it(`returns null when edit data has no items with saving set to 'value'`, () => {
-      const nullList = updateItems(editDataList, sources, dataType);
-      expect(nullList).toBeNull();
-    });
-    it(`returns null until item.value and source match and item.saving='value'`, () => {
-      const item = editDataList[0] as Mutable<EditData>;
-      const value = item.value as Mutable<PhoneValue>;
-      const source = sources[0] as Mutable<PhoneNode>;
-      item.saving = 'value';
-      value.phone = createNewValue('phones');
-      const nullList = updateItems(editDataList, sources, dataType);
-      expect(nullList).toBeNull();
-      source.phone = value.phone;
-      const newList = updateItems(
-        editDataList,
-        sources,
-        dataType
-      ) as EditData[];
-      expect(newList).toHaveLength(editDataList.length);
-      const updatedItem = newList[0];
-      // old item has not changed
-      expect(item.saving).toEqual('value');
-      // change saving so item will match updatedItem
-      item.saving = undefined;
-      expect(updatedItem).toEqual(item);
-      expect(updatedItem.saving).toEqual(undefined);
-    });
-    it(`returns null until item.primary and source.primary match and item.saving='set-primary'`, () => {
-      const item = editDataList[0] as Mutable<EditData>;
-      const source = sources[0] as Mutable<PhoneNode>;
-      item.saving = saveTypeSetPrimary;
-      item.primary = true;
-      source.primary = false;
-      const nullList = updateItems(editDataList, sources, dataType);
-      expect(nullList).toBeNull();
-      source.primary = true;
-      const newList = updateItems(
-        editDataList,
-        sources,
-        dataType
-      ) as EditData[];
-      expect(newList).toHaveLength(editDataList.length);
-      const updatedItem = newList[0];
-      // change saving so item will match updatedItem
-      expect(updatedItem).toEqual({ ...item, saving: undefined });
-      expect(updatedItem.saving).toEqual(undefined);
-    });
-  });
+
   describe(`updateAfterSavingError `, () => {
     it(`resets item.saving to undefined and updates editData list with a clone`, () => {
       const { getEditData, updateAfterSavingError } = createEditorForDataType(

--- a/src/profile/helpers/__tests__/editData.test.ts
+++ b/src/profile/helpers/__tests__/editData.test.ts
@@ -12,6 +12,10 @@ import {
   EditFunctions,
   EmailValue,
   FormValues,
+  getNewItem,
+  hasNewItem,
+  isMultiItemDataType,
+  isNewItem,
   MultiItemProfileNode,
   PhoneValue,
   pickSources,
@@ -98,6 +102,32 @@ describe('editData.ts ', () => {
     return newValue;
   };
 
+  const pickItemIds = (itemList: (EditData | MultiItemProfileNode)[]) =>
+    itemList.map(item => item.id);
+
+  const createTestDataWithNewItem = (dataType: EditDataType) => {
+    const editor = createEditorForDataType(myProfile, dataType);
+    const oldList = editor.getEditData();
+    const newItem = editor.addItem();
+    const newList = editor.getEditData();
+    //list of ids is stored for checking wrong items are not removed.
+    const oldIdList = pickItemIds(oldList);
+    return {
+      editor,
+      oldList,
+      newList,
+      newItem,
+      oldIdList,
+    };
+  };
+  const pickMultiItemFormValues = (
+    formValues: FormValues | Partial<FormValues>,
+    dataType: EditDataType
+  ): MultiItemProfileNode[] =>
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    formValues[dataType] as MultiItemProfileNode[];
+
   allDataTypes.forEach(dataType => {
     it(`Picks correct data from myProfile when dataType is ${dataType}`, () => {
       const { getEditData } = createEditorForDataType(myProfile, dataType);
@@ -172,16 +202,16 @@ describe('editData.ts ', () => {
         updateItemAndCreateSaveData,
       } = createEditorForDataType(myProfile, dataType);
       const editDataList = getEditData();
+      const isMultiItem = isMultiItemDataType(dataType);
       editDataList.forEach((target, index) => {
         const oldValue = { ...target.value };
         const newValue = createUniqueEditDataValue(target, dataType);
         const newFormValues = updateItemAndCreateSaveData(target, newValue);
         const newEditDataList = getEditData();
         const newTarget = newEditDataList[index];
-        const newFormValue =
-          dataType !== basicDataType && dataType !== additionalInformationType
-            ? (newFormValues[dataType] as MultiItemProfileNode[])[index]
-            : newFormValues;
+        const newFormValue = isMultiItem
+          ? pickMultiItemFormValues(newFormValues, dataType)[index]
+          : newFormValues;
 
         // new value does not match old
         expect(newValue).not.toMatchObject(oldValue);
@@ -194,6 +224,10 @@ describe('editData.ts ', () => {
         // new id and primary match with old
         expect(newTarget.id).toEqual(target.id);
         expect(newTarget.primary).toEqual(target.primary);
+        // nodes should have id
+        if (isMultiItem) {
+          expect((newFormValue as MultiItemProfileNode).id).toEqual(target.id);
+        }
 
         // verify cloning is done: editing old data does not affect new data
         (target as Mutable<EditData>).id = 'test';
@@ -251,6 +285,176 @@ describe('editData.ts ', () => {
         expect(postUpdateTarget.saving).toEqual(undefined);
         expect(postUpdateTarget.value).toMatchObject(newValue);
         expect(postUpdateTarget.primary).toEqual(postEditTarget.primary);
+      });
+    });
+  });
+  multiItemDataTypes.forEach(dataType => {
+    describe(`addItem `, () => {
+      it(`creates new ${dataType} item with correct properties`, () => {
+        const { newItem } = createTestDataWithNewItem(dataType);
+        expect(newItem.id).toEqual('');
+        expect(newItem.primary).toBeFalsy();
+        expect(newItem.saving).toBeUndefined();
+        if (dataType === 'emails') {
+          expect((newItem.value as EmailValue).email).toBeDefined();
+        } else if (dataType === 'phones') {
+          expect((newItem.value as PhoneValue).phone).toBeDefined();
+        } else if (dataType === 'addresses') {
+          expect((newItem.value as AddressValue).address).toBeDefined();
+        }
+      });
+      it(`updateItemAndCreateSaveData updates the new ${dataType} item and it returns formValues`, () => {
+        const { editor, newItem } = createTestDataWithNewItem(dataType);
+        const newValue = createUniqueEditDataValue(newItem, dataType);
+        const saveData = editor.updateItemAndCreateSaveData(newItem, newValue);
+        const updatedList = editor.getEditData();
+        const updatedNewItem = updatedList[updatedList.length - 1];
+        const itemsInFormValues = pickMultiItemFormValues(saveData, dataType);
+        const newNodeInFormValues =
+          itemsInFormValues[itemsInFormValues.length - 1];
+        expect(newNodeInFormValues.id).toEqual(newItem.id);
+        expect(updatedNewItem.value).toMatchObject(newValue);
+        expect(pickValue(newNodeInFormValues, dataType)).toMatchObject(
+          newValue
+        );
+      });
+      it(`creates new ${dataType} item and helper functions detect it correctly`, () => {
+        const {
+          newList,
+          newItem,
+          oldList,
+          oldIdList,
+        } = createTestDataWithNewItem(dataType);
+        expect(newList.length).toEqual(oldList.length + 1);
+        expect(pickItemIds(newList)).toEqual([...oldIdList, '']);
+
+        expect(isNewItem(newItem)).toEqual(true);
+        expect(isNewItem(newList[0])).toEqual(false);
+
+        expect(hasNewItem(newList)).toEqual(true);
+        expect(hasNewItem(oldList)).toEqual(false);
+
+        expect(getNewItem(oldList)).toBeUndefined();
+        expect(getNewItem(newList)).toMatchObject(newItem);
+        // new item is last one in the array
+        expect(newList[newList.length - 1]).toMatchObject(newItem);
+      });
+      it(`adding a second new item throws`, () => {
+        const { editor } = createTestDataWithNewItem(dataType);
+        expect(() => editor.addItem()).toThrow();
+      });
+      it(`updateData updates profile data with new item when dataType is ${dataType}. 
+      New item does not exist after update`, () => {
+        const { editor, newItem, oldIdList } = createTestDataWithNewItem(
+          dataType
+        );
+        const newValue = createUniqueEditDataValue(newItem, dataType);
+        editor.updateItemAndCreateSaveData(newItem, newValue);
+        const profileManipulator = cloneProfileAndProvideManipulationFunctions(
+          myProfile.myProfile as ProfileData
+        );
+        const newItemId = '999';
+        profileManipulator.add(dataType, { ...newValue, id: newItemId });
+        editor.updateData({
+          myProfile: profileManipulator.getProfile(),
+        });
+        const updatedItems = editor.getEditData();
+        expect(hasNewItem(updatedItems)).toBeFalsy();
+        expect(updatedItems[updatedItems.length - 1].value).toMatchObject(
+          newValue
+        );
+        expect(updatedItems[updatedItems.length - 1].id).toEqual(newItemId);
+        expect(pickItemIds(updatedItems)).toEqual([...oldIdList, newItemId]);
+      });
+    });
+    describe(`removeItem `, () => {
+      it(`removing old ${dataType} item does not remove it until data is updated. 
+      Old item removal returns formValues without the removed item. `, () => {
+        const { editor, newList } = createTestDataWithNewItem(dataType);
+        // index of item to remove
+        const testIndex = 0;
+        // item to remove
+        const removeItem = newList[testIndex];
+        // removeItem() returns new formValues
+        const saveData = editor.removeItem(removeItem) as FormValues;
+        // old item is not removed, just marked by setting item.saving = 'remove'
+        const editDataWithRemovedItem = editor.getEditData();
+        const updatedItem = editDataWithRemovedItem[testIndex];
+        expect(saveData).toBeDefined();
+        expect(updatedItem.saving).toEqual('remove');
+        // original item is not mutated
+        expect(removeItem.saving).toBeUndefined();
+        const itemsInFormValues = pickMultiItemFormValues(saveData, dataType);
+        // item at target index has chaged
+        expect(itemsInFormValues[testIndex].id).toEqual(
+          editDataWithRemovedItem[testIndex + 1].id
+        );
+        // edit data have not changed yet
+        expect(editDataWithRemovedItem.length).toEqual(newList.length);
+        expect(pickItemIds(editDataWithRemovedItem)).toEqual(
+          pickItemIds(newList)
+        );
+        // formValues do not have removed item
+        expect(editDataWithRemovedItem.length).toEqual(
+          itemsInFormValues.length + 1
+        );
+        const newIdListWithoutRemovedItem = pickItemIds(newList);
+        newIdListWithoutRemovedItem.shift();
+        // removed id not found in ids
+        expect(pickItemIds(itemsInFormValues)).toEqual(
+          newIdListWithoutRemovedItem
+        );
+
+        // update data and verify item @testIndex has different item
+        const nextFirstItem = editDataWithRemovedItem[testIndex + 1];
+
+        const profileManipulator = cloneProfileAndProvideManipulationFunctions(
+          myProfile.myProfile as ProfileData
+        );
+        profileManipulator.remove(dataType, removeItem);
+
+        editor.updateData({
+          myProfile: profileManipulator.getProfile(),
+        });
+        const updatedItems = editor.getEditData();
+        expect(updatedItems.length).toEqual(newList.length - 1);
+        expect(updatedItems[testIndex]).toMatchObject(nextFirstItem);
+        const updatedIdList = pickItemIds(updatedItems);
+        expect(updatedIdList).toEqual(newIdListWithoutRemovedItem);
+        expect(updatedIdList.indexOf(removeItem.id)).toEqual(-1);
+        // new item is still found as last item
+        expect(isNewItem(updatedItems[updatedItems.length - 1])).toBeTruthy();
+      });
+
+      it(`removes new ${dataType} item. 
+      New item removal does not return new formValues but 'null'. 
+      Item list is immediately updated.`, () => {
+        const {
+          newItem,
+          editor,
+          newList,
+          oldIdList,
+        } = createTestDataWithNewItem(dataType);
+        const formValues = editor.removeItem(newItem);
+        const listWithoutNew = editor.getEditData();
+        expect(hasNewItem(listWithoutNew)).toBeFalsy();
+        expect(formValues).toBeNull();
+        expect(editor.getEditData().length).toEqual(newList.length - 1);
+        expect(pickItemIds(listWithoutNew)).toEqual(oldIdList);
+      });
+      it(`removing missing items throw`, () => {
+        const { editor } = createTestDataWithNewItem(dataType);
+        expect(() =>
+          editor.removeItem({ id: 'this_wont_exist' } as EditData)
+        ).toThrow();
+      });
+      it(`removing an item twice throws`, () => {
+        const { editor } = createTestDataWithNewItem(dataType);
+        const item = editor.getEditData()[0];
+        editor.removeItem(item);
+        expect(() => {
+          editor.removeItem(item);
+        }).toThrow();
       });
     });
   });

--- a/src/profile/helpers/formProperties.ts
+++ b/src/profile/helpers/formProperties.ts
@@ -23,7 +23,7 @@ export const formFieldsByDataType: FormFieldsByDataType = {
     },
     postalCode: {
       required: true,
-      max: 5,
+      max: 32,
       translationKey: 'profileForm.postalCode',
     },
     city: {

--- a/src/profile/helpers/formik.ts
+++ b/src/profile/helpers/formik.ts
@@ -51,3 +51,24 @@ export function getFieldError<FormValues>(
     t(message, options);
   return getError<FormValues>(formikProps, fieldName, renderError, isOldData);
 }
+
+export function createFormFieldHelpers<FormikValues>(
+  t: TFunction,
+  isNew: boolean
+): {
+  hasFieldError: (
+    formikProps: FormikProps<FormikValues>,
+    type: keyof FormikValues
+  ) => boolean;
+  getFieldErrorMessage: (
+    formikProps: FormikProps<FormikValues>,
+    type: keyof FormikValues
+  ) => ReactNode | undefined;
+} {
+  return {
+    hasFieldError: (formikProps, type) =>
+      getIsInvalid<FormikValues>(formikProps, type as string, !isNew),
+    getFieldErrorMessage: (formikProps, type) =>
+      getFieldError<FormikValues>(t, formikProps, type as string, !isNew),
+  };
+}

--- a/src/profile/hooks/__tests__/useProfileMutations.test.ts
+++ b/src/profile/hooks/__tests__/useProfileMutations.test.ts
@@ -3,11 +3,10 @@ import { RenderHookResult, act } from '@testing-library/react-hooks';
 import _ from 'lodash';
 
 import {
-  exposeProfileMutationsHook,
   createResultPropertyTracker,
   RenderHookResultsChildren,
   cleanComponentMocks,
-} from '../../../common/test/componentMocking';
+} from '../../../common/test/testingLibraryTools';
 import {
   ResponseProvider,
   MockedResponse,
@@ -23,6 +22,7 @@ import getAddressesFromNode from '../../helpers/getAddressesFromNode';
 import getEmailsFromNode from '../../helpers/getEmailsFromNode';
 import getPhonesFromNode from '../../helpers/getPhonesFromNode';
 import { MutationReturnType } from '../useProfileMutations';
+import { exposeProfileMutationsHook } from '../../../common/test/exposeHooksForTesting';
 
 describe('useProfileMutations.ts ', () => {
   const updateVariables: (UpdateMyProfileVariables | undefined)[] = [];

--- a/src/profile/hooks/__tests__/useProfileMutations.test.ts
+++ b/src/profile/hooks/__tests__/useProfileMutations.test.ts
@@ -30,7 +30,7 @@ describe('useProfileMutations.ts ', () => {
   let profileManipulator: ManipulationFunctions;
   afterEach(() => {
     cleanComponentMocks();
-    updateVariables.length = 0;
+    responses.length = 0;
     updateVariables.length = 0;
   });
   const responseProvider: ResponseProvider = variables => {

--- a/src/profile/hooks/useCommonEditHandling.ts
+++ b/src/profile/hooks/useCommonEditHandling.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import to from 'await-to-js';
+
+import { EditDataValue, isNewItem } from '../helpers/editData';
+import { Action } from './useProfileDataEditor';
+import { ActionHandler } from '../components/editButtons/EditButtons';
+import { RowItemProps } from '../components/multiItemEditor/MultiItemEditor';
+
+type UseActionHandlingReturnType = {
+  currentAction: Action;
+  isEditing: boolean;
+  isNew: boolean;
+  actionHandler: ActionHandler;
+};
+
+export const useCommonEditHandling = (
+  props: RowItemProps
+): UseActionHandlingReturnType => {
+  const { data, onAction } = props;
+  const isNew = isNewItem(data);
+  const [isEditing, setEditing] = useState(isNew);
+  const [currentAction, setCurrentAction] = useState<Action>(undefined);
+  const actionHandler: ActionHandler = async (action, newValue) => {
+    if (action === 'set-primary' || action === 'remove' || action === 'save') {
+      setCurrentAction(action);
+    }
+    const [err] = await to(onAction(action, data, newValue as EditDataValue));
+    if (isNew) {
+      if (err) {
+        setCurrentAction(undefined);
+      }
+      return Promise.resolve();
+    }
+    if (err || action !== 'remove') {
+      setCurrentAction(undefined);
+    }
+    if (action === 'cancel') {
+      setEditing(false);
+    } else if (action === 'edit') {
+      setEditing(true);
+    } else if (action === 'save' && !err) {
+      setEditing(false);
+    }
+    return Promise.resolve();
+  };
+
+  return {
+    actionHandler,
+    isEditing,
+    currentAction,
+    isNew,
+  };
+};

--- a/src/profile/hooks/useProfileDataEditor.ts
+++ b/src/profile/hooks/useProfileDataEditor.ts
@@ -15,6 +15,9 @@ export type ProfileDataEditorReturnType = {
   editDataList: EditData[];
   save: (item: EditData, newValue: EditDataValue) => Promise<UpdateResult>;
   reset: (item: EditData) => void;
+  add: () => void;
+  hasNew: () => boolean;
+  remove: (item: EditData) => Promise<UpdateResult | void>;
 };
 
 export type Action = SaveType | 'edit' | 'cancel' | 'save' | 'add';
@@ -58,6 +61,9 @@ export function useProfileDataEditor({
     updateData,
     updateAfterSavingError,
     resetItem,
+    addItem,
+    hasNewItem: hasNew,
+    removeItem,
   } = useMemo(
     () => createEditorForDataType(profileData, dataType),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,14 +102,29 @@ export function useProfileDataEditor({
     triggerUpdate();
     return executeMutationUpdateAndHandleResult(formValues, item.id);
   };
+
   const reset: ProfileDataEditorReturnType['reset'] = item => {
     const success = resetItem(item);
     success && triggerUpdate();
+  };
+
+  const add = () => {
+    addItem();
+    triggerUpdate();
+  };
+
+  const remove = async (item: EditData) => {
+    removeItem(item);
+    triggerUpdate();
+    return Promise.resolve();
   };
 
   return {
     editDataList: getEditData(),
     save,
     reset,
+    add,
+    hasNew,
+    remove,
   };
 }


### PR DESCRIPTION
Added components for viewing and editing emails, phones and addresses. 

Old data can be saved and new added and saved, but "remove"-button is not added for deleting items.

If there is a need to remove data, it can be done in https://profiili.dev.hel.ninja/
