### PR TITLE
HP-879 session polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hds-core": "1.1.0",
     "hds-design-tokens": "1.1.0",
     "hds-react": "1.1.0",
+    "http-status-typed": "^1.0.0",
     "i18n-iso-countries": "^6.8.0",
     "i18next": "^20.3.2",
     "i18next-browser-languagedetector": "^6.1.2",

--- a/src/auth/__mocks__/http-poller.ts
+++ b/src/auth/__mocks__/http-poller.ts
@@ -1,0 +1,42 @@
+import { HttpPoller, HttpPollerProps } from '../http-poller';
+
+type MockHttpPollerData = {
+  start: jest.Mock;
+  stop: jest.Mock;
+  props?: HttpPollerProps;
+};
+
+type GlobalWithPollerData = {
+  mockHttpPoller: MockHttpPollerData;
+};
+
+const globalWithPollerData = (global as unknown) as GlobalWithPollerData;
+
+if (!globalWithPollerData.mockHttpPoller) {
+  globalWithPollerData.mockHttpPoller = {
+    start: jest.fn(),
+    stop: jest.fn(),
+    props: undefined,
+  };
+}
+const { mockHttpPoller } = globalWithPollerData;
+
+export function getHttpPollerMockData(): MockHttpPollerData {
+  return mockHttpPoller;
+}
+
+export default function createHttpPoller(
+  pollerProps: HttpPollerProps
+): HttpPoller {
+  mockHttpPoller.start.mockReset();
+  mockHttpPoller.stop.mockReset();
+  mockHttpPoller.props = pollerProps;
+  return {
+    start: () => {
+      mockHttpPoller.start();
+    },
+    stop: () => {
+      mockHttpPoller.stop();
+    },
+  };
+}

