### PR TITLE
HP-1099: Render the verify email notification only with certain amr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/auth/__tests__/useProfile.test.tsx
+++ b/src/auth/__tests__/useProfile.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { User } from 'oidc-client';
+
+import {
+  mockUserCreator,
+  MockedUserOverrides,
+} from '../../common/test/userMocking';
+import authService from '../authService';
+import useProfile, { Profile } from '../useProfile';
+
+type Status = 'loading' | 'error' | 'loaded';
+type DataGetters = {
+  getInfo: () => Status;
+  getProfile: () => Profile | null;
+  hasCalledGetUser: () => boolean;
+  getMockedUserData: () => User;
+};
+
+describe('useProfile', () => {
+  const loadingStatus: Status = 'loading';
+  const loadedStatus: Status = 'loaded';
+  const errorStatus: Status = 'error';
+  const statusIndicatorElementId = 'status-indicator';
+  const profileElementId = 'profile';
+  const noProfile = { noProfile: true };
+  const TestProfileComponent = ({
+    callCounter,
+  }: {
+    callCounter: () => number;
+  }) => {
+    const hasLoadStarted = callCounter() > 0;
+    const { profile, loading, error } = useProfile();
+    const isFinished = hasLoadStarted && loading === false;
+
+    if (error) {
+      return <span id={statusIndicatorElementId}>{errorStatus}</span>;
+    }
+    if (!isFinished) {
+      return <span id={statusIndicatorElementId}>{loadingStatus}</span>;
+    }
+    return (
+      <div>
+        <span id={statusIndicatorElementId}>{loadedStatus}</span>
+        <span id={profileElementId}>
+          {JSON.stringify(profile ? profile : noProfile)}
+        </span>
+      </div>
+    );
+  };
+  const renderTestComponent = (
+    overrides?: MockedUserOverrides,
+    error = false
+  ): DataGetters => {
+    const userData = mockUserCreator(overrides);
+    const mockedGetUser = jest.spyOn(authService, 'getUser');
+
+    if (error) {
+      mockedGetUser.mockRejectedValueOnce(null);
+    } else {
+      mockedGetUser.mockResolvedValueOnce(userData);
+    }
+    const result = render(
+      <TestProfileComponent
+        callCounter={() => mockedGetUser.mock.calls.length}
+      />
+    );
+    const { container } = result;
+    const getElementById = (id: string) =>
+      container.querySelector(`#${id}`) as HTMLElement;
+    return {
+      getInfo: () =>
+        getElementById(statusIndicatorElementId).innerHTML as Status,
+      getProfile: () => {
+        const data = getElementById(profileElementId).innerHTML;
+        return JSON.parse(data);
+      },
+      hasCalledGetUser: () => mockedGetUser.mock.calls.length > 0,
+      getMockedUserData: () => userData,
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return the profile which the authService.getUser() provides', async () => {
+    const {
+      getInfo,
+      getProfile,
+      getMockedUserData,
+      hasCalledGetUser,
+    } = renderTestComponent();
+    const userData = getMockedUserData();
+    await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
+    expect(hasCalledGetUser()).toBeTruthy();
+    expect(getProfile()).toEqual(userData.profile);
+  });
+
+  it('should provide no profile if it has expired', async () => {
+    const { getInfo, getProfile } = renderTestComponent({
+      userOverrides: ({
+        expired: true,
+      } as unknown) as Partial<User>,
+    });
+    await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
+    expect(getProfile()).toEqual(noProfile);
+  });
+
+  it('should provide no profile if user.expired is undefined', async () => {
+    const { getInfo, getProfile } = renderTestComponent({
+      userOverrides: ({
+        expired: undefined,
+      } as unknown) as Partial<User>,
+    });
+    await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
+    expect(getProfile()).toEqual(noProfile);
+  });
+
+  it('should return error when authService.getUser() fails', async () => {
+    const { getInfo } = renderTestComponent(undefined, true);
+    await waitFor(() => expect(getInfo()).toEqual(errorStatus));
+  });
+});

--- a/src/auth/__tests__/useProfile.test.tsx
+++ b/src/auth/__tests__/useProfile.test.tsx
@@ -84,17 +84,24 @@ describe('useProfile', () => {
     jest.restoreAllMocks();
   });
 
