### PR TITLE
HP-1204: Increase yarn timeout in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ USER root
 RUN bash /tools/apt-install.sh build-essential
 
 USER appuser
+RUN yarn config set network-timeout 300000
 RUN yarn && yarn cache clean --force
 
 USER root


### PR DESCRIPTION
Build fails in Azure stage and IBM suggested this as a cure.