### PR TITLE
HP-974: HDS font-sizes and colors

### DIFF
--- a/src/accessibilityStatement/AccessibilityStatement.module.css
+++ b/src/accessibilityStatement/AccessibilityStatement.module.css
@@ -20,28 +20,10 @@
   margin: var(--spacing-layout-2-xs) 0;
 }
 
-.inner-content h1 {
-  font-size: var(--fontsize-heading-m);
-  margin-top: 0;
-}
-
-.inner-content h2 {
-  margin-top: var(--spacing-layout-xs);
-  font-size: var(--fontsize-heading-s);
-}
-
 @media (min-width: 768px) {
   .inner-content {
     width: 768px;
     margin-left: auto;
     margin-right: auto;
-  }
-
-  .inner-content h1 {
-    font-size: var(--fontsize-heading-l);
-  }
-
-  .inner-content h2 {
-    font-size: var(--fontsize-heading-m);
   }
 }

--- a/src/auth/components/login/Login.module.css
+++ b/src/auth/components/login/Login.module.css
@@ -18,17 +18,13 @@
 button.button {
   margin-top: var(--spacing-layout-m);
 }
+
 .content h1 {
   margin-top: var(--common-top-spacing);
-  font-size: var(--fontsize-heading-m);
-}
-.content h2 {
-  line-height: var(--lineheight-l);
-  font-size: var(--fontsize-heading-xs);
 }
 
