### PR TITLE
HP-819: add municipality of residence and patch UI

### DIFF
--- a/src/common/header/userDropdown/UserDropdown.tsx
+++ b/src/common/header/userDropdown/UserDropdown.tsx
@@ -10,7 +10,7 @@ type UserDataWithActions = {
   userName: string;
   label: string;
   ariaLabel: string;
-  onClick: (e: React.MouseEvent) => Promise<void>;
+  onClick: (e?: React.MouseEvent) => Promise<void>;
 };
 
 function UserDropdown(): React.ReactElement {
@@ -24,8 +24,8 @@ function UserDropdown(): React.ReactElement {
     // eslint-disable-next-line no-shadow
     const name = getName(true);
 
-    const logoutAction = (e: React.MouseEvent): Promise<void> => {
-      e.preventDefault();
+    const logoutAction = (e?: React.MouseEvent): Promise<void> => {
+      e && e.preventDefault();
       trackEvent({ category: 'action', action: 'Log out' });
       return authService.logout();
     };
@@ -61,21 +61,17 @@ function UserDropdown(): React.ReactElement {
     <Navigation.User
       authenticated={isAuthenticated}
       label={label}
-      onSignIn={(): Promise<void> => authService.login()}
+      onSignIn={(): Promise<void> => onClick()}
       userName={userName}
       buttonAriaLabel={label}
+      id="header-user-dropdown"
     >
-      <Navigation.Item
-        label={userName}
-        href="/"
-        target="_blank"
-        variant="primary"
-      />
       <Navigation.Item
         onClick={(e: React.MouseEvent): Promise<void> => onClick(e)}
         variant="secondary"
         label={label}
         href="/logout"
+        data-testid="header-logout-button"
         icon={<IconSignout aria-hidden />}
       />
     </Navigation.User>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -127,7 +127,7 @@
     "email": "Email",
     "firstName": "First name",
     "givenName": "Given name",
-    "language": "Profile language",
+    "language": "EN: Asiointikieli",
     "lastName": "Last name",
     "makeAddressPrimary": "Change to your primary address",
     "makeEmailPrimary": "Change to your primary email address",
@@ -143,7 +143,8 @@
     "terms": "I have read <0>file description</0> and  city's <1>data protection principles</1>",
     "termsDataProtectionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf",
-    "nationalIdentificationNumber": "EN: Henkilötunnus"
+    "nationalIdentificationNumber": "EN: Henkilötunnus",
+    "municipalityOfResidence": "EN: Kotikunta"
   },
   "profileInformation": {
     "address": "Address",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -127,7 +127,7 @@
     "email": "Sähköpostiosoite",
     "firstName": "Etunimi",
     "givenName": "Kutsumanimi",
-    "language": "Profiilin kieli",
+    "language": "Asiointikieli",
     "lastName": "Sukunimi",
     "makeAddressPrimary": "Muuta ensisijaiseksi osoitteeksi",
     "makeEmailPrimary": "Muuta ensisijaiseksi sähköpostiosoitteeksi",
@@ -143,7 +143,8 @@
     "terms": "Olen tutustunut palvelun <0>rekisteriselosteeseen</0> ja kaupungin <1>tietosuojakäytäntöön</1> ",
     "termsDataProtectionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf",
-    "nationalIdentificationNumber": "Henkilötunnus"
+    "nationalIdentificationNumber": "Henkilötunnus",
+    "municipalityOfResidence": "Kotikunta"
   },
   "profileInformation": {
     "address": "Osoite",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -127,7 +127,7 @@
     "email": "Epost-adress",
     "firstName": "Förnamn",
     "givenName": "SV: Kutsumanimi",
-    "language": "Profilspråk",
+    "language": "SV: Asiointikieli",
     "lastName": "Efternamn",
     "makeAddressPrimary": "Ändra till din primära adress",
     "makeEmailPrimary": "Byt till din primära e-postadress",
@@ -143,7 +143,8 @@
     "terms": "Jag har läst filen <0>beskrivningen</0> och stads <1>sekretesspolicy</1>",
     "termsDataProtectionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd",
     "termsFileDescriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf",
-    "nationalIdentificationNumber": "SV: Henkilötunnus"
+    "nationalIdentificationNumber": "SV: Henkilötunnus",
+    "municipalityOfResidence": "SV: Kotikunta"
   },
   "profileInformation": {
     "address": "Adress",

--- a/src/profile/components/serviceConnections/ServiceConnections.module.css
+++ b/src/profile/components/serviceConnections/ServiceConnections.module.css
@@ -1,5 +1,5 @@
 .serviceConnections {
-  background: var(--color-black-5);
+  background: var(--color-black-ultra-light);
   flex: 1;
 }
 

--- a/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
+++ b/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
@@ -51,6 +51,7 @@ function VerifiedPersonalInformation(): React.ReactElement | null {
     temporaryAddress,
     permanentForeignAddress,
     nationalIdentificationNumber,
+    municipalityOfResidence,
   } = verifiedPersonalInformation;
 
   const AddressComponent = (props: AddressProps): React.ReactElement | null => {
@@ -159,6 +160,11 @@ function VerifiedPersonalInformation(): React.ReactElement | null {
         <LabeledValue
           label={t('profileForm.nationalIdentificationNumber')}
           value={nationalIdentificationNumber}
+          verifiedInfoText={verifiedInfoText}
+        />
+        <LabeledValue
+          label={t('profileForm.municipalityOfResidence')}
+          value={municipalityOfResidence}
           verifiedInfoText={verifiedInfoText}
         />
       </div>


### PR DESCRIPTION
Added municipality of residence to verified personal information and translation for it.

Changed translation used with language selection.

Fixed bg color in Service connections.

Added test ids to user dropdown and logout.

Removed useless link in user dropdown.