### PR TITLE
HP-1169 service connection query fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/public/env-config.js
+++ b/public/env-config.js
@@ -14,5 +14,5 @@ window._env_ = {
   REACT_APP_PROFILE_BE_GDPR_CLIENT_ID: 'https://api.hel.fi/auth/helsinkiprofile',
   REACT_APP_OIDC_RESPONSE_TYPE: 'code',
   REACT_APP_SENTRY_DSN: 'https://8b5b23e2171b42cd8617e2b1ad7353b6@sentry.hel.ninja/63',
-  REACT_APP_VERSION: '1.1.11'
+  REACT_APP_VERSION: '1.1.12'
 }

--- a/src/common/test/MockApolloClientProvider.tsx
+++ b/src/common/test/MockApolloClientProvider.tsx
@@ -6,6 +6,7 @@ import fetchMock from 'jest-fetch-mock';
 import graphqlClient from '../../graphql/client';
 import {
   ProfileData,
+  ServiceConnectionsQueryVariables,
   ServiceConnectionsRoot,
   UpdateProfileData,
 } from '../../graphql/typings';
@@ -19,7 +20,7 @@ export type MockedResponse = {
 };
 
 export type ResponseProvider = (
-  variables?: UpdateMyProfileVariables
+  variables?: UpdateMyProfileVariables | ServiceConnectionsQueryVariables
 ) => MockedResponse;
 
 export function MockApolloClientProvider({

--- a/src/common/test/getMyProfileWithServiceConnections.ts
+++ b/src/common/test/getMyProfileWithServiceConnections.ts
@@ -44,6 +44,29 @@ export default function getMyProfileWithServiceConnections(): ServiceConnections
             },
             __typename: 'ServiceConnectionTypeEdge',
           },