-@media (min-width: 768px) {
-  .content h1 {
-    font-size: var(--fontsize-heading-xl);
-  }
+.ingress {
+  line-height: var(--lineheight-l);
+  font-size: var(--fontsize-body-l);
+  font-weight: bold;
 }

--- a/src/auth/components/login/Login.tsx
+++ b/src/auth/components/login/Login.tsx
@@ -25,7 +25,7 @@ function Login(): React.ReactElement {
         >
           <HelsinkiLogo />
           <h1>{t('login.title')}</h1>
-          <h2>{t('login.description')}</h2>
+          <p className={styles.ingress}>{t('login.description')}</p>
           <Button
             variant="primary"
             className={styles.button}

--- a/src/common/cssHelpers/form.module.css
+++ b/src/common/cssHelpers/form.module.css
@@ -10,7 +10,7 @@
 }
 
 .section-title {
-  font-size: var(--fontsize-heading-s);
+  font-size: var(--h3-size);
   border-bottom: 1px solid var(--color-black-30);
   width: 100%;
   padding-bottom: var(--spacing-layout-2-xs);

--- a/src/common/expandingPanel/ExpandingPanel.module.css
+++ b/src/common/expandingPanel/ExpandingPanel.module.css
@@ -18,7 +18,7 @@
 
 .title h2 {
   margin: var(--ep-vertical-whitespace) 0;
-  font-size: var(--fontsize-heading-s);
+  font-size: var(--h3-size);
   color: var(--color-bus);
 }
 

--- a/src/common/explanation/Explanation.module.css
+++ b/src/common/explanation/Explanation.module.css
@@ -1,6 +1,4 @@
 .container {
-  --h2-fontsize: var(--fontsize-heading-l);
-  --h3-fontsize: var(--fontsize-heading-m);
   padding-bottom: var(--spacing-xl);
 }
 
@@ -8,31 +6,10 @@
   margin: 0 var(--content-horizontal-padding);
 }
 
-.main {
+.heading {
   margin-bottom: 30px;
 }
-.main.h2 {
-  font-size: var(--fontsize-heading-m);
-}
-.main.h3 {
-  font-size: var(--fontsize-heading-s);
-}
-.small {
+
+.text {
   margin-top: 0;
-  color: var(--color-black-70);
-  font-size: var(--fontsize-heading-s);
-}
-
-.small:last-child {
-  margin-bottom: 0;
-}
-
-@media (min-width: 450px) {
-  .main.h2 {
-    font-size: var(--fontsize-heading-l);
-  }
-
-  .main.h3 {
-    font-size: var(--fontsize-heading-m);
-  }
 }

--- a/src/common/explanation/Explanation.tsx
+++ b/src/common/explanation/Explanation.tsx
@@ -43,15 +43,8 @@ function Explanation({
         className
       )}
     >
-      <HeadingTagName
-        className={classNames(styles.main, {
-          [styles.h2]: titleVariant === 'h2',
-          [styles.h3]: titleVariant === 'h3',
-        })}
-      >
-        {main}
-      </HeadingTagName>
-      {small && <p className={styles.small}>{small}</p>}
+      <HeadingTagName className={styles.heading}>{main}</HeadingTagName>
+      {small && <p className={styles.text}>{small}</p>}
     </div>
   );
 }

--- a/src/common/footer/Footer.module.css
+++ b/src/common/footer/Footer.module.css
@@ -1,7 +1,3 @@
-.custom-theme.custom-theme {
-  --footer-background: #000;
-}
-
 .link-with-icon {
   display: inline-flex;
   align-items: center;

--- a/src/common/footer/Footer.tsx
+++ b/src/common/footer/Footer.tsx
@@ -20,12 +20,7 @@ function Footer(): React.ReactElement {
   };
 
   return (
-    <HDSFooter
-      theme="dark"
-      title={t('appName')}
-      logoLanguage={logoLanguage}
-      className={styles['custom-theme']}
-    >
+    <HDSFooter theme="dark" title={t('appName')} logoLanguage={logoLanguage}>
       <HDSFooter.Utilities backToTopLabel={t('footer.backToTop')}>
         <HDSFooter.Item
           href={t('footer.contactUsLink')}

--- a/src/common/pageHeading/PageHeading.module.css
+++ b/src/common/pageHeading/PageHeading.module.css
@@ -8,11 +8,6 @@
   text-align: center;
 }
 
-.page-heading h1 {
-  font-size: var(--fontsize-heading-m);
-  font-weight: bold;
-}
-
 .user-icon {
   width: 54px;
   height: 54px;
@@ -31,7 +26,6 @@
     margin-bottom: 0;
   }
   .page-heading h1 {
-    font-size: var(--fontsize-heading-xl);
     margin-left: var(--spacing-layout-xs);
   }
 }

--- a/src/common/profileSection/profileSection.module.css
+++ b/src/common/profileSection/profileSection.module.css
@@ -1,5 +1,6 @@
 .profile-section {
   --title-fontsize: var(--fontsize-heading-m);
+  --horizontal-whitespace: var(--spacing-m);
   background: var(--color-white);
   border-radius: 2px;
   padding: var(--spacing-l) var(--horizontal-whitespace);
@@ -14,7 +15,6 @@
 }
 
 .profile-section-title h1 {
-  font-size: var(--title-fontsize);
   margin-top: 0;
   margin-bottom: var(--spacing-s);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,19 @@
   text-rendering: optimizeLegibility;
 }
 
+main h1 {
+  font-size: var(--h1-size);
+}
+main h2 {
+  font-size: var(--h2-size);
+}
+main h3 {
+  font-size: var(--h3-size);
+}
+main h4 {
+  font-size: var(--h4-size);
+}
+
 :root {
   --soft-white: #fdfdfd;
   --font-helsinki-grotesk: 'HelsinkiGrotesk', Arial, -apple-system,
@@ -82,11 +95,19 @@
   --color-black-ultra-light: #fafafb;
   --common-top-spacing: var(--spacing-layout-s);
   --common-bottom-spacing: var(--spacing-layout-l);
+  --h1-size: var(--fontsize-heading-l);
+  --h2-size: var(--fontsize-heading-m);
+  --h3-size: var(--fontsize-heading-s);
+  --h4-size: var(--fontsize-heading-xs);
 }
 
 @media (min-width: 768px) {
   :root {
     --common-top-spacing: var(--spacing-layout-l);
     --common-bottom-spacing: var(--spacing-layout-xl);
+    --h1-size: var(--fontsize-heading-xl);
+    --h2-size: var(--fontsize-heading-l);
+    --h3-size: var(--fontsize-heading-m);
+    --h4-size: var(--fontsize-heading-s);
   }
 }


### PR DESCRIPTION
Use responsive heading font-sizes from HDS and remove "own" font sizes, weights and colors. Also changed some css class names that were not very informative (main, small).

Removed also background color override from footer.

Body text size is correct, so did not change those.