### PR TITLE
HP-196: yletunnus amr fix

### DIFF
--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -9,7 +9,7 @@ export type AMR =
   | 'github'
   | 'google'
   | 'facebook'
-  | 'yle'
+  | 'yletunnus'
   | typeof tunnistusSuomifiAMR
   | typeof config.helsinkiAccountAMR;
 
@@ -17,7 +17,7 @@ export type AMRStatic =
   | 'github'
   | 'google'
   | 'facebook'
-  | 'yle'
+  | 'yletunnus'
   | 'helsinkiAccount'
   | 'tunnistusSuomifi';
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -218,7 +218,7 @@
     "github": "GitHub",
     "google": "Google",
     "facebook": "Facebook",
-    "yle": "Yle",
+    "yletunnus": "Yle",
     "tunnistusSuomifi": "Suomi.fi"
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -218,7 +218,7 @@
     "github": "GitHub",
     "google": "Google",
     "facebook": "Facebook",
-    "yle": "Yle",
+    "yletunnus": "Yle",
     "tunnistusSuomifi": "Suomi.fi"
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -218,7 +218,7 @@
     "github": "GitHub",
     "google": "Google",
     "facebook": "Facebook",
-    "yle": "Yle",
+    "yletunnus": "Yle",
     "tunnistusSuomifi": "Suomi.fi"
   }
 }

--- a/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
+++ b/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
@@ -23,7 +23,7 @@ export function getAmr(profile: Profile | null): AMRStatic | null {
     amr === 'github' ||
     amr === 'google' ||
     amr === 'facebook' ||
-    amr === 'yle'
+    amr === 'yletunnus'
   ) {
     return amr;
   }
@@ -42,7 +42,7 @@ export function getAmrUrl(authenticationMethodReference: AMRStatic): string {
       return config.identityProviderManagementUrlGoogle;
     case 'facebook':
       return config.identityProviderManagementUrlFacebook;
-    case 'yle':
+    case 'yletunnus':
       return config.identityProviderManagementUrlYle;
     case 'tunnistusSuomifi':
       return config.identityProviderManagementUrlTunnistusSuomifi;


### PR DESCRIPTION
Wrong amr changed.
Translations updated too because amr is a translation key