### PR TITLE
HP-318 step 7: remove old items

### DIFF
--- a/src/common/test/renderComponentTestDOM.tsx
+++ b/src/common/test/renderComponentTestDOM.tsx
@@ -22,6 +22,7 @@ function renderComponentTestDOM(
           <ProfileContextAsHTML />
         </ProfileProvider>
       </MockApolloClientProvider>
+      <div id="modal-container" />
     </BrowserRouter>
   );
 }

--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -229,7 +229,9 @@ export const renderComponentWithMocksAndContexts = async (
         return;
       }
       if (!elementValue || !elementValue.includes(value)) {
-        throw new Error('element value does not match given value');
+        throw new Error(
+          `element value (${elementValue}) does not include given value ${value}`
+        );
       }
     });
   };

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.module.css
@@ -6,6 +6,7 @@
   background-color: var(--color-white);
   border-radius: 2px;
   border: none;
+  border-top: 10px solid var(--color-bus);
   z-index: 100;
 }
 
@@ -26,32 +27,35 @@
   z-index: 99;
 }
 
-.titleRow {
+.wrapper {
   display: flex;
   align-items: flex-start;
+  position: relative;
 }
-.titleRow > *:first-child {
+.wrapper > div {
   flex-grow: 1;
 }
 
 .closeButton {
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-  width: var(--spacing-layout);
-  height: var(--spacing-layout);
+  background: none;
+  border: 0;
+  color: var(--color-bus);
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .icon {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 }
 
 .content {
   width: 100%;
   display: flex;
-  margin: var(--spacing-s) 0 var(--spacing-m) 0;
+  margin-bottom: var(--spacing-m);
   flex-direction: column;
+  padding: 0 var(--spacing-s) 0;
 }
 
 .content h3 {

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import ReactModal from 'react-modal';
 import { useTranslation } from 'react-i18next';
-import { IconCross } from 'hds-react';
+import { IconCross, IconAlertCircle } from 'hds-react';
 
 import styles from './ConfirmationModal.module.css';
-import { ServiceConnectionsQuery } from '../../../../graphql/generatedTypes';
+import { ServiceConnectionsRoot } from '../../../../graphql/typings';
 import getServices from '../../../helpers/getServices';
 import Button from '../../../../common/button/Button';
 
-type Props = {
+export type Props = {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   modalTitle?: string;
   modalText?: string;
   actionButtonText: string;
-  services?: ServiceConnectionsQuery;
+  services?: ServiceConnectionsRoot;
 };
 
 function ConfirmationModal({
@@ -37,32 +37,46 @@ function ConfirmationModal({
       overlayClassName={styles.overlay}
       shouldCloseOnOverlayClick
     >
-      <div className={styles.content}>
-        <div className={styles.titleRow}>
-          <h3>{modalTitle}</h3>
-          <button
-            className={styles.closeButton}
-            type="button"
-            onClick={onClose}
-            aria-label={t('confirmationModal.close')}
-          >
-            <IconCross className={styles.icon} />
-          </button>
+      <div className={styles.wrapper}>
+        <span aria-hidden="true">
+          <IconAlertCircle />
+        </span>
+        <div className={styles.content}>
+          <div className={styles.titleRow}>
+            <h3>{modalTitle}</h3>
+            <p>{modalText}</p>
+          </div>
+          <ul>
+            {servicesArray.map((service, index) => (
+              <li key={index}>{service.title}</li>
+            ))}
+          </ul>
         </div>
-        <p>{modalText}</p>
-        <ul>
-          {servicesArray.map((service, index) => (
-            <li key={index}>{service.title}</li>
-          ))}
-        </ul>
+        <button
+          className={styles.closeButton}
+          type="button"
+          onClick={onClose}
+          aria-label={t('confirmationModal.close')}
+        >
+          <IconCross className={styles.icon} />
+        </button>
       </div>
 
       <div className={styles.actions}>
-        <Button className={styles.button} variant="outlined" onClick={onClose}>
-          {t('confirmationModal.cancel')}
-        </Button>
-        <Button className={styles.button} onClick={onConfirm}>
+        <Button
+          className={styles.button}
+          onClick={onConfirm}
+          data-testid="confirmation-modal-confirm-button"
+        >
           {actionButtonText}
+        </Button>
+        <Button
+          className={styles.button}
+          variant="outlined"
+          onClick={onClose}
+          data-testid="confirmation-modal-cancel-button"
+        >
+          {t('confirmationModal.cancel')}
         </Button>
       </div>
     </ReactModal>

--- a/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
+++ b/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
@@ -181,7 +181,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
         <EditButtons
           handler={actionHandler}
           actions={{
-            removable: false,
+            removable: !primary,
             primary,
             setPrimary: false,
           }}

--- a/src/profile/components/multiItemRow/MultiItemRow.tsx
+++ b/src/profile/components/multiItemRow/MultiItemRow.tsx
@@ -109,7 +109,7 @@ function MultiItemRow(props: RowItemProps): React.ReactElement {
       <EditButtons
         handler={actionHandler}
         actions={{
-          removable: false,
+          removable: !primary,
           primary,
           setPrimary: false,
         }}

--- a/src/profile/hooks/useConfirmationModal.ts
+++ b/src/profile/hooks/useConfirmationModal.ts
@@ -1,0 +1,70 @@
+import { useRef, useState } from 'react';
+
+import { Props as ModalComponentProps } from '../components/modals/confirmationModal/ConfirmationModal';
+
+type AsyncModalProps = Pick<
+  ModalComponentProps,
+  'modalTitle' | 'modalText' | 'actionButtonText'
+>;
+
+type AsyncModalPromiseControls = {
+  resolve?: (result: boolean) => void;
+  reject?: (result: boolean) => void;
+};
+
+type AsyncModalReturnType = {
+  showModal: (props: AsyncModalProps) => Promise<boolean>;
+  modalProps: ModalComponentProps;
+};
+
+export function useConfirmationModal(): AsyncModalReturnType {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const componentPropsRef = useRef<ModalComponentProps>({
+    isOpen,
+    actionButtonText: '',
+    onClose: () => false,
+    onConfirm: () => false,
+  });
+  const controlsRef = useRef<AsyncModalPromiseControls>({});
+
+  const closeModal = () => {
+    controlsRef.current = {};
+    componentPropsRef.current.isOpen = false;
+    setIsOpen(componentPropsRef.current.isOpen);
+  };
+
+  const showModal: AsyncModalReturnType['showModal'] = props => {
+    const currentControls = controlsRef.current;
+    if (currentControls.reject) {
+      currentControls.reject(true);
+    }
+    const newControls: AsyncModalPromiseControls = {};
+    const promise: Promise<boolean> = new Promise((resolve, reject) => {
+      newControls.resolve = resolve;
+      newControls.reject = reject;
+    });
+    controlsRef.current = newControls;
+    const newComponentProps = {
+      ...props,
+      isOpen: true,
+      onClose: () => {
+        newControls.reject && newControls.reject(true);
+        closeModal();
+      },
+      onConfirm: () => {
+        newControls.resolve && newControls.resolve(true);
+        closeModal();
+      },
+    };
+    Object.assign(componentPropsRef.current, newComponentProps);
+
+    controlsRef.current = newControls;
+    setIsOpen(true);
+    return promise;
+  };
+
+  return {
+    showModal,
+    modalProps: componentPropsRef.current,
+  };
+}

--- a/src/profile/hooks/useProfileDataEditor.ts
+++ b/src/profile/hooks/useProfileDataEditor.ts
@@ -114,9 +114,12 @@ export function useProfileDataEditor({
   };
 
   const remove = async (item: EditData) => {
-    removeItem(item);
+    const newFormValues = removeItem(item);
     triggerUpdate();
-    return Promise.resolve();
+    if (!newFormValues) {
+      return Promise.resolve();
+    }
+    return executeMutationUpdateAndHandleResult(newFormValues, item.id);
   };
 
   return {


### PR DESCRIPTION
Added remove feature for old, saved items (addresses, emails, phones).  Note that primary items cannot be removed. Remove button is not visible in that case.