### PR TITLE
HP-1169: Service connection texts do not update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.10",
+  "version": "1.1.12",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -1,0 +1,45 @@
+import { DocumentNode, Reference, TypedDocumentNode } from '@apollo/client';
+import { loader } from 'graphql.macro';
+
+import graphqlClient from './client';
+
+type GraphQlQuery = DocumentNode | TypedDocumentNode;
+
+const SERVICE_CONNECTIONS = loader(
+  '../profile/graphql/ServiceConnectionsQuery.graphql'
+);
+
+export function clearCache({
+  query,
+  fieldName,
+  variables,
+}: {
+  query: GraphQlQuery;
+  fieldName?: string;
+  variables?: unknown;
+}): void {
+  const cached = graphqlClient.readQuery({
+    query,
+    variables,
+  });
+
+  if (!cached) {
+    return;
+  }
+
+  const cache = graphqlClient.cache;
+  const id = cache.identify((cached.myProfile as unknown) as Reference);
+  if (id) {
+    cache.evict({
+      id,
+      fieldName,
+    });
+  }
+}
+
+export function clearServiceConnectionCache(): void {
+  clearCache({
+    query: SERVICE_CONNECTIONS,
+    fieldName: 'serviceConnections',
+  });
+}

--- a/src/i18n/components/languageSwitcher/LanguageSwitcher.tsx
+++ b/src/i18n/components/languageSwitcher/LanguageSwitcher.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
 import getLanguageCode from '../../../common/helpers/getLanguageCode';
+import { clearServiceConnectionCache } from '../../../graphql/utils';
 
 function LanguageSwitcher(): React.ReactElement {
   const { i18n, t } = useTranslation();
@@ -12,6 +13,7 @@ function LanguageSwitcher(): React.ReactElement {
     e.preventDefault();
     i18n.changeLanguage(code);
     trackEvent({ category: 'action', action: `Language selected ${code}` });
+    clearServiceConnectionCache();
   };
   const i18NLanguageCode = getLanguageCode(i18n.language);
   const languages = [

--- a/src/i18n/components/languageSwitcher/__tests__/LanguageSwitcher.test.tsx
+++ b/src/i18n/components/languageSwitcher/__tests__/LanguageSwitcher.test.tsx
@@ -24,7 +24,15 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+const mockClearServiceConnectionCache = jest.fn();
+jest.mock('../../../../graphql/utils', () => ({
+  clearServiceConnectionCache: () => mockClearServiceConnectionCache(),
+}));
+
 describe('<LanguageSwitcher /> ', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   const selectedLanguageSelector = 'div a[aria-current="page"]';
   const renderComponentAndReturnElements = (): LanguageTestElements => {
     const result = render(
@@ -74,7 +82,8 @@ describe('<LanguageSwitcher /> ', () => {
     mockI18n.language = 'sv-x';
     testLang(renderComponentAndReturnElements(), mockI18n.language);
   });
-  it('calls the i18n.changeLanguage with "sv" when the "sv"-link in the language dropdown is clicked', async () => {
+  it(`calls the i18n.changeLanguage with "sv" when the "sv"-link in the language dropdown is clicked
+      Changing the language also calls a function to clear serviceConnections from cache`, async () => {
     mockI18n.language = 'fi';
     const elements = renderComponentAndReturnElements();
     elements.button.click();
@@ -87,5 +96,6 @@ describe('<LanguageSwitcher /> ', () => {
       expect(mockI18n.changeLanguage).toHaveBeenCalledTimes(1);
       expect(mockI18n.changeLanguage).toHaveBeenCalledWith('sv');
     });
+    expect(mockClearServiceConnectionCache).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Texts for the Service connections are fetched from the API. Those were updated only, if user was on the Service connections -tab when  language was changed.

Otherwise texts stored in the cache were used. Fixed the bug by clearing the cache when language changes.