--- a/src/auth/__tests__/http-poller.test.ts
+++ b/src/auth/__tests__/http-poller.test.ts
@@ -1,0 +1,196 @@
+import HttpStatusCode from 'http-status-typed';
+
+import createHttpPoller, { HttpPoller } from '../http-poller';
+
+type TestProps = {
+  requestResponse: {
+    status: HttpStatusCode.OK | HttpStatusCode.FORBIDDEN | -1;
+  };
+  onErrorReturnValue: { keepPolling: boolean };
+  shouldPollReturnValue: boolean;
+  maxPollCount: number;
+};
+
+jest.unmock('../http-poller');
+
+describe(`http-poller`, () => {
+  const pollFunctionMockCallback = jest.fn();
+  const onErrorMockCallback = jest.fn();
+  const shouldPollMockCallback = jest.fn();
+  const loadCallTracker = jest.fn();
+  const intervalInMs = 200;
+  let poller: HttpPoller;
+  const pollerDefaultTestProps: TestProps = {
+    requestResponse: { status: HttpStatusCode.OK },
+    onErrorReturnValue: { keepPolling: true },
+    shouldPollReturnValue: true,
+    maxPollCount: 0,
+  };
+  function createPoller(responses: TestProps): HttpPoller {
+    let pollCount = 0;
+    return createHttpPoller({
+      pollFunction: async () => {
+        pollFunctionMockCallback();
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            loadCallTracker();
+            if (responses.requestResponse.status === -1) {
+              reject(new Error('An error'));
+            } else {
+              resolve(responses.requestResponse as Response);
+            }
+          }, intervalInMs * 2);
+        });
+      },
+      onError: returnedHttpStatus => {
+        onErrorMockCallback(returnedHttpStatus);
+        return responses.onErrorReturnValue;
+      },
+      shouldPoll: () => {
+        shouldPollMockCallback();
+        if (responses.maxPollCount > 0 && pollCount >= responses.maxPollCount) {
+          return false;
+        }
+        pollCount += 1;
+        return responses.shouldPollReturnValue;
+      },
+      pollIntervalInMs: intervalInMs,
+    });
+  }
+  const advanceOneInterval = async () => {
+    jest.advanceTimersByTime(intervalInMs + 1);
+  };
+  const advanceToTimerEnd = async () => {
+    await advanceOneInterval();
+  };
+  const advanceFromTimerEndToLoadEnd = async () => {
+    await advanceOneInterval();
+    await advanceOneInterval();
+    // https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+    await new Promise(resolve => setImmediate(resolve));
+  };
+  const advanceFromStartTimerToLoadEnd = async () => {
+    await advanceToTimerEnd();
+    await advanceFromTimerEndToLoadEnd();
+  };
+  const advanceFromTimerEndToNextTimerEnd = async () => {
+    await advanceFromTimerEndToLoadEnd();
+    await advanceToTimerEnd();
+  };
+  afterEach(() => {
+    poller.stop();
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  describe('Calling start() starts the timer and when timer ends ', () => {
+    it('the pollFunction and shouldPoll have been called continuously', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+      });
+      poller.start();
+      expect(shouldPollMockCallback).not.toBeCalled();
+      expect(pollFunctionMockCallback).not.toBeCalled();
+      expect(onErrorMockCallback).not.toBeCalled();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      await advanceFromTimerEndToNextTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(2);
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+    });
+    it('the pollFunction should not be called if shouldPoll returns false', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        shouldPollReturnValue: false,
+      });
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+    });
+    it(`the onError is called with responseStatus when response status is not httpStatus.OK (200). 
+        Polling continues when onError returns {keepPolling : true}`, async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN },
+      });
+      poller.start();
+      await advanceFromStartTimerToLoadEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toBeCalledWith(HttpStatusCode.FORBIDDEN);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+    });
+    it(`the onError is called also on network error 
+        and polling stops after error when onError returns {keepPolling : false}`, async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: -1 },
+        onErrorReturnValue: { keepPolling: false },
+      });
+      poller.start();
+      await advanceFromStartTimerToLoadEnd();
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toBeCalledWith(undefined);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+    });
+    it('Polling never starts if poller.stop is called', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+      });
+      poller.start();
+      poller.stop();
+      await advanceFromStartTimerToLoadEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(0);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+      expect(loadCallTracker).toHaveBeenCalledTimes(0);
+    });
+    it('Response is ignored if poller.stop is called after load has started', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN },
+      });
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      poller.stop();
+      await advanceFromTimerEndToLoadEnd();
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+    });
+    it('Multiple starts do not start multiple requests', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN },
+      });
+      poller.start();
+      poller.start();
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      poller.stop();
+      await advanceFromTimerEndToLoadEnd();
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/auth/http-poller.ts
+++ b/src/auth/http-poller.ts
@@ -1,0 +1,84 @@
+import to from 'await-to-js';
+import HttpStatusCode from 'http-status-typed';
+
+export type HttpPoller = {
+  start: () => void;
+  stop: () => void;
+};
+
+export type HttpPollerProps = {
+  pollFunction: () => Promise<Response | undefined>;
+  shouldPoll: () => boolean;
+  onError: (returnedHttpStatus?: number) => { keepPolling: boolean };
+  pollIntervalInMs?: number;
+};
+
+const defaultPollIntervalInMs = 60000;
+
+export default function createHttpPoller({
+  pollFunction,
+  shouldPoll,
+  onError,
+  pollIntervalInMs = defaultPollIntervalInMs,
+}: HttpPollerProps): HttpPoller {
+  let isPolling = false;
+  let isForceStopped = false;
+  let pollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const load = async (): Promise<[Error | null, Response | undefined]> => {
+    isPolling = true;
+    const result = await to(pollFunction());
+    isPolling = false;
+    return result;
+  };
+
+  const shouldCallPollFunction = (): boolean => {
+    if (isPolling) {
+      return false;
+    }
+    return shouldPoll();
+  };
+
+  const startTimer = () => {
+    if (pollTimeoutId) {
+      clearTimeout(pollTimeoutId);
+    }
+    pollTimeoutId = setTimeout(() => {
+      pollTimeoutId = undefined;
+      if (!shouldCallPollFunction()) {
+        startTimer();
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      pollAndHandleResult();
+    }, pollIntervalInMs);
+  };
+
+  const pollAndHandleResult = async (): Promise<void> => {
+    const [err, data] = await load();
+    if (isForceStopped) {
+      return;
+    }
+    const responseStatus = data && data.status;
+    const isErrorResponse = responseStatus !== HttpStatusCode.OK;
+    if ((!err && !isErrorResponse) || onError(responseStatus).keepPolling) {
+      startTimer();
+    }
+  };
+
+  const stop = () => {
+    if (pollTimeoutId) {
+      clearTimeout(pollTimeoutId);
+      pollTimeoutId = undefined;
+    }
+    isForceStopped = true;
+  };
+
+  return {
+    start: () => {
+      isForceStopped = false;
+      startTimer();
+    },
+    stop,
+  };
+}

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -55,11 +55,8 @@ function Profile(): React.ReactElement {
 
   useEffect(() => {
     authService
-      .getUser()
+      .getAuthenticatedUser()
       .then(user => {
-        if (!authService.isAuthenticatedUser(user)) {
-          return history.push('/login');
-        }
         checkProfileExists();
         setTunnistamoUser(user as User);
         setIsCheckingAuthState(false);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -19,3 +19,5 @@ jest.mock('react-router', () => ({
     pathname: '/',
   }),
 }));
+
+jest.mock('./auth/http-poller');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7375,6 +7375,11 @@ http-proxy@^1.17.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
+http-status-typed@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-status-typed/-/http-status-typed-1.0.0.tgz#2dbf0a036a7c5e4c0447fa22bc8f42f0221b9481"
+  integrity sha512-pDW3/qUMd9IRxJ7WLizQbD2EY6qp/Zf5FB96gIbNoz9QuxdY5LAEl/z4eNQX2p/cKYKngaUNTqmQ1XgLwi/bhg==
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
Same polling system that was added first to Example UI.

Same files:
- http-poller
- __mocks__/http-poller

Polling is controller by authService, which does not exist in Example U, so it's new code. Polling is bound to events triggered by the oidc-client. It is also started when UI is loaded and a valid user exists in session storage.

Testing can be done by starting Profile UI locally and logging in to Profile UI (dev) or Example UI (dev) with same user. And then logout from dev UI.  Change poll interval to 5000ms or wait 60 secs for polling to check user.