+          {
+            node: {
+              createdAt: '2020-03-10T11:34:14.719531+00:00',
+              service: {
+                title: 'Example UI',
+                description: 'Esimerkkiapplikaatio.',
+                allowedDataFields: {
+                  edges: [
+                    generateAllowedDataFieldEdge('name'),
+                    generateAllowedDataFieldEdge('email'),
+                    generateAllowedDataFieldEdge('addresses'),
+                    generateAllowedDataFieldEdge('phones'),
+                    generateAllowedDataFieldEdge('Personal_identity_code'),
+                    generateAllowedDataFieldEdge('Municipality_of_residence'),
+                  ],
+                  __typename: 'AllowedDataFieldNodeConnection',
+                },
+                __typename: 'ServiceNode',
+              },
+              __typename: 'ServiceConnectionType',
+            },
+            __typename: 'ServiceConnectionTypeEdge',
+          },
         ],
         __typename: 'ServiceConnectionTypeConnection',
       },

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -490,6 +490,9 @@ export interface ProfileExistsQuery {
 export interface ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node {
   readonly __typename: "AllowedDataFieldNode";
   readonly fieldName: string;
+  /**
+   * Supports hel_translation directive.
+   */
   readonly label: string | null;
 }
 
@@ -511,7 +514,13 @@ export interface ServiceConnectionsQuery_myProfile_serviceConnections_edges_node
 
 export interface ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service {
   readonly __typename: "ServiceNode";
+  /**
+   * Supports hel_translation directive.
+   */
   readonly title: string | null;
+  /**
+   * Supports hel_translation directive.
+   */
   readonly description: string | null;
   readonly allowedDataFields: ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields;
 }
@@ -561,6 +570,10 @@ export interface ServiceConnectionsQuery {
    * * `TODO`
    */
   readonly myProfile: ServiceConnectionsQuery_myProfile | null;
+}
+
+export interface ServiceConnectionsQueryVariables {
+  readonly language: HelTranslationLanguage;
 }
 
 /* tslint:disable */
@@ -787,6 +800,12 @@ export enum EmailType {
   WORK = "WORK",
 }
 
+export enum HelTranslationLanguage {
+  EN = "EN",
+  FI = "FI",
+  SV = "SV",
+}
+
 /**
  * An enumeration.
  */
@@ -835,6 +854,14 @@ export interface DeleteMyProfileMutationInput {
   readonly clientMutationId?: string | null;
 }
 
+/**
+ * The following fields are deprecated:
+ * 
+ * * `image`
+ * * `subscriptions`
+ * 
+ * There's no replacement for these.
+ */
 export interface ProfileInput {
   readonly firstName?: string | null;
   readonly lastName?: string | null;

--- a/src/graphql/typings.ts
+++ b/src/graphql/typings.ts
@@ -25,6 +25,8 @@ import {
   MyProfileQuery_myProfile_primaryEmail,
   MyProfileQuery_myProfile_primaryPhone,
   ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges,
+  HelTranslationLanguage,
+  ServiceConnectionsQueryVariables as ServiceConnectionsQueryVars,
 } from './generatedTypes';
 
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
@@ -75,6 +77,8 @@ export type PermanentAddress = MyProfileQuery_myProfile_verifiedPersonalInformat
 
 export type ServiceConnectionsRoot = ServiceConnectionsQuery;
 export type ServiceConnectionsNode = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node;
+export type TranslationLanguage = HelTranslationLanguage;
+export type ServiceConnectionsQueryVariables = ServiceConnectionsQueryVars;
 export type Service = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service;
 // eslint-disable-next-line max-len
 export type ServiceAllowedFieldsNode = ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields_edges_node;

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { ApolloError, useLazyQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 import { useTranslation } from 'react-i18next';
@@ -9,12 +9,16 @@ import { useMatomo } from '@datapunt/matomo-tracker-react';
 
 import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
-import { ServiceConnectionsRoot } from '../../../graphql/typings';
+import {
+  ServiceConnectionsQueryVariables,
+  ServiceConnectionsRoot,
+} from '../../../graphql/typings';
 import styles from './deleteProfile.module.css';
 import useDeleteProfile from '../../../gdprApi/useDeleteProfile';
 import ModalServicesContent from '../modals/deleteProfileContent/DeleteProfileContent';
 import { useFocusSetter } from '../../hooks/useFocusSetter';
 import DeleteProfileError from '../modals/deleteProfileError/DeleteProfileError';
+import createServiceConnectionsQueryVariables from '../../helpers/createServiceConnectionsQueryVariables';
 
 const SERVICE_CONNECTIONS = loader(
   '../../graphql/ServiceConnectionsQuery.graphql'
@@ -63,10 +67,11 @@ function DeleteProfile(): React.ReactElement {
     targetId: `delete-profile-button`,
   });
 
-  const [
-    getServiceConnections,
-    { data: serviceConnections, refetch },
-  ] = useLazyQuery<ServiceConnectionsRoot>(SERVICE_CONNECTIONS, {
+  const [getServiceConnections, { data: serviceConnections }] = useLazyQuery<
+    ServiceConnectionsRoot,
+    ServiceConnectionsQueryVariables
+  >(SERVICE_CONNECTIONS, {
+    variables: createServiceConnectionsQueryVariables(i18n.language),
     onCompleted: () => {
       setDataLoadState(loadedLoadState);
     },
@@ -74,23 +79,6 @@ function DeleteProfile(): React.ReactElement {
       setDataLoadState(errorLoadState);
       Sentry.captureException(error);
     },
-  });
-
-  useEffect(() => {
-    const cb = () => {
-      if (refetch) {
-        const asyncRefetch = async () => {
-          setDataLoadState(loadingLoadState);
-          await refetch();
-          setDataLoadState(loadedLoadState);
-        };
-        asyncRefetch();
-      }
-    };
-    i18n.on('languageChanged', cb);
-    return () => {
-      i18n.off('languageChanged', cb);
-    };
   });
 
   const loadServiceConnections = useCallback(

--- a/src/profile/components/deleteProfile/__tests__/DeleteProfile.test.tsx
+++ b/src/profile/components/deleteProfile/__tests__/DeleteProfile.test.tsx
@@ -10,6 +10,8 @@ import {
 import DeleteProfile from '../DeleteProfile';
 import { ResponseProvider } from '../../../../common/test/MockApolloClientProvider';
 import getMyProfileWithServiceConnections from '../../../../common/test/getMyProfileWithServiceConnections';
+import i18n from '../../../../common/test/testi18nInit';
+import { ServiceConnectionsQueryVariables } from '../../../../graphql/typings';
 
 const mockStartFetchingAuthorizationCode = jest.fn();
 
@@ -21,7 +23,7 @@ jest.mock('../../../../gdprApi/useAuthorizationCode.ts', () => () => [
 describe('<DeleteProfile /> ', () => {
   let responseCounter = -1;
   const serviceConnections = getMyProfileWithServiceConnections();
-
+  const queryVariableTracker = jest.fn();
   let showComponent: React.Dispatch<React.SetStateAction<boolean>>;
 
   const ComponentRendererWithForceUpdate = (): React.ReactElement => {
@@ -31,8 +33,9 @@ describe('<DeleteProfile /> ', () => {
   };
 
   const renderTestSuite = (errorResponseIndex = -1) => {
-    const responseProvider: ResponseProvider = () => {
+    const responseProvider: ResponseProvider = payload => {
       responseCounter = responseCounter + 1;
+      queryVariableTracker(payload as ServiceConnectionsQueryVariables);
       return responseCounter === errorResponseIndex
         ? { errorType: 'networkError' }
         : { profileDataWithServiceConnections: serviceConnections };
@@ -68,6 +71,7 @@ describe('<DeleteProfile /> ', () => {
   });
   afterEach(() => {
     cleanComponentMocks();
+    jest.resetAllMocks();
   });
 
   const initTests = async (errorResponseIndex = -1): Promise<TestTools> => {
@@ -77,13 +81,19 @@ describe('<DeleteProfile /> ', () => {
 
   it(`toggle button opens the panel 
       which first loads service connections 
-      and then shows a checkbox and a submit button`, async () => {
+      and then shows a checkbox and a submit button.
+      Current language is sent as a variable. Value must be in uppercase
+      `, async () => {
     await act(async () => {
       const { clickElement, waitForElement } = await initTests();
       await clickElement(toggleButton);
       await waitForElement(loadIndicator);
       await waitForElement(checkbox);
       await waitForElement(submitButton);
+
+      expect(queryVariableTracker).toHaveBeenCalledWith({
+        language: i18n.language.toUpperCase(),
+      });
     });
   });
 

--- a/src/profile/components/serviceConnections/ServiceConnections.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnections.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { loader } from 'graphql.macro';
 import { useQuery } from '@apollo/client';
@@ -9,10 +9,14 @@ import Explanation from '../../../common/explanation/Explanation';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
 import CheckedLabel from '../../../common/checkedLabel/CheckedLabel';
 import styles from './ServiceConnections.module.css';
-import { ServiceConnectionsRoot } from '../../../graphql/typings';
+import {
+  ServiceConnectionsQueryVariables,
+  ServiceConnectionsRoot,
+} from '../../../graphql/typings';
 import getServiceConnectionData from '../../helpers/getServiceConnectionData';
 import getAllowedDataFieldsFromService from '../../helpers/getAllowedDataFieldsFromService';
 import useToast from '../../../toast/useToast';
+import createServiceConnectionsQueryVariables from '../../helpers/createServiceConnectionsQueryVariables';
 
 const SERVICE_CONNECTIONS = loader(
   '../../graphql/ServiceConnectionsQuery.graphql'
@@ -23,25 +27,15 @@ type Props = Record<string, unknown>;
 function ServiceConnections(props: Props): React.ReactElement {
   const { t, i18n } = useTranslation();
   const { createToast } = useToast();
-
-  const { data, loading, refetch } = useQuery<ServiceConnectionsRoot>(
-    SERVICE_CONNECTIONS,
-    {
-      onError: (error: Error) => {
-        Sentry.captureException(error);
-        createToast({ type: 'error' });
-      },
-    }
-  );
-
-  // Refetch services when language changes, services are translated based on
-  // Accept-Language header which is set in the graphql-client (src/graphql/client).
-  useEffect(() => {
-    const cb = () => refetch();
-    i18n.on('languageChanged', cb);
-    return () => {
-      i18n.off('languageChanged', cb);
-    };
+  const { data, loading } = useQuery<
+    ServiceConnectionsRoot,
+    ServiceConnectionsQueryVariables
+  >(SERVICE_CONNECTIONS, {
+    variables: createServiceConnectionsQueryVariables(i18n.language),
+    onError: (error: Error) => {
+      Sentry.captureException(error);
+      createToast({ type: 'error' });
+    },
   });
 
   const getDateTime = (date: Date) => {

--- a/src/profile/components/serviceConnections/__tests__/ServiceConnections.test.tsx
+++ b/src/profile/components/serviceConnections/__tests__/ServiceConnections.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import getMyProfileWithServiceConnections from '../../../../common/test/getMyProfileWithServiceConnections';
+import {
+  MockedResponse,
+  resetApolloMocks,
+  ResponseProvider,
+} from '../../../../common/test/MockApolloClientProvider';
+import { renderComponentWithMocksAndContexts } from '../../../../common/test/testingLibraryTools';
+import {
+  AnyObject,
+  ServiceConnectionsQueryVariables,
+} from '../../../../graphql/typings';
+import getServiceConnectionData from '../../../helpers/getServiceConnectionData';
+import ServiceConnections from '../ServiceConnections';
+import i18n from '../../../../common/test/testi18nInit';
+
+describe('<ServiceConnections />', () => {
+  const queryVariableTracker = jest.fn();
+  const renderTestSuite = (responses: MockedResponse[]) => {
+    const responseProvider: ResponseProvider = payload => {
+      queryVariableTracker(payload as ServiceConnectionsQueryVariables);
+      return responses.shift() as MockedResponse;
+    };
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <ServiceConnections />
+    );
+  };
+
+  const queryResultWithServiceConnection = getMyProfileWithServiceConnections();
+  const serviceList = getServiceConnectionData(
+    queryResultWithServiceConnection
+  );
+  const queryResultWithoutServiceConnections = getMyProfileWithServiceConnections();
+  ((queryResultWithoutServiceConnections.myProfile as unknown) as AnyObject).serviceConnections = null;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+    resetApolloMocks();
+  });
+
+  it('should render all service connections', async () => {
+    const responses: MockedResponse[] = [
+      { profileDataWithServiceConnections: queryResultWithServiceConnection },
+    ];
+    await act(async () => {
+      const { getElement } = await renderTestSuite(responses);
+      await waitFor(() =>
+        serviceList.forEach(service => {
+          expect(getElement({ text: service.title as string })).toBeDefined();
+        })
+      );
+    });
+  });
+  it('should render specific text if there are no service connections', async () => {
+    const t = i18n.getFixedT('fi');
+    const responses: MockedResponse[] = [
+      {
+        profileDataWithServiceConnections: queryResultWithoutServiceConnections,
+      },
+    ];
+    await act(async () => {
+      const { getElement } = await renderTestSuite(responses);
+      await waitFor(() => {
+        expect(
+          getElement({ text: t('serviceConnections.empty') })
+        ).toBeDefined();
+      });
+    });
+  });
+  it('should send current language as a variable. Value must be in uppercase', async () => {
+    const responses: MockedResponse[] = [
+      { profileDataWithServiceConnections: queryResultWithServiceConnection },
+    ];
+    const lang = 'af';
+    i18n.language = lang;
+    await act(async () => {
+      const { waitForElement } = await renderTestSuite(responses);
+      await waitForElement({ text: serviceList[0].title as string });
+      expect(queryVariableTracker).toHaveBeenCalledWith({
+        language: lang.toUpperCase(),
+      });
+    });
+  });
+});

--- a/src/profile/graphql/ServiceConnectionsQuery.graphql
+++ b/src/profile/graphql/ServiceConnectionsQuery.graphql
@@ -1,17 +1,17 @@
-query ServiceConnectionsQuery {
+query ServiceConnectionsQuery($language: HelTranslationLanguage!) {
   myProfile {
     id
     serviceConnections {
       edges {
         node {
           service {
-            title
-            description
+            title @hel_translation(in: $language)
+            description @hel_translation(in: $language)
             allowedDataFields {
               edges {
                 node {
                   fieldName
-                  label
+                  label @hel_translation(in: $language)
                 }
               }
             }

--- a/src/profile/helpers/createServiceConnectionsQueryVariables.ts
+++ b/src/profile/helpers/createServiceConnectionsQueryVariables.ts
@@ -1,0 +1,15 @@
+import getLanguageCode from '../../common/helpers/getLanguageCode';
+import {
+  ServiceConnectionsQueryVariables,
+  TranslationLanguage,
+} from '../../graphql/typings';
+
+export default function createServiceConnectionsQueryVariables(
+  langOrLangAndLocale: string
+): ServiceConnectionsQueryVariables {
+  return {
+    language: getLanguageCode(
+      langOrLangAndLocale
+    ).toUpperCase() as TranslationLanguage,
+  };
+}

--- a/src/profile/hooks/__tests__/useProfileMutations.test.ts
+++ b/src/profile/hooks/__tests__/useProfileMutations.test.ts
@@ -34,7 +34,7 @@ describe('useProfileMutations.ts ', () => {
     updateVariables.length = 0;
   });
   const responseProvider: ResponseProvider = variables => {
-    updateVariables.push(variables);
+    updateVariables.push(variables as UpdateMyProfileVariables);
     return responses.shift() as MockedResponse;
   };
 


### PR DESCRIPTION
Added current language as a variable when querying for service connections. When language is changed, the texts are refetched instead of cache hit, which caused the bug.