### PR TITLE
HP-836: optimize graphql queries

### DIFF
--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -14,7 +14,7 @@ export const API_TOKEN = 'apiToken';
 
 export class AuthService {
   userManager: UserManager;
-
+  private _isProcessingLogin = false;
   constructor() {
     const settings: UserManagerSettings = {
       automaticSilentRenew: true,
@@ -61,7 +61,9 @@ export class AuthService {
     });
 
     this.userManager.events.addUserLoaded(async user => {
-      this.fetchApiToken(user);
+      if (!this._isProcessingLogin) {
+        this.fetchApiToken(user);
+      }
     });
   }
 
@@ -95,10 +97,11 @@ export class AuthService {
   }
 
   public async endLogin(): Promise<User> {
+    this._isProcessingLogin = true;
     const user = await this.userManager.signinRedirectCallback();
 
     await this.fetchApiToken(user);
-
+    this._isProcessingLogin = false;
     return user;
   }
 

--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useRef } from 'react';
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
 import {
   Button,
   Card,
@@ -15,6 +15,7 @@ type Props = PropsWithChildren<{
   showInformationText?: boolean;
   initiallyOpen: boolean;
   scrollIntoViewOnMount?: boolean;
+  onChange?: (isOpen: boolean) => void;
 }>;
 
 function ExpandingPanel({
@@ -23,6 +24,7 @@ function ExpandingPanel({
   showInformationText,
   scrollIntoViewOnMount,
   title,
+  onChange,
 }: Props): React.ReactElement {
   const container = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
@@ -40,6 +42,11 @@ function ExpandingPanel({
   const { isOpen, buttonProps, contentProps } = useAccordion({
     initiallyOpen,
   });
+  useEffect(() => {
+    if (onChange) {
+      onChange(isOpen);
+    }
+  }, [isOpen, onChange]);
   const Icon = isOpen ? IconAngleUp : IconAngleDown;
   const buttonText = isOpen
     ? t('expandingPanel.hideInformation')

--- a/src/gdprApi/useDeleteProfile.ts
+++ b/src/gdprApi/useDeleteProfile.ts
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
-  useQuery,
   useMutation,
   MutationHookOptions,
   MutationResult,
+  useLazyQuery,
 } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
@@ -26,7 +26,6 @@ function useDeleteProfile(
     GdprDeleteMyProfileMutationVariables
   >
 ): [() => void, MutationResult<GdprDeleteMyProfileMutation>] {
-  const { data } = useQuery<GdprServiceConnectionsRoot>(SERVICE_CONNECTIONS);
   const [deleteProfile, queryResult] = useMutation<
     GdprDeleteMyProfileMutation,
     GdprDeleteMyProfileMutationVariables
@@ -54,18 +53,31 @@ function useDeleteProfile(
     handleAuthorizationCodeCallback
   );
 
-  const handleDownloadActionInitialization = React.useCallback(() => {
-    const deleteScopes = getDeleteScopes(data);
+  const handleDownloadActionInitialization = React.useCallback(
+    serviceConnectionsResult => {
+      const deleteScopes = getDeleteScopes(serviceConnectionsResult);
 
-    startFetchingAuthorizationCode(deleteScopes);
-  }, [data, startFetchingAuthorizationCode]);
+      startFetchingAuthorizationCode(deleteScopes);
+    },
+    [startFetchingAuthorizationCode]
+  );
+
+  const [getServiceConnections] = useLazyQuery<GdprServiceConnectionsRoot>(
+    SERVICE_CONNECTIONS,
+    {
+      fetchPolicy: 'no-cache',
+      onCompleted: data => {
+        handleDownloadActionInitialization(data);
+      },
+    }
+  );
 
   const injectedMutationResult = {
     ...queryResult,
     loading: isAuthorizing || queryResult.loading,
   };
 
-  return [handleDownloadActionInitialization, injectedMutationResult];
+  return [getServiceConnections, injectedMutationResult];
 }
 
 export default useDeleteProfile;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,7 +36,8 @@
     "accept": "I understand what deleting my data means and wish to proceed.",
     "delete": "Delete my information",
     "explanation": "If you want to, you can delete all information we have stored about you. The information cannot be restored after it has been deleted. If you have connected your profile to one of the services of the City of Helsinki, you can no longer use the service until you create a new profile. After deleting you will be automatically logged out of this service. Note that the account you have used to log in (for example Google or Facebook) will not be deleted.",
-    "title": "Do you want to delete your information?"
+    "title": "Do you want to delete your information?",
+    "loadingServices": "EN: Haetaan profiiliin yhdistettyjä palveluita"
   },
   "deleteProfileModal": {
     "delete": "Delete my information",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -36,7 +36,8 @@
     "accept": "Ymmärrän mitä tietojeni poistaminen tarkoittaa ja haluan jatkaa.",
     "delete": "Poista omat tiedot",
     "explanation": "Jos haluat, voit poistaa kaikki sinusta tallentamamme tiedot. Tietoja ei voi palauttaa sen jälkeen, kun ne on poistettu. Jos olet yhdistänyt profiilisi johonkin Helsingin kaupungin palveluun, et enää pysty käyttämään kyseistä palvelua ennen kuin luot uuden profiilin. Poistamisen jälkeen sinut kirjataan automaattisesti ulos tästä palvelusta. Huomaa, että kirjautumiseen käyttämääsi tiliä (esim. Google, Facebook) ei poisteta.",
-    "title": "Haluatko poistaa omat tietosi?"
+    "title": "Haluatko poistaa omat tietosi?",
+    "loadingServices": "Haetaan profiiliin yhdistettyjä palveluita"
   },
   "deleteProfileModal": {
     "delete": "Poista omat tiedot",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -36,7 +36,8 @@
     "accept": "Jag förstår vad att radera min information betyder och vill fortsätta.",
     "delete": "Radera min information",
     "explanation": "Om du vill, kan du radera all information som vi har lagrat om dig. Informationen kan inte återställas efter att den har raderats. Om du har anslutit din profil till en av Helsingfors stads tjänster kan du inte längre använda tjänsten förrän du skapar en ny profil. Efter radering kommer du automatiskt att logga ut från den här tjänsten. Observera att kontot du har använt för att logga in (till exempel Google eller Facebook) inte kommer att raderas.",
-    "title": "Vill du radera din information?"
+    "title": "Vill du radera din information?",
+    "loadingServices": "SV: Haetaan profiiliin yhdistettyjä palveluita"
   },
   "deleteProfileModal": {
     "delete": "Radera min information",
@@ -65,8 +66,8 @@
   "landmarks": {
     "navigation": {
       "language": "Språk: Svenska. Ändra språk. Vaihda kieli. Change language.",
-      "main": "",
-      "user": ""
+      "main": "SV: Pää",
+      "user": "SV: Käyttäjä"
     }
   },
   "LANGUAGE_OPTIONS": {
@@ -174,7 +175,7 @@
     "permanentForeignAddress": "SV: Vakinainen ulkomainen osoite",
     "primaryEmail": "SV: Ensisijainen sähköpostiosoite",
     "primaryPhone": "SV: Ensisijainen puhelinnumero",
-    "primaryAddressAriaDescription": "SV :Tämä on ensisijainen osoitteesi",
+    "primaryAddressAriaDescription": "SV: Tämä on ensisijainen osoitteesi",
     "primaryEmailAriaDescription": "SV: Tämä on ensisijainen sähköpostiosoitteesi",
     "primaryPhoneAriaDescription": "SV: Tämä on ensisijainen puhelinnumerosi",
     "verifiedDataInformationPrefix": "SV: Merkityt",

--- a/src/profile/components/deleteProfile/deleteProfile.module.css
+++ b/src/profile/components/deleteProfile/deleteProfile.module.css
@@ -1,3 +1,14 @@
 .button {
   margin-top: var(--spacing-m);
 }
+
+.loading-info {
+  display: flex;
+  align-items: center;
+  margin: var(--spacing-xs) 0;
+}
+
+.loading-info p {
+  margin: 0;
+  padding-left: var(--spacing-m);
+}

--- a/src/profile/components/modals/deleteProfileContent/DeleteProfileContent.tsx
+++ b/src/profile/components/modals/deleteProfileContent/DeleteProfileContent.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { ServiceConnectionsRoot } from '../../../../graphql/typings';
 import getServices from '../../../helpers/getServices';
 
 export type Props = {
-  description: string;
   data?: ServiceConnectionsRoot;
 };
 
-function DeleteProfileContent({
-  data,
-  description,
-}: Props): React.ReactElement | null {
+function DeleteProfileContent({ data }: Props): React.ReactElement | null {
+  const { t } = useTranslation();
   const servicesArray = getServices(data);
+  const description =
+    data?.myProfile?.serviceConnections?.edges?.length !== 0
+      ? t('deleteProfileModal.explanation')
+      : t('deleteProfileModal.noServiceExplanation');
   return (
     <>
       <p>{description}</p>

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -57,12 +57,11 @@ function Profile(): React.ReactElement {
     authService
       .getUser()
       .then(user => {
-        if (!user || user.expired) {
+        if (!authService.isAuthenticatedUser(user)) {
           return history.push('/login');
         }
-
         checkProfileExists();
-        setTunnistamoUser(user);
+        setTunnistamoUser(user as User);
         setIsCheckingAuthState(false);
         return undefined;
       })

--- a/src/profile/components/profile/__tests__/Profile.test.tsx
+++ b/src/profile/components/profile/__tests__/Profile.test.tsx
@@ -37,7 +37,10 @@ describe('<Profile />', () => {
   };
 
   const mockUser = (): void => {
-    const user = ({ profile: { name: 'Mock User' } } as unknown) as User;
+    const user = ({
+      profile: { name: 'Mock User' },
+      access_token: 'huuhaa',
+    } as unknown) as User;
     const userManager = authService.userManager;
     jest.spyOn(userManager, 'getUser').mockResolvedValueOnce(user);
   };


### PR DESCRIPTION
When users navigate to their profile page, the page loads
- ProfileExistsQuery
- MyProfileQuery
and also
- ServiceConnectionsQuery
- GdprServiceConnectionsQuery 

Neither ServiceConnectionQuery is required when profile is shown. Loading started, because DeleteProfile ja DownloadProfile components used useQuery-hooks instead of useLazyQuery. 

DeleteProfile requires ServiceConnections to be loaded so the UI can show correct information before deleting the profile. Had to add a loader and load indicator. Now the UI loads the connections first and then shows proper warnings. 

DownloadProfile won't show any additional data to user, so lazy query was easy to add there.