### PR TITLE
HP-993: Fix menu logout button in mobile

### DIFF
--- a/src/common/header/userDropdown/UserDropdown.tsx
+++ b/src/common/header/userDropdown/UserDropdown.tsx
@@ -68,7 +68,7 @@ function UserDropdown(): React.ReactElement {
     >
       <Navigation.Item
         onClick={(e: React.MouseEvent): Promise<void> => onClick(e)}
-        variant="secondary"
+        variant="supplementary"
         label={label}
         href="/logout"
         data-testid="header-logout-button"


### PR DESCRIPTION
 Changed the 'variant'-property to "supplementary" to hide button borders in mobile view. It is now consistent with HDS examples in StoryBook