### PR TITLE
HP-1174:  authentication improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/public/env-config.js
+++ b/public/env-config.js
@@ -14,5 +14,5 @@ window._env_ = {
   REACT_APP_PROFILE_BE_GDPR_CLIENT_ID: 'https://api.hel.fi/auth/helsinkiprofile',
   REACT_APP_OIDC_RESPONSE_TYPE: 'code',
   REACT_APP_SENTRY_DSN: 'https://8b5b23e2171b42cd8617e2b1ad7353b6@sentry.hel.ninja/63',
-  REACT_APP_VERSION: '1.1.5'
+  REACT_APP_VERSION: '1.1.11'
 }

--- a/src/auth/__mocks__/http-poller.ts
+++ b/src/auth/__mocks__/http-poller.ts
@@ -4,6 +4,8 @@ type MockHttpPollerData = {
   start: jest.Mock;
   stop: jest.Mock;
   props?: HttpPollerProps;
+  actual?: HttpPoller;
+  actualCreator?: (p: HttpPollerProps) => HttpPoller;
 };
 
 type GlobalWithPollerData = {
@@ -25,18 +27,46 @@ export function getHttpPollerMockData(): MockHttpPollerData {
   return mockHttpPoller;
 }
 
+export function removeActualHttpPoller(): void {
+  if (mockHttpPoller.actual) {
+    mockHttpPoller.actual.stop();
+  }
+  mockHttpPoller.actual = undefined;
+}
+
+export function enableActualHttpPoller(httpPollerModule: {
+  default: (props: HttpPollerProps) => HttpPoller;
+}): void {
+  removeActualHttpPoller();
+  mockHttpPoller.actualCreator = httpPollerModule.default;
+}
+
+export function disableActualHttpPoller(): void {
+  removeActualHttpPoller();
+  mockHttpPoller.actualCreator = undefined;
+}
+
 export default function createHttpPoller(
   pollerProps: HttpPollerProps
 ): HttpPoller {
   mockHttpPoller.start.mockReset();
   mockHttpPoller.stop.mockReset();
   mockHttpPoller.props = pollerProps;
+  if (mockHttpPoller.actualCreator) {
+    mockHttpPoller.actual = mockHttpPoller.actualCreator(pollerProps);
+  }
   return {
     start: () => {
       mockHttpPoller.start();
+      if (mockHttpPoller.actual) {
+        mockHttpPoller.actual.start();
+      }
     },
     stop: () => {
       mockHttpPoller.stop();
+      if (mockHttpPoller.actual) {
+        mockHttpPoller.actual.stop();
+      }
     },
   };
 }

--- a/src/auth/__tests__/http-poller-with-promises.test.ts
+++ b/src/auth/__tests__/http-poller-with-promises.test.ts
@@ -1,0 +1,205 @@
+import { waitFor } from '@testing-library/react';
+import to from 'await-to-js';
+import HttpStatusCode from 'http-status-typed';
+
+import retryPollingUntilSuccessful, {
+  RetryingPollerProps,
+} from '../http-poller-with-promises';
+import {
+  getHttpPollerMockData,
+  enableActualHttpPoller,
+  disableActualHttpPoller,
+  removeActualHttpPoller,
+} from '../__mocks__/http-poller';
+import { TestResponse } from './http-poller.test';
+
+describe(`http-poller-with-promises.ts`, () => {
+  const pollFunctionMockCallback = jest.fn();
+  const successfulResponse: TestResponse = {
+    status: HttpStatusCode.OK,
+    data: 'success',
+  };
+  const forbiddenResponse: TestResponse = { status: HttpStatusCode.FORBIDDEN };
+  const errorResponse: TestResponse = { status: -1 };
+  const responsesWithErrorForbiddenSuccess = [
+    errorResponse,
+    forbiddenResponse,
+    successfulResponse,
+  ];
+  const pollIntervalInMs = 100;
+  let isResolved = false;
+  let isRejected = false;
+
+  function createAPoller(
+    responses: TestResponse[],
+    props?: Partial<RetryingPollerProps>
+  ): Promise<Response> {
+    const list = [...responses];
+    const retryPromise = retryPollingUntilSuccessful({
+      pollFunction: async () => {
+        pollFunctionMockCallback(Date.now());
+        const response = list.shift();
+        if (!response || response.status === -1) {
+          return Promise.reject(new Error('An error'));
+        } else {
+          return Promise.resolve(response as Response);
+        }
+      },
+      pollIntervalInMs,
+      ...props,
+    });
+    retryPromise
+      .then(() => {
+        isResolved = true;
+      })
+      .catch(() => {
+        isRejected = true;
+      });
+    return retryPromise;
+  }
+  const mockHttpPoller = getHttpPollerMockData();
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+    mockHttpPoller.start.mockReset();
+    mockHttpPoller.stop.mockReset();
+    removeActualHttpPoller();
+  });
+  beforeEach(() => {
+    jest.useFakeTimers();
+    isResolved = false;
+    isRejected = false;
+  });
+  beforeAll(() => {
+    enableActualHttpPoller(jest.requireActual('../http-poller'));
+  });
+  afterAll(() => {
+    disableActualHttpPoller();
+  });
+  const advanceOneInterval = async () => {
+    jest.advanceTimersByTime(pollIntervalInMs);
+  };
+  const testCallbackCount = async ({
+    assumedCallCount,
+    assumedState,
+  }: {
+    assumedCallCount: number;
+    assumedState?: 'resolved' | 'rejected';
+  }) => {
+    await waitFor(() => {
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(assumedCallCount);
+    });
+    expect(isResolved).toEqual(assumedState === 'resolved');
+    expect(isRejected).toEqual(assumedState === 'rejected');
+  };
+  it('First request is done immediately without http-poller. Successful response is returned.', async () => {
+    const promise = createAPoller([successfulResponse]);
+    await testCallbackCount({
+      assumedCallCount: 1,
+      assumedState: 'resolved',
+    });
+    advanceOneInterval();
+    advanceOneInterval();
+    const response = await promise;
+    await testCallbackCount({
+      assumedCallCount: 1,
+      assumedState: 'resolved',
+    });
+    expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+    expect(mockHttpPoller.start).toHaveBeenCalledTimes(0);
+    expect(response).toEqual(successfulResponse);
+  });
+  it(`If first request fails, http-poller is started. 
+      Promise is resolved, when request is successful.
+      New attempts are not made after that. Successful response is returned.`, async () => {
+    const promise = createAPoller(responsesWithErrorForbiddenSuccess);
+    await testCallbackCount({
+      assumedCallCount: 1,
+    });
+    advanceOneInterval();
+    expect(mockHttpPoller.start).toHaveBeenCalledTimes(1);
+    await testCallbackCount({
+      assumedCallCount: 2,
+    });
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 3,
+      assumedState: 'resolved',
+    });
+    const [err, response] = await to(promise);
+    expect(err).toBeNull();
+    expect(response).toEqual(successfulResponse);
+    expect(pollFunctionMockCallback).toHaveBeenCalledTimes(3);
+    expect(mockHttpPoller.stop).toHaveBeenCalledTimes(1);
+    advanceOneInterval();
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 3,
+      assumedState: 'resolved',
+    });
+  });
+  it(`maxRetries sets maximum number retries. 
+      When maxRetries is reached, the promise is rejected 
+      and new attempts are not made after that 
+      An error is returned.`, async () => {
+    const promise = createAPoller(responsesWithErrorForbiddenSuccess, {
+      maxRetries: 1,
+    });
+
+    await testCallbackCount({
+      assumedCallCount: 1,
+    });
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 2,
+      assumedState: 'rejected',
+    });
+    advanceOneInterval();
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 2,
+      assumedState: 'rejected',
+    });
+    const [err, result] = await to(promise);
+    expect(err).toBeDefined();
+    expect(result).toBeUndefined();
+    expect(pollFunctionMockCallback).toHaveBeenCalledTimes(2);
+    expect(mockHttpPoller.start).toHaveBeenCalledTimes(1);
+    expect(mockHttpPoller.stop).toHaveBeenCalledTimes(1);
+  });
+  it('pollIntervalInMs sets the delay between attempts', async () => {
+    const promise = createAPoller(responsesWithErrorForbiddenSuccess, {
+      pollIntervalInMs: pollIntervalInMs * 4,
+    });
+
+    await testCallbackCount({
+      assumedCallCount: 1,
+    });
+    advanceOneInterval();
+    advanceOneInterval();
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 1,
+    });
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 2,
+    });
+    advanceOneInterval();
+    advanceOneInterval();
+    advanceOneInterval();
+    await testCallbackCount({
+      assumedCallCount: 2,
+    });
+    advanceOneInterval();
+    await promise;
+    await testCallbackCount({
+      assumedCallCount: 3,
+      assumedState: 'resolved',
+    });
+    expect(pollFunctionMockCallback).toHaveBeenCalledTimes(3);
+    expect(mockHttpPoller.start).toHaveBeenCalledTimes(1);
+    expect(mockHttpPoller.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -8,12 +8,28 @@ import {
 import * as Sentry from '@sentry/browser';
 import HttpStatusCode from 'http-status-typed';
 import i18n from 'i18next';
+import to from 'await-to-js';
 
 import pickProfileApiToken from './pickProfileApiToken';
 import createHttpPoller, { HttpPoller } from './http-poller';
 
 const origin = window.location.origin;
 export const API_TOKEN = 'apiToken';
+
+function isUserExpired(user?: Partial<User> | null): boolean {
+  if (!user) {
+    return true;
+  }
+  if (user.expired !== undefined) {
+    return user.expired;
+  }
+  const expiresAtInSeconds = user.expires_at;
+
+  if (expiresAtInSeconds) {
+    return expiresAtInSeconds - Date.now() / 1000 <= 0;
+  }
+  return true;
+}
 
 export class AuthService {
   userManager: UserManager;
@@ -92,21 +108,22 @@ export class AuthService {
       this.logout();
     });
 
-    this.userManager.events.addUserSignedOut(() => {
-      this.userManager.clearStaleState();
-      sessionStorage.removeItem(API_TOKEN);
-      this.userSessionValidityPoller.stop();
+    this.userManager.events.addUserSignedOut(async () => {
+      await this.cleanUpUserSessionAndApiTokens();
     });
 
+    // This is called by userManager while processing endLogin()
+    // and when silent renew is complete
+    // endLogin() also calls fetchApiToken. Multiple calls are prevented with _isProcessingLogin
     this.userManager.events.addUserLoaded(async user => {
       if (!this._isProcessingLogin && this.isAuthenticatedUser(user)) {
-        this.fetchApiToken(user);
+        await this.fetchApiToken(user);
       }
-      this.userSessionValidityPoller.start();
+      return Promise.resolve();
     });
 
-    this.userManager.events.addUserUnloaded(() => {
-      this.userSessionValidityPoller.stop();
+    this.userManager.events.addUserUnloaded(async () => {
+      await this.cleanUpUserSessionAndApiTokens();
     });
   }
 
@@ -114,6 +131,9 @@ export class AuthService {
     return this.userManager.getUser();
   }
 
+  // It is assumed that user and api tokens are removed hand in hand.
+  // If user tokens exists, api tokens must also exist.
+  // That is why api tokens are not checked here.
   public async getAuthenticatedUser(): Promise<User | null> {
     const user = await this.getUser();
     if (!this.isAuthenticatedUser(user)) {
@@ -128,7 +148,7 @@ export class AuthService {
   }
 
   public isAuthenticatedUser(user?: User | null): boolean {
-    return !!user && user.expired !== true && !!user.access_token;
+    return !!user && !isUserExpired(user) && !!user.access_token;
   }
 
   public isAuthenticated(): boolean {
@@ -158,8 +178,15 @@ export class AuthService {
     if (!this.isAuthenticatedUser(user)) {
       return Promise.reject(new Error('Login failed - no valid user returned'));
     }
-    await this.fetchApiToken(user);
+    const apiTokenSuccess = await this.fetchApiToken(user);
+    if (!apiTokenSuccess) {
+      await this.userManager.removeUser();
+      return Promise.reject(
+        new Error('Api token error - no valid api token returned')
+      );
+    }
     this._isProcessingLogin = false;
+    this.userSessionValidityPoller.start();
     return user;
   }
 
@@ -168,24 +195,33 @@ export class AuthService {
   }
 
   public async logout(): Promise<void> {
-    sessionStorage.removeItem(API_TOKEN);
-    this.userManager.clearStaleState();
     await this.userManager.signoutRedirect({
       extraQueryParams: { ui_locales: i18n.language },
     });
   }
 
-  async fetchApiToken(user: User): Promise<void> {
+  async fetchApiToken(user: User): Promise<boolean> {
     const url = `${window._env_.REACT_APP_OIDC_AUTHORITY}api-tokens/`;
-    const response = await fetch(url, {
-      headers: {
-        authorization: `bearer ${user.access_token}`,
-      },
-    });
+    const [, response] = await to(
+      fetch(url, {
+        headers: {
+          authorization: `bearer ${user.access_token}`,
+        },
+      })
+    );
+    if (!response) {
+      return Promise.resolve(false);
+    }
     const result = await response.json();
     const apiToken = pickProfileApiToken(result);
-
     sessionStorage.setItem(API_TOKEN, apiToken);
+    return Promise.resolve(!!apiToken);
+  }
+
+  async cleanUpUserSessionAndApiTokens(): Promise<void> {
+    await this.userManager.clearStaleState();
+    sessionStorage.removeItem(API_TOKEN);
+    this.userSessionValidityPoller.stop();
   }
 }
 

--- a/src/auth/http-poller-with-promises.ts
+++ b/src/auth/http-poller-with-promises.ts
@@ -1,0 +1,51 @@
+import to from 'await-to-js';
+
+import createHttpPoller, { HttpPoller } from './http-poller';
+
+export type RetryingPollerProps = {
+  pollFunction: () => Promise<Response | undefined>;
+  pollIntervalInMs?: number;
+  maxRetries?: number;
+};
+
+export default async function retryPollingUntilSuccessful({
+  pollFunction,
+  pollIntervalInMs = 1000,
+  maxRetries = 10,
+}: RetryingPollerProps): Promise<Response> {
+  const [err, response] = await to(pollFunction());
+  if (!err && response) {
+    return Promise.resolve(response);
+  }
+  let retries = maxRetries;
+  let poller: HttpPoller | undefined;
+  const removePoller = () => {
+    poller && poller.stop();
+    poller = undefined;
+  };
+
+  return new Promise(async (resolve, reject) => {
+    poller = createHttpPoller({
+      pollFunction: async () => pollFunction(),
+      onSuccess: successResponse => {
+        retries = 0;
+        resolve(successResponse);
+        return { keepPolling: false };
+      },
+      onError: () => {
+        retries = retries - 1;
+        const keepPolling = retries > 0;
+        if (!keepPolling) {
+          reject(new Error('Max retries reached'));
+        }
+        return { keepPolling };
+      },
+      shouldPoll: () => retries > 0,
+      pollIntervalInMs,
+    });
+    poller.start();
+  })
+    .then(r => Promise.resolve(r as Response))
+    .catch(e => Promise.reject(e))
+    .finally(() => removePoller());
+}

--- a/src/profile/components/profile/__tests__/Profile.test.tsx
+++ b/src/profile/components/profile/__tests__/Profile.test.tsx
@@ -40,6 +40,7 @@ describe('<Profile />', () => {
     const user = ({
       profile: { name: 'Mock User' },
       access_token: 'huuhaa',
+      expired: false,
     } as unknown) as User;
     const userManager = authService.userManager;
     jest.spyOn(userManager, 'getUser').mockResolvedValueOnce(user);


### PR DESCRIPTION
Minor changes to authService:
- clean up on sign out is focused to one place and depends more on triggered events
- improved error handling in api token fetching 
- when user token is silently renewed, api token fetching is retried if it fails. Profile has been fetched already once and there is time to refetch api tokens before they expire.
- when user is initially logged in and api token fetching fails, an error is shown (as before). In this case retrying is not necessary, because profile cannot be loaded and user has no data to lose.