-  it('should return the profile which the authService.getUser() provides', async () => {
+  it('should return the profile which the authService.getUser() provides where amr is always an array', async () => {
+    const amr = 'string-arm';
     const {
       getInfo,
       getProfile,
       getMockedUserData,
       hasCalledGetUser,
-    } = renderTestComponent();
+    } = renderTestComponent({
+      profileOverrides: { amr },
+    });
     const userData = getMockedUserData();
     await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
     expect(hasCalledGetUser()).toBeTruthy();
-    expect(getProfile()).toEqual(userData.profile);
+    const profileWithConvertedAmr = {
+      ...userData.profile,
+      amr: [amr],
+    };
+    expect(getProfile()).toEqual(profileWithConvertedAmr);
   });
 
   it('should provide no profile if it has expired', async () => {
@@ -115,6 +122,19 @@ describe('useProfile', () => {
     });
     await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
     expect(getProfile()).toEqual(noProfile);
+  });
+
+  it('should return an empty array if arm is undefined', async () => {
+    const { getInfo, getProfile, getMockedUserData } = renderTestComponent({
+      profileOverrides: { amr: undefined },
+    });
+    const userData = getMockedUserData();
+    await waitFor(() => expect(getInfo()).toEqual(loadedStatus));
+    const profileWithConvertedAmr = {
+      ...userData.profile,
+      amr: [],
+    };
+    expect(getProfile()).toEqual(profileWithConvertedAmr);
   });
 
   it('should return error when authService.getUser() fails', async () => {

--- a/src/common/test/userMocking.ts
+++ b/src/common/test/userMocking.ts
@@ -4,12 +4,16 @@ import { Profile } from '../../auth/useProfile';
 
 export type MockedUserOverrides = {
   userOverrides?: Partial<User>;
-  profileOverrides?: Partial<Profile>;
+  profileOverrides?: Omit<Partial<Profile>, 'amr'> & {
+    amr?: string | string[];
+  };
 };
 
-export function mockProfileCreator(overrides?: Partial<Profile>): Profile {
+export function mockProfileCreator(
+  overrides?: MockedUserOverrides['profileOverrides']
+): Profile {
   return {
-    amr: 'helusername-test',
+    amr: ['helusername-test'],
     auth_time: 1593431180,
     email: 'email@email.com',
     email_verified: false,
@@ -19,7 +23,7 @@ export function mockProfileCreator(overrides?: Partial<Profile>): Profile {
     nickname: 'Betty',
     sub: 'uuidvalue',
     ...overrides,
-  };
+  } as Profile;
 }
 
 export function mockUserCreator({

--- a/src/common/test/userMocking.ts
+++ b/src/common/test/userMocking.ts
@@ -1,0 +1,47 @@
+import { User, Profile as OidcProfile } from 'oidc-client';
+
+import { Profile } from '../../auth/useProfile';
+
+export type MockedUserOverrides = {
+  userOverrides?: Partial<User>;
+  profileOverrides?: Partial<Profile>;
+};
+
+export function mockProfileCreator(overrides?: Partial<Profile>): Profile {
+  return {
+    amr: 'helusername-test',
+    auth_time: 1593431180,
+    email: 'email@email.com',
+    email_verified: false,
+    family_name: 'Betty',
+    given_name: 'Smith',
+    name: 'Betty Smith',
+    nickname: 'Betty',
+    sub: 'uuidvalue',
+    ...overrides,
+  };
+}
+
+export function mockUserCreator({
+  userOverrides,
+  profileOverrides,
+}: MockedUserOverrides = {}): User {
+  const expirationTimeInMs = 100000;
+  const scopes = ['openid', 'profile', 'https://api.hel.fi/foobar'];
+  return {
+    id_token: 'id_token',
+    access_token: 'access_token',
+    expires_at: Date.now() + expirationTimeInMs,
+    scope: scopes.join(' '),
+    token_type: 'bearer',
+    expired: false,
+    expires_in: expirationTimeInMs,
+    scopes,
+    toStorageString: () => 'storageString',
+    refresh_token: undefined,
+    session_state: undefined,
+    state: undefined,
+    ...userOverrides,
+    profile: (mockProfileCreator(profileOverrides) as unknown) as OidcProfile,
+  };
+}

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -33,6 +33,8 @@ import FocusKeeper from '../../../common/focusKeeper/FocusKeeper';
 import AccessibleFormikErrors from '../accessibleFormikErrors/AccessibleFormikErrors';
 import AccessibilityFieldHelpers from '../../../common/accessibilityFieldHelpers/AccessibilityFieldHelpers';
 import { AnyObject } from '../../../graphql/typings';
+import useProfile from '../../../auth/useProfile';
+import { hasTunnistusSuomiFiAmr } from '../profileInformation/profileInformationAccountManagementLinkUtils';
 
 function EmailEditor(): React.ReactElement | null {
   const dataType: EditDataType = 'emails';
@@ -56,6 +58,8 @@ function EmailEditor(): React.ReactElement | null {
   const { email } = value as EmailValue;
   const formFields = getFormFields(dataType);
   const ariaLabels = createActionAriaLabels(dataType, email, t);
+  const { profile } = useProfile();
+  const willSendEmailVerificationCode = hasTunnistusSuomiFiAmr(profile);
 
   const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
     EmailValue
@@ -76,7 +80,9 @@ function EmailEditor(): React.ReactElement | null {
         setFocusToEditButton();
         setSuccessMessage('save');
         setEditing(false);
-        setShowVerifyEmailInfo(true);
+        if (willSendEmailVerificationCode) {
+          setShowVerifyEmailInfo(true);
+        }
       }
     }
     if (action === 'cancel') {

--- a/src/profile/components/profileInformation/ProfileInformationAccountManagementLink.tsx
+++ b/src/profile/components/profileInformation/ProfileInformationAccountManagementLink.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import useProfile from '../../../auth/useProfile';
 import LabeledValue from '../../../common/labeledValue/LabeledValue';
 import {
-  getAmr,
+  getAmrStatic,
   getAmrUrl,
 } from './profileInformationAccountManagementLinkUtils';
 import styles from './profileInformationAccountManagementLink.module.css';
@@ -15,7 +15,7 @@ function ProfileInformationAccountManagementLink(): React.ReactElement | null {
   const { t } = useTranslation();
   const { profile } = useProfile();
 
-  const amr = getAmr(profile);
+  const amr = getAmrStatic(profile);
 
   if (!amr) {
     return null;

--- a/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
+++ b/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
@@ -18,7 +18,7 @@ jest.mock('../../../../auth/useProfile', () => () => mockUserCreator());
 
 jest.mock('../profileInformationAccountManagementLinkUtils', () => ({
   ...jest.requireActual('../profileInformationAccountManagementLinkUtils'),
-  getAmr: () => mockCurrentAmr,
+  getAmrStatic: () => mockCurrentAmr,
 }));
 
 describe('<ProfileInformationAuthenticationSourceBackLink /> ', () => {

--- a/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
+++ b/src/profile/components/profileInformation/__tests__/ProfileInformationAccountManagementLink.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import enzymeToJson from 'enzyme-to-json';
 
 import ProfileInformationAuthenticationSourceBackLink from '../ProfileInformationAccountManagementLink';
+import { mockUserCreator } from '../../../../common/test/userMocking';
 
 let mockCurrentAmr;
 const helsinkiAccountAMR = 'helusername-test';
@@ -13,19 +14,7 @@ jest.mock('../../../../config', () => ({
   helsinkiAccountAMR,
 }));
 
-jest.mock('../../../../auth/useProfile', () => () => ({
-  profile: {
-    amr: 'helusername-test',
-    auth_time: 1593431180,
-    email: 'email@email.com',
-    email_verified: false,
-    family_name: 'Betty',
-    given_name: 'Smith',
-    name: 'Betty Smith',
-    nickname: 'Betty',
-    sub: 'uuidvalue',
-  },
-}));
+jest.mock('../../../../auth/useProfile', () => () => mockUserCreator());
 
 jest.mock('../profileInformationAccountManagementLinkUtils', () => ({
   ...jest.requireActual('../profileInformationAccountManagementLinkUtils'),

--- a/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
+++ b/src/profile/components/profileInformation/profileInformationAccountManagementLinkUtils.ts
@@ -5,8 +5,12 @@ import {
 } from '../../../auth/useProfile';
 import config from '../../../config';
 
-export function getAmr(profile: Profile | null): AMRStatic | null {
-  const amr = profile?.amr;
+function getAmrFromProfileData(profile: Profile | null): string | undefined {
+  return profile && profile.amr ? profile.amr[0] : '';
+}
+
+export function getAmrStatic(profile: Profile | null): AMRStatic | null {
+  const amr = getAmrFromProfileData(profile);
 
   // If amr designates helsinki account, switch the value into a static
   // value. This setup allows the amr for Helsinki account to be
@@ -51,4 +55,8 @@ export function getAmrUrl(authenticationMethodReference: AMRStatic): string {
         `Unexpected authentication method reference "${authenticationMethodReference}"`
       );
   }
+}
+
+export function hasTunnistusSuomiFiAmr(profile: Profile | null): boolean {
+  return getAmrFromProfileData(profile) === tunnistusSuomifiAMR;
 }


### PR DESCRIPTION
First commit includes missing tests for useProfile. Tests were added because second commit includes a change how useProfile handles the profile returned from Tunnistamo. According to the OIDC spec, Profile.amr should be an array of strings, but it is not. Now it is converted to an array, if it is not.

EmailEditor should show the "verify your email"-notification only if user's amr is 'heltunnistussuomifi'. Currently that is the only case, so the check is simple. In other cases the backend won't send an email and the notification should not be shown.


