### PR TITLE
HP-903: ui_locales passed to OIDC provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/auth/__tests__/authService.test.js
+++ b/src/auth/__tests__/authService.test.js
@@ -2,6 +2,7 @@ import to from 'await-to-js';
 
 import authService, { API_TOKEN } from '../authService';
 import { getHttpPollerMockData } from '../__mocks__/http-poller';
+import i18n from '../../common/test/testi18nInit';
 
 describe('authService', () => {
   const userManager = authService.userManager;
@@ -88,13 +89,29 @@ describe('authService', () => {
   });
 
   describe('login', () => {
-    it('should call signinRedirect from oidc with the provided path', () => {
+    const defaultSigninParams = {
+      data: { path: '/' },
+      ui_locales: 'fi',
+    };
+    it('should call signinRedirect from oidc with the provided path', async () => {
       const path = '/applications';
       const signinRedirect = jest.spyOn(userManager, 'signinRedirect');
 
-      authService.login(path);
+      await to(authService.login(path));
 
-      expect(signinRedirect).toHaveBeenNthCalledWith(1, { data: { path } });
+      expect(signinRedirect).toHaveBeenNthCalledWith(1, {
+        ...defaultSigninParams,
+        data: { path },
+      });
+    });
+    it('should reflect i18n language changes in the login url', async () => {
+      const signinRedirect = jest.spyOn(userManager, 'signinRedirect');
+      i18n.changeLanguage('sv');
+      await to(authService.login());
+      expect(signinRedirect).toHaveBeenNthCalledWith(1, {
+        ...defaultSigninParams,
+        ui_locales: 'sv',
+      });
     });
   });
 

--- a/src/auth/__tests__/authService.test.js
+++ b/src/auth/__tests__/authService.test.js
@@ -196,12 +196,17 @@ describe('authService', () => {
   });
 
   describe('logout', () => {
-    it('should call signoutRedirect from oidc', () => {
+    it('should call signoutRedirect from oidc. Ui_locales is found in extraQueryParams', () => {
       const signoutRedirect = jest.spyOn(userManager, 'signoutRedirect');
-
+      i18n.changeLanguage('sv');
       authService.logout();
 
       expect(signoutRedirect).toHaveBeenCalledTimes(1);
+      expect(signoutRedirect).toHaveBeenNthCalledWith(1, {
+        extraQueryParams: {
+          ui_locales: 'sv',
+        },
+      });
     });
 
     it('should remove the tokens from sessionStorage', async () => {

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -170,7 +170,9 @@ export class AuthService {
   public async logout(): Promise<void> {
     sessionStorage.removeItem(API_TOKEN);
     this.userManager.clearStaleState();
-    await this.userManager.signoutRedirect();
+    await this.userManager.signoutRedirect({
+      extraQueryParams: { ui_locales: i18n.language },
+    });
   }
 
   async fetchApiToken(user: User): Promise<void> {

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -7,6 +7,7 @@ import {
 } from 'oidc-client';
 import * as Sentry from '@sentry/browser';
 import HttpStatusCode from 'http-status-typed';
+import i18n from 'i18next';
 
 import pickProfileApiToken from './pickProfileApiToken';
 import createHttpPoller, { HttpPoller } from './http-poller';
@@ -140,12 +141,14 @@ export class AuthService {
 
   public async login(path = '/'): Promise<void> {
     let success = true;
-    await this.userManager.signinRedirect({ data: { path } }).catch(error => {
-      success = false;
-      if (error.message !== 'Network Error') {
-        Sentry.captureException(error);
-      }
-    });
+    await this.userManager
+      .signinRedirect({ data: { path }, ui_locales: i18n.language })
+      .catch(error => {
+        success = false;
+        if (error.message !== 'Network Error') {
+          Sentry.captureException(error);
+        }
+      });
     return success ? Promise.resolve() : Promise.reject();
   }
 


### PR DESCRIPTION
Added "ui_locales" to login and logout requests. 

{ ui_locales: 'xx' } is not supported in logout arguments, so had to use { extraQueryParams: { ui_locales: 'xx' } }