### PR TITLE
HP-696 use session storage for tokens

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 REACT_APP_OIDC_AUTHORITY="https://tunnistamo.dev.hel.ninja/"
 REACT_APP_OIDC_CLIENT_ID="https://api.hel.fi/auth/helsinkiprofile-ui-dev"
 REACT_APP_PROFILE_AUDIENCE="https://api.hel.fi/auth/helsinkiprofiledev"
-REACT_APP_PROFILE_GRAPHQL="https://helsinki-profile-api-dev.agw.arodevtest.hel.fi/graphql/"
+REACT_APP_PROFILE_GRAPHQL="https://profile-api.dev.hel.ninja/graphql/"
 REACT_APP_OIDC_SCOPE="openid profile https://api.hel.fi/auth/helsinkiprofiledev"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "i18next": "^19.8.3",
     "i18next-browser-languagedetector": "^6.0.1",
     "lodash": "4.17.20",
-    "oidc-client": "^1.9.1",
+    "oidc-client": "1.11.5",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-helmet": "^6.0.0",

--- a/public/env-config.js
+++ b/public/env-config.js
@@ -8,7 +8,7 @@ window._env_ = {
   REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.dev.hel.ninja/',
   REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/helsinkiprofile-ui-dev',
   REACT_APP_PROFILE_AUDIENCE: 'https://api.hel.fi/auth/helsinkiprofiledev',
-  REACT_APP_PROFILE_GRAPHQL: 'https://helsinki-profile-api-dev.agw.arodevtest.hel.fi/graphql/',
+  REACT_APP_PROFILE_GRAPHQL: 'https://profile-api.dev.hel.ninja/graphql/',
   REACT_APP_OIDC_SCOPE: 'openid profile https://api.hel.fi/auth/helsinkiprofiledev',
   REACT_APP_APPLICATION_NAME: 'open-city-profile-ui',
   REACT_APP_SENTRY_DSN: 'https://8b5b23e2171b42cd8617e2b1ad7353b6@sentry.hel.ninja/63',

--- a/public/silent_renew.html
+++ b/public/silent_renew.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Silent renewal</title>
-</head>
-<body>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/oidc-client/1.10.1/oidc-client.min.js" integrity="sha512-J+l1VucK7pEidJ+w1fYQfo0Yq4LGkTXwKQ3w9Y9/c4O2NoQe+DgiIwvh2ocNVv4ost5H6W4uhy1K2sw5tWO+ew==" crossorigin="anonymous"></script>
-<script>
-  var mgr = new Oidc.UserManager();
-  mgr.signinSilentCallback().catch(error => {
-    console.error('silent_renew.html error', error);
-  });
-</script></body>
+  <head>
+    <title>Silent renewal</title>
+  </head>
+  <body>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/oidc-client/1.11.5/oidc-client.min.js"
+      integrity="sha512-pGtU1n/6GJ8fu6bjYVGIOT9Dphaw5IWPwVlqkpvVgqBxFkvdNbytUh0H8AP15NYF777P4D3XEeA/uDWFCpSQ1g=="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      var mgr = new Oidc.UserManager();
+      mgr.signinSilentCallback().catch(error => {
+        console.error('silent_renew.html error', error);
+      });
+    </script>
+  </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import AccessibilityStatement from './accessibilityStatement/AccessibilityStatem
 import { MAIN_CONTENT_ID } from './common/constants';
 import AccessibilityShortcuts from './common/accessibilityShortcuts/AccessibilityShortcuts';
 import AppMeta from './AppMeta';
-import authConstants from './auth/constants/authConstants';
 import GdprAuthorizationCodeManagerCallback from './gdprApi/GdprAuthorizationCodeManagerCallback';
 import ToastProvider from './toast/ToastProvider';
 import authService from './auth/authService';
@@ -44,23 +43,6 @@ function App(): React.ReactElement {
   if (location.pathname === '/loginsso') {
     authService.login();
   }
-
-  window.addEventListener('storage', event => {
-    if (
-      event.key === authConstants.OIDC_KEY &&
-      event.oldValue &&
-      !event.newValue
-    ) {
-      authService.logout();
-    }
-    if (
-      event.key === authConstants.OIDC_KEY &&
-      !event.oldValue &&
-      event.newValue
-    ) {
-      authService.login();
-    }
-  });
 
   return (
     <ApolloProvider client={graphqlClient}>

--- a/src/auth/__tests__/authService.test.js
+++ b/src/auth/__tests__/authService.test.js
@@ -5,7 +5,7 @@ describe('authService', () => {
   const oidcUserKey = `oidc.user:${window._env_.REACT_APP_OIDC_AUTHORITY}:${window._env_.REACT_APP_OIDC_CLIENT_ID}`;
 
   afterEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     jest.restoreAllMocks();
   });
 
@@ -23,7 +23,7 @@ describe('authService', () => {
   });
 
   describe('getToken', () => {
-    it('should get API_TOKENS from localStorage', () => {
+    it('should get API_TOKENS from sessionStorage', () => {
       const getSpy = jest.spyOn(Storage.prototype, 'getItem');
       authService.getToken();
 
@@ -64,7 +64,7 @@ describe('authService', () => {
       });
 
       jest.spyOn(authService, 'getToken').mockReturnValue(apiToken);
-      localStorage.setItem(oidcUserKey, validUser);
+      sessionStorage.setItem(oidcUserKey, validUser);
 
       expect(authService.isAuthenticated()).toBe(true);
     });
@@ -124,7 +124,7 @@ describe('authService', () => {
       expect(authService.fetchApiToken).toHaveBeenNthCalledWith(1, mockUser);
     });
 
-    it('should set the user in localStorage before the function returns', async () => {
+    it('should set the user in sessionStorage before the function returns', async () => {
       const setSpy = jest.spyOn(Storage.prototype, 'setItem');
       expect.assertions(1);
       jest
@@ -170,15 +170,15 @@ describe('authService', () => {
       expect(signoutRedirect).toHaveBeenCalledTimes(1);
     });
 
-    it('should remove the tokens from localStorage', async () => {
+    it('should remove the tokens from sessionStorage', async () => {
       expect.assertions(1);
       jest.spyOn(userManager, 'signoutRedirect').mockResolvedValue(undefined);
       const apiTokens = 'a8d56df4-7ae8-4fbf-bf73-f366cd6fc479';
 
-      localStorage.setItem(API_TOKEN, apiTokens);
+      sessionStorage.setItem(API_TOKEN, apiTokens);
       await authService.logout();
 
-      expect(localStorage.getItem(API_TOKEN)).toBeNull();
+      expect(sessionStorage.getItem(API_TOKEN)).toBeNull();
     });
 
     it('should call clearStaleState', async () => {
@@ -227,7 +227,7 @@ describe('authService', () => {
       `);
     });
 
-    it('should call localStorage.setItem with the right arguments', async () => {
+    it('should call sessionStorage.setItem with the right arguments', async () => {
       const setSpy = jest.spyOn(Storage.prototype, 'setItem');
       expect.assertions(2);
       await authService.fetchApiToken(mockUser);

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -18,7 +18,7 @@ export class AuthService {
   constructor() {
     const settings: UserManagerSettings = {
       automaticSilentRenew: true,
-      userStore: new WebStorageStateStore({ store: window.localStorage }),
+      userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       authority: window._env_.REACT_APP_OIDC_AUTHORITY,
       client_id: window._env_.REACT_APP_OIDC_CLIENT_ID,
       redirect_uri: `${origin}/callback`,
@@ -57,7 +57,7 @@ export class AuthService {
 
     this.userManager.events.addUserSignedOut(() => {
       this.userManager.clearStaleState();
-      localStorage.removeItem(API_TOKEN);
+      sessionStorage.removeItem(API_TOKEN);
     });
 
     this.userManager.events.addUserLoaded(async user => {
@@ -70,12 +70,12 @@ export class AuthService {
   }
 
   public getToken(): string | null {
-    return localStorage.getItem(API_TOKEN);
+    return sessionStorage.getItem(API_TOKEN);
   }
 
   public isAuthenticated(): boolean {
     const userKey = `oidc.user:${window._env_.REACT_APP_OIDC_AUTHORITY}:${window._env_.REACT_APP_OIDC_CLIENT_ID}`;
-    const oidcStorage = localStorage.getItem(userKey);
+    const oidcStorage = sessionStorage.getItem(userKey);
     const apiTokens = this.getToken();
 
     return (
@@ -107,7 +107,7 @@ export class AuthService {
   }
 
   public async logout(): Promise<void> {
-    localStorage.removeItem(API_TOKEN);
+    sessionStorage.removeItem(API_TOKEN);
     this.userManager.clearStaleState();
     await this.userManager.signoutRedirect();
   }
@@ -122,7 +122,7 @@ export class AuthService {
     const result = await response.json();
     const apiToken = pickProfileApiToken(result);
 
-    localStorage.setItem(API_TOKEN, apiToken);
+    sessionStorage.setItem(API_TOKEN, apiToken);
   }
 }
 

--- a/src/gdprApi/GdprAuthorizationCodeManager.ts
+++ b/src/gdprApi/GdprAuthorizationCodeManager.ts
@@ -29,7 +29,7 @@ class GdprAuthorizationCodeManager {
   }
 
   get(key: string): Record<string, unknown> | string | null {
-    const value = localStorage.getItem(`${PREFIX}.${key}`);
+    const value = sessionStorage.getItem(`${PREFIX}.${key}`);
 
     if (value === null) {
       return null;
@@ -39,11 +39,11 @@ class GdprAuthorizationCodeManager {
   }
 
   set(key: string, value: Record<string, unknown> | string): void {
-    localStorage.setItem(`${PREFIX}.${key}`, JSON.stringify(value));
+    sessionStorage.setItem(`${PREFIX}.${key}`, JSON.stringify(value));
   }
 
   clear(key: string): void {
-    localStorage.removeItem(`${PREFIX}.${key}`);
+    sessionStorage.removeItem(`${PREFIX}.${key}`);
   }
 
   consumeCode(): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,7 +2798,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3642,7 +3642,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2, base64-js@^1.3.0:
+base64-js@^1.0.2, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4663,7 +4663,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.1.tgz#23f84048f366fdfcf52d3fd1c68fec349177d119"
   integrity sha512-Se+LaxqXlVXGvmexKGPvnUIYC1jwXu1H6Pkyb3uBM5d8/NELMYCHs/4/roD7721NxrTLyv7e5nXd5/QLBO+10g==
 
-core-js@^2.4.0, core-js@^2.6.4:
+core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
@@ -4672,6 +4672,11 @@ core-js@^3.0.1, core-js@^3.4.0, core-js@^3.6.5:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.1.tgz#f51523668ac8a294d1285c3b9db44025fda66d47"
   integrity sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==
+
+core-js@^3.8.3:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
+  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4793,10 +4798,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^3.1.9-1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -9646,15 +9651,16 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-oidc-client@^1.9.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.10.1.tgz#fe67ae54924fc1c338062f3fd733be362026192c"
-  integrity sha512-/QB5Nl7c9GmT9ir1E+OVY3+yZZnuk7Qa9ZEAJqSvDq0bAyAU9KAgeKipTEfKjGdGLTeOLy9FRWuNpULMkfZydQ==
+oidc-client@1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.11.5.tgz#020aa193d68a3e1f87a24fcbf50073b738de92bb"
+  integrity sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==
   dependencies:
-    base64-js "^1.3.0"
-    core-js "^2.6.4"
-    crypto-js "^3.1.9-1"
-    uuid "^3.3.2"
+    acorn "^7.4.1"
+    base64-js "^1.5.1"
+    core-js "^3.8.3"
+    crypto-js "^4.0.0"
+    serialize-javascript "^4.0.0"
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Changed from localStorage to sessionStorage. Now tokens are destroyed when window/tab is closed. Also, two windows/tabs cannot share same tokens so logging out in one, does not log out in another. Removed localStorage listener, because it is useless now.

Updated also oidc-client from 1.11.beta to 1.11.5.