### PR TITLE
HP-1057: Fixed service connection load bug

### DIFF
--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -16,6 +16,7 @@ type Props = PropsWithChildren<{
   initiallyOpen: boolean;
   scrollIntoViewOnMount?: boolean;
   onChange?: (isOpen: boolean) => void;
+  dataTestId?: string;
 }>;
 
 function ExpandingPanel({
@@ -24,6 +25,7 @@ function ExpandingPanel({
   showInformationText,
   scrollIntoViewOnMount,
   title,
+  dataTestId,
   onChange,
 }: Props): React.ReactElement {
   const container = useRef<HTMLDivElement | null>(null);
@@ -51,6 +53,9 @@ function ExpandingPanel({
   const buttonText = isOpen
     ? t('expandingPanel.hideInformation')
     : t('expandingPanel.showInformation');
+  const buttonTestId = dataTestId
+    ? { 'data-testid': `${dataTestId}-toggle-button` }
+    : null;
   return (
     <div className={styles['container']} ref={handleContainerRef}>
       <div className={styles['title']}>
@@ -61,6 +66,7 @@ function ExpandingPanel({
             variant={'supplementary'}
             iconRight={<Icon aria-hidden />}
             {...buttonProps}
+            {...buttonTestId}
           >
             {showInformationText && (
               <span className={styles['show-information']} aria-hidden>

--- a/src/common/test/MockApolloClientProvider.tsx
+++ b/src/common/test/MockApolloClientProvider.tsx
@@ -4,12 +4,17 @@ import { GraphQLError } from 'graphql';
 import fetchMock from 'jest-fetch-mock';
 
 import graphqlClient from '../../graphql/client';
-import { ProfileData, UpdateProfileData } from '../../graphql/typings';
+import {
+  ProfileData,
+  ServiceConnectionsRoot,
+  UpdateProfileData,
+} from '../../graphql/typings';
 import { UpdateMyProfileVariables } from '../../graphql/generatedTypes';
 
 export type MockedResponse = {
   profileData?: ProfileData;
   updatedProfileData?: UpdateProfileData;
+  profileDataWithServiceConnections?: ServiceConnectionsRoot;
   errorType?: 'networkError' | 'graphQLError';
 };
 
@@ -44,9 +49,20 @@ export function MockApolloClientProvider({
 const getResponseData = (
   response: MockedResponse
 ): Record<string, unknown> | undefined => {
-  const { errorType, profileData, updatedProfileData } = response;
+  const {
+    errorType,
+    profileData,
+    updatedProfileData,
+    profileDataWithServiceConnections,
+  } = response;
   if (errorType) {
     return undefined;
+  }
+  if (profileDataWithServiceConnections) {
+    return (profileDataWithServiceConnections as unknown) as Record<
+      string,
+      unknown
+    >;
   }
   return profileData
     ? { myProfile: profileData }

--- a/src/common/test/getMyProfileWithServiceConnections.ts
+++ b/src/common/test/getMyProfileWithServiceConnections.ts
@@ -1,0 +1,53 @@
+import {
+  ServiceAllowedFieldsEdge,
+  ServiceConnectionsRoot,
+} from '../../graphql/typings';
+
+export default function getMyProfileWithServiceConnections(): ServiceConnectionsRoot {
+  const generateAllowedDataFieldEdge = (
+    fieldName: string
+  ): ServiceAllowedFieldsEdge => ({
+    node: {
+      fieldName,
+      label: `${fieldName} Label`,
+      __typename: 'AllowedDataFieldNode',
+    },
+    __typename: 'AllowedDataFieldNodeEdge',
+  });
+
+  return {
+    myProfile: {
+      id: 'asd',
+      serviceConnections: {
+        edges: [
+          {
+            node: {
+              createdAt: '2021-03-10T11:34:14.719531+00:00',
+              service: {
+                title: 'Profiili käyttöliittymä',
+                description:
+                  'Henkilön omien profiilitietojen hallintakäyttöliittymä.',
+                allowedDataFields: {
+                  edges: [
+                    generateAllowedDataFieldEdge('name'),
+                    generateAllowedDataFieldEdge('email'),
+                    generateAllowedDataFieldEdge('addresses'),
+                    generateAllowedDataFieldEdge('phones'),
+                    generateAllowedDataFieldEdge('Personal_identity_code'),
+                    generateAllowedDataFieldEdge('Municipality_of_residence'),
+                  ],
+                  __typename: 'AllowedDataFieldNodeConnection',
+                },
+                __typename: 'ServiceNode',
+              },
+              __typename: 'ServiceConnectionType',
+            },
+            __typename: 'ServiceConnectionTypeEdge',
+          },
+        ],
+        __typename: 'ServiceConnectionTypeConnection',
+      },
+      __typename: 'ProfileNode',
+    },
+  };
+}

--- a/src/graphql/typings.ts
+++ b/src/graphql/typings.ts
@@ -24,6 +24,7 @@ import {
   MyProfileQuery_myProfile_primaryAddress,
   MyProfileQuery_myProfile_primaryEmail,
   MyProfileQuery_myProfile_primaryPhone,
+  ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges,
 } from './generatedTypes';
 
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
@@ -77,6 +78,8 @@ export type ServiceConnectionsNode = ServiceConnectionsQuery_myProfile_serviceCo
 export type Service = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service;
 // eslint-disable-next-line max-len
 export type ServiceAllowedFieldsNode = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node;
+// eslint-disable-next-line max-len
+export type ServiceAllowedFieldsEdge = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges;
 export type GdprServiceConnectionsRoot = GdprServiceConnectionsQuery;
 
 export { PhoneType, EmailType, AddressType, Language } from './generatedTypes';

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -63,9 +63,10 @@ function DeleteProfile(): React.ReactElement {
     targetId: `delete-profile-button`,
   });
 
-  const [getServiceConnections, { data, refetch }] = useLazyQuery<
-    ServiceConnectionsRoot
-  >(SERVICE_CONNECTIONS, {
+  const [
+    getServiceConnections,
+    { data: serviceConnections, refetch },
+  ] = useLazyQuery<ServiceConnectionsRoot>(SERVICE_CONNECTIONS, {
     onCompleted: () => {
       setDataLoadState(loadedLoadState);
     },
@@ -94,11 +95,18 @@ function DeleteProfile(): React.ReactElement {
   });
 
   const loadServiceConnections = useCallback(() => {
-    if (dataLoadState === notStartedLoadState) {
+    if (serviceConnections) {
+      setDataLoadState(loadedLoadState);
+    } else if (dataLoadState === notStartedLoadState) {
       getServiceConnections();
       setDataLoadState(loadingLoadState);
     }
-  }, [getServiceConnections, setDataLoadState, dataLoadState]);
+  }, [
+    getServiceConnections,
+    setDataLoadState,
+    dataLoadState,
+    serviceConnections,
+  ]);
 
   const onExpandingPanelChange = useCallback(
     isOpen => {
@@ -121,7 +129,7 @@ function DeleteProfile(): React.ReactElement {
   const handleProfileDelete = async () => {
     setDeleteConfirmationModal(false);
 
-    if (data === undefined) {
+    if (serviceConnections === undefined) {
       throw Error('Could not find services to delete');
     }
 
@@ -173,7 +181,7 @@ function DeleteProfile(): React.ReactElement {
         isOpen={deleteConfirmationModal}
         onClose={handleConfirmationModal}
         onConfirm={handleProfileDelete}
-        content={() => <ModalServicesContent data={data} />}
+        content={() => <ModalServicesContent data={serviceConnections} />}
         title={t('deleteProfileModal.title')}
         actionButtonText={t('deleteProfileModal.delete')}
       />

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -172,6 +172,7 @@ function DeleteProfile(): React.ReactElement {
         initiallyOpen={initiallyOpen}
         scrollIntoViewOnMount={initiallyOpen}
         onChange={onExpandingPanelChange}
+        dataTestId={'delete-profile'}
       >
         <p>{t('deleteProfile.explanation')}</p>
         {dataLoadState !== loadedLoadState ? (

--- a/src/profile/components/deleteProfile/__tests__/DeleteProfile.test.tsx
+++ b/src/profile/components/deleteProfile/__tests__/DeleteProfile.test.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { act, waitFor } from '@testing-library/react';
+
+import {
+  renderComponentWithMocksAndContexts,
+  TestTools,
+  cleanComponentMocks,
+  ElementSelector,
+} from '../../../../common/test/testingLibraryTools';
+import DeleteProfile from '../DeleteProfile';
+import { ResponseProvider } from '../../../../common/test/MockApolloClientProvider';
+import getMyProfileWithServiceConnections from '../../../../common/test/getMyProfileWithServiceConnections';
+
+const mockStartFetchingAuthorizationCode = jest.fn();
+
+jest.mock('../../../../gdprApi/useAuthorizationCode.ts', () => () => [
+  mockStartFetchingAuthorizationCode,
+  false,
+]);
+
+describe('<DeleteProfile /> ', () => {
+  let responseCounter = -1;
+  const serviceConnections = getMyProfileWithServiceConnections();
+
+  let showComponent: React.Dispatch<React.SetStateAction<boolean>>;
+
+  const ComponentRendererWithForceUpdate = (): React.ReactElement => {
+    const [isOpen, toggleOpener] = useState<boolean>(true);
+    showComponent = toggleOpener;
+    return <div>{isOpen ? <DeleteProfile /> : <span>closed</span>}</div>;
+  };
+
+  const renderTestSuite = (errorResponseIndex = -1) => {
+    const responseProvider: ResponseProvider = () => {
+      responseCounter = responseCounter + 1;
+      return responseCounter === errorResponseIndex
+        ? { errorType: 'networkError' }
+        : { profileDataWithServiceConnections: serviceConnections };
+    };
+
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <ComponentRendererWithForceUpdate />
+    );
+  };
+
+  const toggleButton: ElementSelector = {
+    testId: 'delete-profile-toggle-button',
+  };
+  const loadIndicator: ElementSelector = {
+    testId: 'delete-profile-load-indicator',
+  };
+  const checkbox: ElementSelector = {
+    id: 'deleteInstructions',
+  };
+  const submitButton: ElementSelector = {
+    id: 'delete-profile-button',
+  };
+  const confirmButtonSelector: ElementSelector = {
+    testId: 'confirmation-modal-confirm-button',
+  };
+  const reloadButtonSelector: ElementSelector = {
+    testId: 'reload-service-connections',
+  };
+
+  beforeEach(() => {
+    responseCounter = -1;
+  });
+  afterEach(() => {
+    cleanComponentMocks();
+  });
+
+  const initTests = async (errorResponseIndex = -1): Promise<TestTools> => {
+    const testTools = await renderTestSuite(errorResponseIndex);
+    return Promise.resolve(testTools);
+  };
+
+  it(`toggle button opens the panel 
+      which first loads service connections 
+      and then shows a checkbox and a submit button`, async () => {
+    await act(async () => {
+      const { clickElement, waitForElement } = await initTests();
+      await clickElement(toggleButton);
+      await waitForElement(loadIndicator);
+      await waitForElement(checkbox);
+      await waitForElement(submitButton);
+    });
+  });
+
+  it(`Submit button is disabled until checkbox is checked.
+      Submitting opens a confirmation dialog and after confirmation
+      authorisation code is fetched.
+      `, async () => {
+    await act(async () => {
+      const {
+        clickElement,
+        getElement,
+        isDisabled,
+        waitForElement,
+      } = await initTests();
+      await clickElement(toggleButton);
+      await waitFor(() => {
+        expect(isDisabled(getElement(submitButton))).toBeTruthy();
+      });
+      await clickElement(checkbox);
+      await waitFor(() => {
+        expect(isDisabled(getElement(submitButton))).toBeFalsy();
+      });
+      await clickElement(submitButton);
+      await waitForElement(confirmButtonSelector);
+      await clickElement(confirmButtonSelector);
+      await waitFor(() => {
+        expect(mockStartFetchingAuthorizationCode).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  it(`When re-rendered, service connections are fetched from cache.
+    UI won't get stuck on "loading" -state, but works like on first load.`, async () => {
+    await act(async () => {
+      const { clickElement, getElement, waitForElement } = await initTests();
+      await clickElement(toggleButton);
+      await waitForElement(checkbox);
+      showComponent(false);
+      await waitFor(() => {
+        expect(() => getElement(checkbox)).toThrow();
+      });
+      showComponent(true);
+      await clickElement(toggleButton);
+      await waitForElement(checkbox);
+    });
+  });
+
+  it(`When service connection load fails, an error is shown.
+    Clicking "Try again"-button reloads data`, async () => {
+    await act(async () => {
+      const { clickElement, waitForElement } = await initTests(0);
+      await clickElement(toggleButton);
+      await waitForElement(reloadButtonSelector);
+      await clickElement(reloadButtonSelector);
+      await waitForElement(checkbox);
+    });
+  });
+});


### PR DESCRIPTION
Apollo-client does not call 'onCompleted' on cache hit.

The data object returned from useLazyQuery-hook is now also checked to detect, if loading is complete due a cache hit.

Checked also other onCompleted-callbacks. They all have 'no-cache' or 'network-only'. Except profile download, but caching cannot happen, because downloading causes a full page reload.