### PR TITLE
HP-975: 404 page not found

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import GdprAuthorizationCodeManagerCallback from './gdprApi/GdprAuthorizationCod
 import ToastProvider from './toast/ToastProvider';
 import authService from './auth/authService';
 import config from './config';
+import PageNotFound from './common/pageNotFound/PageNotFound';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -70,7 +71,9 @@ function App(): React.ReactElement {
                 <ErrorPage />
               </Route>
               <Route path="/loginsso" exact />
-              <Route path="*">404 - not found</Route>
+              <Route path="*">
+                <PageNotFound />
+              </Route>
             </Switch>
           </ProfileProvider>
         </MatomoProvider>

--- a/src/common/pageNotFound/PageNotFound.tsx
+++ b/src/common/pageNotFound/PageNotFound.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ErrorPage from '../../profile/components/errorPage/ErrorPage';
+
+function PageNotFound(): React.ReactElement {
+  const { t } = useTranslation();
+
+  const content = {
+    title: t('pageNotFoundTitle'),
+    message: t('pageNotFoundText'),
+    hideLoginButton: true,
+    hideFrontPageLink: false,
+  };
+  return <ErrorPage content={content} />;
+}
+
+export default PageNotFound;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -236,5 +236,7 @@
   },
   "opensInNewWindow": "{{title}}. Opens in a new window.",
   "accessibilityStatement": "Accessibility Statement",
-  "cityOfHelsinki": "City of Helsinki"
+  "cityOfHelsinki": "City of Helsinki",
+  "pageNotFoundTitle": "Page not found",
+  "pageNotFoundText": "EN: Tarkista URL-osoitteen oikeinkirjoitus (tarkista isot ja pienet kirjaimet sekä välimerkit). Tai palaa edelliselle sivulle napsauttamalla selaimen Edellinen-painiketta. Voit mennä myös etusivulle alla olevasta linkistä."
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -236,5 +236,7 @@
   },
   "opensInNewWindow": "{{title}}. Avautuu uudessa ikkunassa.",
   "accessibilityStatement": "Saavutettavuusseloste",
-  "cityOfHelsinki": "Helsingin kaupunki"
+  "cityOfHelsinki": "Helsingin kaupunki",
+  "pageNotFoundTitle": "Sivua ei löytynyt",
+  "pageNotFoundText": "Tarkista URL-osoitteen oikeinkirjoitus (tarkista isot ja pienet kirjaimet sekä välimerkit). Tai palaa edelliselle sivulle napsauttamalla selaimen Edellinen-painiketta. Voit mennä myös etusivulle alla olevasta linkistä."
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -236,5 +236,7 @@
   },
   "opensInNewWindow": "{{title}}. Öppnas i ett nytt fönster.",
   "accessibilityStatement": "Tillgänglighetsutlåtande",
-  "cityOfHelsinki": "Helsingfors stad"
+  "cityOfHelsinki": "Helsingfors stad",
+  "pageNotFoundTitle": "SV: Sivua ei löytynyt",
+  "pageNotFoundText": "SV: Tarkista URL-osoitteen oikeinkirjoitus (tarkista isot ja pienet kirjaimet sekä välimerkit). Tai palaa edelliselle sivulle napsauttamalla selaimen Edellinen-painiketta. Voit mennä myös etusivulle alla olevasta linkistä."
 }

--- a/src/profile/components/errorPage/ErrorPage.tsx
+++ b/src/profile/components/errorPage/ErrorPage.tsx
@@ -16,15 +16,45 @@ export type ErrorPageQueryParams = {
   hideFrontPageLink?: string;
 };
 
-function ErrorPage(): React.ReactElement {
+export type ErrorPageContent = {
+  message?: string;
+  title?: string;
+  hideLoginButton: boolean;
+  hideFrontPageLink: boolean;
+};
+
+type ErrorPageProps = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  content?: ErrorPageContent;
+};
+
+function ErrorPage(props?: ErrorPageProps): React.ReactElement {
   const { t } = useTranslation();
   const location = useLocation();
+
+  const getContentFromPropsOrUrl = (
+    pageProps?: ErrorPageProps
+  ): ErrorPageContent => {
+    if (pageProps && pageProps.content) {
+      return pageProps.content;
+    }
+    const contentFromUrl = queryParamsToObject<ErrorPageQueryParams>(
+      location.search
+    );
+    return {
+      message: contentFromUrl.message,
+      title: contentFromUrl.title,
+      hideLoginButton: contentFromUrl.hideLoginButton !== undefined,
+      hideFrontPageLink: contentFromUrl.hideFrontPageLink !== undefined,
+    };
+  };
+
   const {
     message,
     title,
     hideLoginButton,
     hideFrontPageLink,
-  } = queryParamsToObject<ErrorPageQueryParams>(location.search);
+  } = getContentFromPropsOrUrl(props);
   const notificationMessage = message || t('notification.defaultErrorText');
   const notificationTitle = title || t('notification.defaultErrorTitle');
   const isAuthenticated = authService.isAuthenticated();
@@ -38,7 +68,7 @@ function ErrorPage(): React.ReactElement {
           dataTestId={'error-page-notification'}
         >
           <p>{notificationMessage}</p>
-          {hideFrontPageLink === undefined && (
+          {hideFrontPageLink !== true && (
             <p>
               <Link to="/" data-testid={'error-page-frontpage-link'}>
                 {t('nav.goToHomePage')}
@@ -47,7 +77,7 @@ function ErrorPage(): React.ReactElement {
           )}
         </Notification>
         <div className={styles.buttons}>
-          {hideLoginButton === undefined && !isAuthenticated && (
+          {hideLoginButton !== true && !isAuthenticated && (
             <Button
               onClick={() => authService.login()}
               data-testid={'error-page-login-button'}


### PR DESCRIPTION
Modified the ErrorPage component, so it can be used as a 404 error page too.