### PR TITLE
HP-318 step 8: set primary

### DIFF
--- a/src/profile/components/editButtons/EditButtons.tsx
+++ b/src/profile/components/editButtons/EditButtons.tsx
@@ -52,7 +52,10 @@ function EditButtons(props: Props): React.ReactElement {
   return (
     <div className={commonFormStyles.actions}>
       {setPrimary && primary && (
-        <div className={commonFormStyles.primaryContainer}>
+        <div
+          className={commonFormStyles.primaryContainer}
+          data-testid={`${testId}-primary-indicator`}
+        >
           <IconStarFill aria-hidden="true" />
           <span aria-hidden="true">{t('profileForm.primary')}</span>
         </div>

--- a/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
+++ b/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
@@ -25,7 +25,7 @@ import { RowItemProps } from '../multiItemEditor/MultiItemEditor';
 type FormikValues = AddressValue;
 
 function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
-  const { data, testId, dataType } = props;
+  const { data, testId, dataType, disableEditButtons } = props;
   const value = data.value as AddressValue;
   const { address, city, postalCode, countryCode } = value;
   const { t, i18n } = useTranslation();
@@ -57,7 +57,8 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
     FormikValues
   >(t, isNew);
 
-  const { primary } = data;
+  const { primary, saving } = data;
+  const disableButtons = !!currentAction || !!saving;
 
   if (isEditing) {
     return (
@@ -133,7 +134,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
             </div>
             <FormButtons
               handler={actionHandler}
-              disabled={!!currentAction}
+              disabled={disableButtons}
               testId={testId}
               alignLeft
             />
@@ -183,11 +184,11 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
           actions={{
             removable: !primary,
             primary,
-            setPrimary: false,
+            setPrimary: true,
           }}
           buttonClassNames={commonFormStyles.actionsWrapperButton}
           editButtonId={`${testId}-edit-button`}
-          disabled={!!currentAction}
+          disabled={disableButtons || disableEditButtons}
           testId={testId}
         />
         <SaveIndicator action={currentAction} testId={testId} />

--- a/src/profile/components/multiItemEditor/MultiItemEditor.tsx
+++ b/src/profile/components/multiItemEditor/MultiItemEditor.tsx
@@ -19,6 +19,7 @@ import {
   EditDataType,
   EditDataValue,
   isNewItem,
+  isSettingPrimary,
 } from '../../helpers/editData';
 import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
 import { useConfirmationModal } from '../../hooks/useConfirmationModal';
@@ -32,6 +33,7 @@ export type RowItemProps = {
   onAction: ActionListener;
   testId: string;
   dataType: EditDataType;
+  disableEditButtons: boolean;
 };
 
 function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
@@ -42,6 +44,7 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
     add,
     hasNew,
     remove,
+    setNewPrimary,
   } = useProfileDataEditor({
     dataType,
   });
@@ -56,6 +59,7 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
   const { showModal, modalProps } = useConfirmationModal();
   const hasAddressList = dataType === 'addresses';
   const isAddButtonDisabled = hasNew();
+  const setPrimaryInProgress = isSettingPrimary(editDataList);
   const RowComponent = hasAddressList ? MultiItemAddressRow : MultiItemRow;
   const texts = (function() {
     if (dataType === 'emails') {
@@ -124,6 +128,13 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
         }
       }
       return executeActionAndNotifyUser(action, item, newValue);
+    } else if (action === 'set-primary') {
+      const [err] = await to(setNewPrimary(item));
+      if (err) {
+        setErrorMessage(action);
+      } else {
+        setSuccessMessage(action);
+      }
     }
     return Promise.resolve();
   };
@@ -163,6 +174,7 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
               onAction={onAction}
               testId={`${dataType}-${index}`}
               dataType={dataType}
+              disableEditButtons={setPrimaryInProgress}
             />
           </li>
         ))}

--- a/src/profile/components/multiItemRow/MultiItemRow.tsx
+++ b/src/profile/components/multiItemRow/MultiItemRow.tsx
@@ -20,9 +20,10 @@ type EmailAndPhoneFormikValue = { value: string };
 
 function MultiItemRow(props: RowItemProps): React.ReactElement {
   const {
-    data: { value, primary },
+    data: { value, primary, saving },
     testId,
     dataType,
+    disableEditButtons,
   } = props;
   const { t } = useTranslation();
   const {
@@ -39,6 +40,7 @@ function MultiItemRow(props: RowItemProps): React.ReactElement {
 
   const inputId = `${testId}-value`;
   const formFields = getFormFields(dataType);
+  const disableButtons = !!currentAction || !!saving;
   const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
     EmailAndPhoneFormikValue
   >(t, isNew);
@@ -85,7 +87,7 @@ function MultiItemRow(props: RowItemProps): React.ReactElement {
                 />
                 <FormButtons
                   handler={actionHandler}
-                  disabled={!!currentAction}
+                  disabled={disableButtons}
                   testId={testId}
                 />
               </div>
@@ -111,10 +113,10 @@ function MultiItemRow(props: RowItemProps): React.ReactElement {
         actions={{
           removable: !primary,
           primary,
-          setPrimary: false,
+          setPrimary: true,
         }}
         editButtonId={`${testId}-edit-button`}
-        disabled={!!currentAction}
+        disabled={disableButtons || disableEditButtons}
         testId={testId}
       />
       <SaveIndicator action={currentAction} testId={testId} />

--- a/src/profile/hooks/useProfileDataEditor.ts
+++ b/src/profile/hooks/useProfileDataEditor.ts
@@ -18,6 +18,7 @@ export type ProfileDataEditorReturnType = {
   add: () => void;
   hasNew: () => boolean;
   remove: (item: EditData) => Promise<UpdateResult | void>;
+  setNewPrimary: (item: EditData) => Promise<UpdateResult | void>;
 };
 
 export type Action = SaveType | 'edit' | 'cancel' | 'save' | 'add';
@@ -64,6 +65,7 @@ export function useProfileDataEditor({
     addItem,
     hasNewItem: hasNew,
     removeItem,
+    setPrimary,
   } = useMemo(
     () => createEditorForDataType(profileData, dataType),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -122,6 +124,14 @@ export function useProfileDataEditor({
     return executeMutationUpdateAndHandleResult(newFormValues, item.id);
   };
 
+  const setNewPrimary = async (item: EditData) => {
+    const newFormValues = setPrimary(item);
+    if (!newFormValues) {
+      return Promise.resolve();
+    }
+    return executeMutationUpdateAndHandleResult(newFormValues, item.id);
+  };
+
   return {
     editDataList: getEditData(),
     save,
@@ -129,5 +139,6 @@ export function useProfileDataEditor({
     add,
     hasNew,
     remove,
+    setNewPrimary,
   };
 }


### PR DESCRIPTION
Addresses, emails and phones can now be set as primary. While changing the primary item, all other modifications are prohibited by disabling buttons in that group.

Primary item is always the first item in UI. Backend orders only emails like this, so at the moment UI re-orders them, if primary is not at index 0.