### PR TITLE
HP-1001: Fix error handling in profile api fetch

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,7 +111,9 @@
     "authenticating": "Authenticating..."
   },
   "profile": {
-    "loading": "Loading profile..."
+    "loading": "Loading profile...",
+    "loadErrorText": "EN: Profiilin haku epäonnistui! Yritä hakea uudelleen tai kirjaudu ulos.",
+    "reload": "Retry"
   },
   "profileDeleted": {
     "message": "You can recreate it later if you want. You will be logged out after {{time}} seconds.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -111,7 +111,9 @@
     "authenticating": "Tunnistaudutaan..."
   },
   "profile": {
-    "loading": "Ladataan profiilia..."
+    "loading": "Ladataan profiilia...",
+    "loadErrorText": "Profiilin haku epäonnistui! Yritä hakea uudelleen tai kirjaudu ulos.",
+    "reload": "Hae uudelleen"
   },
   "profileDeleted": {
     "message": "Jos haluat, voit luoda profiilisi uudestaan myöhemmin. Sinut kirjataan ulos {{time}} sekunnin kuluttua.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -111,7 +111,9 @@
     "authenticating": "Autentiserar..."
   },
   "profile": {
-    "loading": "Laddar profil..."
+    "loading": "Laddar profil...",
+    "loadErrorText": "SV: Profiilin haku epäonnistui! Yritä hakea uudelleen tai kirjaudu ulos.",
+    "reload": "SV: Hae uudelleen"
   },
   "profileDeleted": {
     "message": "Du kan återskapa det senare om du vill. Du kommer att loggas ut efter {{time}} sekunder.",

--- a/src/profile/components/profile/Profile.module.css
+++ b/src/profile/components/profile/Profile.module.css
@@ -6,5 +6,15 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-top: var(--spacing-l);
+  padding: var(--spacing-l) 0;
+}
+
+.error-button-wrapper {
+  display: flex;
+  flex-direction: row;
+  padding: var(--spacing-m) 0;
+}
+
+.error-button-wrapper > * {
+  margin-right: var(--spacing-m);
 }

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -5,6 +5,7 @@ import { useHistory, useLocation } from 'react-router';
 import { loader } from 'graphql.macro';
 import { User } from 'oidc-client';
 import * as Sentry from '@sentry/browser';
+import { Button } from 'hds-react';
 
 import Notification from '../../../common/copyOfHDSNotification/Notification';
 import PageLayout from '../../../common/pageLayout/PageLayout';
@@ -67,7 +68,8 @@ function Profile(): React.ReactElement {
 
   const isDoingProfileChecks = isCheckingAuthState || loading;
   const isProfileFound = !!(data && data.myProfile);
-  const hasGraphQLError = !!(error && error.graphQLErrors.length);
+  const failedToFetchUserProfileData =
+    tunnistamoUser && !isProfileFound && !!error;
   if (isProfileFound && !isProfileInitialized) {
     fetchProfile();
   }
@@ -87,18 +89,35 @@ function Profile(): React.ReactElement {
         return 'appName';
     }
   };
-
-  if (!isProfileFound && tunnistamoUser && hasGraphQLError) {
+  if (failedToFetchUserProfileData) {
     return (
-      <PageLayout title={getPageTitle()} data-testid="profile-error-layout">
-        <div className={styles['error-wrapper']}>
+      <PageLayout title={'notification.defaultErrorTitle'}>
+        <div
+          className={styles['error-wrapper']}
+          data-testid="profile-check-error-layout"
+        >
           <div className={responsive['max-width-centered']}>
             <Notification
               type={'error'}
               label={t('notification.defaultErrorTitle')}
             >
-              {t('notification.defaultErrorText')}
+              {t('profile.loadErrorText')}
             </Notification>
+            <div className={styles['error-button-wrapper']}>
+              <Button
+                onClick={() => checkProfileExists()}
+                data-testid={'profile-check-error-reload-button'}
+              >
+                {t('profile.reload')}
+              </Button>
+              <Button
+                onClick={() => authService.logout()}
+                data-testid={'profile-check-error-logout-button'}
+                variant={'secondary'}
+              >
+                {t('nav.signout')}
+              </Button>
+            </div>
           </div>
         </div>
       </PageLayout>

--- a/src/profile/components/profile/__tests__/Profile.test.tsx
+++ b/src/profile/components/profile/__tests__/Profile.test.tsx
@@ -99,4 +99,27 @@ describe('<Profile />', () => {
       await waitForElement({ testId: 'mock-toast-type-error' });
     });
   });
+  it('should render an error notification when PROFILE_EXISTS query fails', async () => {
+    const responses: MockedResponse[] = [{ errorType: 'networkError' }];
+    mockUser();
+    await act(async () => {
+      const { waitForElement } = await renderTestSuite(responses);
+      await waitForElement({ testId: 'profile-check-error-layout' });
+    });
+  });
+  it('should retry PROFILE_EXISTS query when reload button is clicked', async () => {
+    // two responses for PROFILE_EXISTS and one for MY_PROFILE_QUERY error
+    const responses: MockedResponse[] = [
+      { errorType: 'networkError' },
+      { profileData: getMyProfile().myProfile as ProfileData },
+      { profileData: getMyProfile().myProfile as ProfileData },
+    ];
+    mockUser();
+    await act(async () => {
+      const { waitForElement, clickElement } = await renderTestSuite(responses);
+      await waitForElement({ testId: 'profile-check-error-layout' });
+      await clickElement({ testId: 'profile-check-error-reload-button' });
+      await waitForElement({ testId: 'view-profile-heading' });
+    });
+  });
 });


### PR DESCRIPTION
Error handling was incorrect when api returned any other error than graphQL error

API does not return an error when a profile does not exist, just an empty myProfile.

So if an error is returned, it is always fatal whether it is a graphQL or a network error.

Added better notfication for the user and buttons for retry and logout.