### PR TITLE
HP-318 add back Verified personal information

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,10 +61,7 @@ function App(): React.ReactElement {
               <Route path="/login">
                 <Login />
               </Route>
-              <Route
-                path={['/', '/connected-services', '/subscriptions']}
-                exact
-              >
+              <Route path={['/', '/connected-services']} exact>
                 <Profile />
               </Route>
               <Route path="/accessibility">

--- a/src/profile/components/profileInformation/ProfileInformation.tsx
+++ b/src/profile/components/profileInformation/ProfileInformation.tsx
@@ -9,15 +9,21 @@ import { ProfileContext } from '../../context/ProfileContext';
 import BasicData from '../basicData/BasicData';
 import MultiItemEditor from '../multiItemEditor/MultiItemEditor';
 import AdditionalInformation from '../additionalInformation/AdditionalInformation';
+import VerifiedPersonalInformation from '../verifiedPersonalInformation/VerifiedPersonalInformation';
+import getVerifiedPersonalInformation from '../../helpers/getVerifiedPersonalInformation';
 
 function ProfileInformation(): React.ReactElement {
   const [berthError, setBerthError] = useState(false);
   const { data } = useContext(ProfileContext);
+  const hasVerifiedData = !!getVerifiedPersonalInformation(data);
+  const UserDataComponent = hasVerifiedData
+    ? VerifiedPersonalInformation
+    : BasicData;
   return (
     <Fragment>
       {data && (
         <Fragment>
-          <BasicData />
+          <UserDataComponent />
           <MultiItemEditor dataType="addresses" />
           <MultiItemEditor dataType="emails" />
           <MultiItemEditor dataType="phones" />

--- a/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
+++ b/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { IconCheckCircleFill } from 'hds-react';
 import classNames from 'classnames';
@@ -7,13 +7,13 @@ import styles from './VerifiedPersonalInformation.module.css';
 import commonFormStyles from '../../../common/cssHelpers/form.module.css';
 import LabeledValue from '../../../common/labeledValue/LabeledValue';
 import ProfileSection from '../../../common/profileSection/ProfileSection';
+import { ProfileContext } from '../../context/ProfileContext';
 import getCountry from '../../helpers/getCountry';
-import getVerifiedPersonalInformation from '../../helpers/getVerifiedPersonalInformation';
 import {
-  MyProfileQuery,
-  MyProfileQuery_myProfile_verifiedPersonalInformation_permanentAddress as PermanentAddress,
-  MyProfileQuery_myProfile_verifiedPersonalInformation_permanentForeignAddress as PermanentForeignAddress,
-} from '../../../graphql/generatedTypes';
+  PermanentForeignAddress,
+  PermanentAddress,
+} from '../../../graphql/typings';
+import getVerifiedPersonalInformation from '../../helpers/getVerifiedPersonalInformation';
 
 type CommonAddress = {
   streetAddress: PermanentAddress['streetAddress'];
@@ -24,19 +24,13 @@ type CommonAddress = {
   __typename: string;
 };
 
-type VPIProps = {
-  data: MyProfileQuery;
-};
-
 type AddressProps = {
   type: 'permanent' | 'temporary' | 'foreign';
   address: CommonAddress;
 };
 
-function VerifiedPersonalInformation(
-  vpiProps: VPIProps
-): React.ReactElement | null {
-  const { data } = vpiProps;
+function VerifiedPersonalInformation(): React.ReactElement | null {
+  const { data } = useContext(ProfileContext);
 
   const { t, i18n } = useTranslation();
   const lang = i18n.languages[0];
@@ -141,7 +135,7 @@ function VerifiedPersonalInformation(
     <ProfileSection hasVerifiedUserData>
       <h3
         className={commonFormStyles.sectionTitle}
-        aria-label={t('personalInformation.verifiedBasicData')}
+        aria-label={t('profileInformation.verifiedBasicData')}
       >
         {t('profileForm.basicData')}
       </h3>


### PR DESCRIPTION
The branch merged to develop did not use VPI component. Copied it from the previous branch used in 'dev' and 'test'-servers.

Also removed 'subscriptions' from App.tsx. It was brought back in merge and previously removed in HP-548.