### PR TITLE
HP-908 remove useless profile exists check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import authService from './auth/authService';
 import config from './config';
 import PageNotFound from './common/pageNotFound/PageNotFound';
 import { useHistoryListener } from './profile/hooks/useHistoryListener';
+import WithAuthCheck from './profile/components/withAuthCheck/WithAuthCheck';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -62,7 +63,7 @@ function App(): React.ReactElement {
                 <Login />
               </Route>
               <Route path={['/', '/connected-services']} exact>
-                <Profile />
+                <WithAuthCheck AuthenticatedComponent={Profile}></WithAuthCheck>
               </Route>
               <Route path="/accessibility" exact>
                 <AccessibilityStatement />

--- a/src/common/test/commonUiActions.ts
+++ b/src/common/test/commonUiActions.ts
@@ -1,0 +1,16 @@
+import { waitFor } from '@testing-library/react';
+
+import { TestTools } from './testingLibraryTools';
+
+export async function submitCreateProfileForm(
+  testTools: TestTools
+): Promise<void> {
+  const { clickElement, isDisabled, getElement } = testTools;
+  await clickElement({ id: 'create-profile-terms' });
+  await waitFor(() => {
+    if (isDisabled(getElement({ testId: 'create-profile-submit-button' }))) {
+      throw new Error('Button is disabled');
+    }
+  });
+  await clickElement({ testId: 'create-profile-submit-button' });
+}

--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -379,9 +379,14 @@ export const getErrorMessage = (error?: Error | GraphQLError): string => {
   if (!error) {
     return '';
   }
-  const retypedError = (error as unknown) as AnyObject<string>;
+  const retypedError = (error as unknown) as {
+    message: string;
+    networkError: string | { body: string };
+  };
   if (retypedError.networkError) {
-    return retypedError.networkError;
+    return typeof retypedError.networkError !== 'string'
+      ? retypedError.networkError.body
+      : retypedError.networkError;
   }
   return retypedError.message;
 };

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -454,36 +454,6 @@ export interface NameQuery {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL query operation: ProfileExistsQuery
-// ====================================================
-
-export interface ProfileExistsQuery_myProfile {
-  readonly __typename: "ProfileNode";
-  /**
-   * The ID of the object.
-   */
-  readonly id: string;
-}
-
-export interface ProfileExistsQuery {
-  /**
-   * Get the profile belonging to the currently authenticated user.
-   * 
-   * Requires authentication.
-   * 
-   * Possible error codes:
-   * 
-   * * `TODO`
-   */
-  readonly myProfile: ProfileExistsQuery_myProfile | null;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-// ====================================================
 // GraphQL query operation: ServiceConnectionsQuery
 // ====================================================
 

--- a/src/profile/components/createProfile/__tests__/CreateProfile.test.tsx
+++ b/src/profile/components/createProfile/__tests__/CreateProfile.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { User } from 'oidc-client';
-import { act, cleanup, waitFor } from '@testing-library/react';
+import { act, cleanup } from '@testing-library/react';
 
 import {
   renderComponentWithMocksAndContexts,
-  TestTools,
   waitForElementAttributeValue,
 } from '../../../../common/test/testingLibraryTools';
 import { ProfileData } from '../../../../graphql/typings';
@@ -19,13 +18,11 @@ import {
   getDefaultCountryCallingCode,
   getCountryCallingCodes,
 } from '../../../../i18n/countryCallingCodes.utils';
+import { submitCreateProfileForm } from '../../../../common/test/commonUiActions';
+import { mockProfileCreator } from '../../../../common/test/userMocking';
 describe('<CreateProfile />', () => {
   const tunnistamoUser = ({
-    profile: {
-      given_name: 'MyFirstName',
-      family_name: 'MyLastName',
-      email: 'email@domain.com',
-    },
+    profile: mockProfileCreator(),
     access_token: 'huuhaa',
     expired: false,
   } as unknown) as User;
@@ -57,17 +54,6 @@ describe('<CreateProfile />', () => {
     resetApolloMocks();
   });
 
-  const submitForm = async (testTools: TestTools): Promise<void> => {
-    const { clickElement, isDisabled, getElement } = testTools;
-    await clickElement({ id: 'create-profile-terms' });
-    await waitFor(() => {
-      if (isDisabled(getElement({ testId: 'create-profile-submit-button' }))) {
-        throw new Error('Button is disabled');
-      }
-    });
-    await clickElement({ testId: 'create-profile-submit-button' });
-  };
-
   it('is auto-filled with user data', async () => {
     await act(async () => {
       const { getTextOrInputValue } = await renderTestSuite();
@@ -94,7 +80,7 @@ describe('<CreateProfile />', () => {
         selector: { id: 'create-profile-lastName' },
         newValue: '',
       });
-      await submitForm(testTools);
+      await submitCreateProfileForm(testTools);
       await waitForElement({ id: 'create-profile-firstName-error' });
       await waitForElement({ id: 'create-profile-lastName-error' });
     });
@@ -116,7 +102,7 @@ describe('<CreateProfile />', () => {
         newValue: '123456',
       });
       await comboBoxSelector('create-profile-countryCallingCode', '');
-      await submitForm(testTools);
+      await submitCreateProfileForm(testTools);
       await waitForElement({ id: 'create-profile-countryCallingCode-error' });
       await waitForElementAttributeValue(
         () => getElement({ id: 'create-profile-countryCallingCode-input' }),
@@ -150,7 +136,7 @@ describe('<CreateProfile />', () => {
         },
         newValue: '123456',
       });
-      await submitForm(testTools);
+      await submitCreateProfileForm(testTools);
       await waitForElement({ testId: 'mock-toast-type-error' });
     });
   });

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { ApolloError } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
-import * as Sentry from '@sentry/browser';
 import { Button, Notification } from 'hds-react';
 
 import PageLayout from '../../../common/pageLayout/PageLayout';
@@ -12,30 +10,18 @@ import Loading from '../../../common/loading/Loading';
 import styles from './Profile.module.css';
 import authService from '../../../auth/authService';
 import responsive from '../../../common/cssHelpers/responsive.module.css';
-import { useProfileErrorListener } from '../../context/ProfileContext';
-import parseGraphQLError from '../../helpers/parseGraphQLError';
-import useToast from '../../../toast/useToast';
 import { useProfileLoadTracker } from '../../hooks/useProfileLoadTracker';
 import { WithAuthCheckChildProps } from '../withAuthCheck/WithAuthCheck';
 
 function Profile(props: WithAuthCheckChildProps): React.ReactElement {
   const { t } = useTranslation();
   const location = useLocation();
-  const { createToast } = useToast();
   const {
     hasExistingProfile,
     isProfileLoadComplete,
     didProfileLoadFail,
     reloadProfile,
   } = useProfileLoadTracker();
-
-  useProfileErrorListener((apolloError: ApolloError | Error) => {
-    if (parseGraphQLError(apolloError).isAllowedError) {
-      return;
-    }
-    Sentry.captureException(apolloError);
-    createToast({ type: 'error' });
-  });
 
   const getPageTitle = () => {
     const pathname = location.pathname.substr(1);

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -1,9 +1,7 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { useLazyQuery, ApolloError } from '@apollo/client';
+import React from 'react';
+import { ApolloError } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
-import { useHistory, useLocation } from 'react-router';
-import { loader } from 'graphql.macro';
-import { User } from 'oidc-client';
+import { useLocation } from 'react-router';
 import * as Sentry from '@sentry/browser';
 import { Button, Notification } from 'hds-react';
 
@@ -12,40 +10,25 @@ import CreateProfile from '../createProfile/CreateProfile';
 import ViewProfile from '../viewProfile/ViewProfile';
 import Loading from '../../../common/loading/Loading';
 import styles from './Profile.module.css';
-import { ProfileExistsQuery as ProfileExistsRoot } from '../../../graphql/generatedTypes';
 import authService from '../../../auth/authService';
 import responsive from '../../../common/cssHelpers/responsive.module.css';
-import {
-  ProfileContext,
-  useProfileErrorListener,
-} from '../../context/ProfileContext';
+import { useProfileErrorListener } from '../../context/ProfileContext';
 import parseGraphQLError from '../../helpers/parseGraphQLError';
 import useToast from '../../../toast/useToast';
-import { getLinkRedirectState } from '../../hooks/useHistoryListener';
+import { useProfileLoadTracker } from '../../hooks/useProfileLoadTracker';
+import { WithAuthCheckChildProps } from '../withAuthCheck/WithAuthCheck';
 
-const PROFILE_EXISTS = loader('../../graphql/ProfileExistsQuery.graphql');
-
-function Profile(): React.ReactElement {
+function Profile(props: WithAuthCheckChildProps): React.ReactElement {
   const { t } = useTranslation();
-  const history = useHistory();
   const location = useLocation();
   const { createToast } = useToast();
-
-  const [checkProfileExists, { data, loading, error }] = useLazyQuery<
-    ProfileExistsRoot
-  >(PROFILE_EXISTS, {
-    fetchPolicy: 'no-cache',
-    onError: (apolloError: ApolloError) => {
-      Sentry.captureException(apolloError);
-    },
-  });
   const {
-    fetch: fetchProfile,
-    isInitialized: isProfileInitialized,
-    isComplete: isProfileComplete,
-  } = useContext(ProfileContext);
-  const [isCheckingAuthState, setIsCheckingAuthState] = useState(true);
-  const [tunnistamoUser, setTunnistamoUser] = useState<User>();
+    hasExistingProfile,
+    isProfileLoadComplete,
+    didProfileLoadFail,
+    reloadProfile,
+  } = useProfileLoadTracker();
+
   useProfileErrorListener((apolloError: ApolloError | Error) => {
     if (parseGraphQLError(apolloError).isAllowedError) {
       return;
@@ -54,36 +37,13 @@ function Profile(): React.ReactElement {
     createToast({ type: 'error' });
   });
 
-  useEffect(() => {
-    authService
-      .getAuthenticatedUser()
-      .then(user => {
-        checkProfileExists();
-        setTunnistamoUser(user as User);
-        setIsCheckingAuthState(false);
-        return undefined;
-      })
-      .catch(() => history.push('/login', getLinkRedirectState()));
-  }, [checkProfileExists, history]);
-
-  const isDoingProfileChecks = isCheckingAuthState || loading;
-  const isProfileFound = !!(data && data.myProfile);
-  const failedToFetchUserProfileData =
-    tunnistamoUser && !isProfileFound && !!error;
-
-  useEffect(() => {
-    if (isProfileFound && !isProfileInitialized) {
-      fetchProfile();
-    }
-  }, [fetchProfile, isProfileFound, isProfileInitialized]);
-
-  const isLoadingProfile = isProfileFound && !isProfileComplete;
-
   const getPageTitle = () => {
     const pathname = location.pathname.substr(1);
 
-    if (!isDoingProfileChecks && pathname.length === 0) {
-      return isProfileFound ? 'nav.information' : 'createProfile.pageTitle';
+    if (isProfileLoadComplete() && pathname.length === 0) {
+      return hasExistingProfile()
+        ? 'nav.information'
+        : 'createProfile.pageTitle';
     }
 
     switch (pathname) {
@@ -93,60 +53,64 @@ function Profile(): React.ReactElement {
         return 'appName';
     }
   };
-  if (failedToFetchUserProfileData) {
-    return (
-      <PageLayout title={'notification.defaultErrorTitle'}>
-        <div
-          className={styles['error-wrapper']}
-          data-testid="profile-check-error-layout"
-        >
-          <div className={responsive['max-width-centered']}>
-            <Notification
-              type={'error'}
-              label={t('notification.defaultErrorTitle')}
-            >
-              {t('profile.loadErrorText')}
-            </Notification>
-            <div className={styles['error-button-wrapper']}>
-              <Button
-                onClick={() => checkProfileExists()}
-                data-testid={'profile-check-error-reload-button'}
+
+  if (isProfileLoadComplete()) {
+    if (didProfileLoadFail()) {
+      return (
+        <PageLayout title={'notification.defaultErrorTitle'}>
+          <div
+            className={styles['error-wrapper']}
+            data-testid="profile-check-error-layout"
+          >
+            <div className={responsive['max-width-centered']}>
+              <Notification
+                type={'error'}
+                label={t('notification.defaultErrorTitle')}
               >
-                {t('profile.reload')}
-              </Button>
-              <Button
-                onClick={() => authService.logout()}
-                data-testid={'profile-check-error-logout-button'}
-                variant={'secondary'}
-              >
-                {t('nav.signout')}
-              </Button>
+                {t('profile.loadErrorText')}
+              </Notification>
+              <div className={styles['error-button-wrapper']}>
+                <Button
+                  onClick={() => reloadProfile()}
+                  data-testid={'profile-check-error-reload-button'}
+                >
+                  {t('profile.reload')}
+                </Button>
+                <Button
+                  onClick={() => authService.logout()}
+                  data-testid={'profile-check-error-logout-button'}
+                  variant={'secondary'}
+                >
+                  {t('nav.signout')}
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
+        </PageLayout>
+      );
+    }
+    if (hasExistingProfile()) {
+      return (
+        <PageLayout title={getPageTitle()}>
+          <ViewProfile />
+        </PageLayout>
+      );
+    }
+    return (
+      <PageLayout title={getPageTitle()}>
+        <CreateProfile
+          tunnistamoUser={props.user}
+          onProfileCreated={() => reloadProfile()}
+        />
+        ;
       </PageLayout>
     );
   }
 
   return (
     <PageLayout title={getPageTitle()} disableFocusing>
-      <Loading
-        isLoading={isDoingProfileChecks || isLoadingProfile}
-        loadingText={t('profile.loading')}
-      >
-        {isProfileFound ? (
-          <ViewProfile />
-        ) : (
-          tunnistamoUser && (
-            <CreateProfile
-              tunnistamoUser={tunnistamoUser}
-              onProfileCreated={() => checkProfileExists()}
-            />
-          )
-        )}
-      </Loading>
+      <Loading isLoading loadingText={t('profile.loading')} />
     </PageLayout>
   );
 }
-
 export default Profile;

--- a/src/profile/components/profile/__tests__/Profile.test.tsx
+++ b/src/profile/components/profile/__tests__/Profile.test.tsx
@@ -44,6 +44,8 @@ describe('<Profile />', () => {
     loadIndicator: { testId: 'load-indicator' },
     profileHeading: { testId: 'view-profile-heading' },
     createProfileHeading: { testId: 'create-profile-heading' },
+    errorLayout: { testId: 'profile-check-error-layout' },
+    errorLayoutReloadButton: { testId: 'profile-check-error-reload-button' },
   };
 
   it('should render load indicator and then CreateProfile when profile does not exist', async () => {
@@ -101,18 +103,18 @@ describe('<Profile />', () => {
       await waitForElement(selectors.profileHeading);
     });
   });
-  it('should render error Toast when query fails', async () => {
+  it('should render an error notification when query fails', async () => {
     const responses: MockedResponse[] = [{ errorType: 'graphQLError' }];
     await act(async () => {
       const { waitForElement } = await renderTestSuite(responses);
-      await waitForElement({ testId: 'mock-toast-type-error' });
+      await waitForElement(selectors.errorLayout);
     });
   });
   it('should render an error notification when profile load fails', async () => {
     const responses: MockedResponse[] = [{ errorType: 'networkError' }];
     await act(async () => {
       const { waitForElement } = await renderTestSuite(responses);
-      await waitForElement({ testId: 'profile-check-error-layout' });
+      await waitForElement(selectors.errorLayout);
     });
   });
   it('should retry profile load when reload button is clicked', async () => {
@@ -122,8 +124,8 @@ describe('<Profile />', () => {
     ];
     await act(async () => {
       const { waitForElement, clickElement } = await renderTestSuite(responses);
-      await waitForElement({ testId: 'profile-check-error-layout' });
-      await clickElement({ testId: 'profile-check-error-reload-button' });
+      await waitForElement(selectors.errorLayout);
+      await clickElement(selectors.errorLayoutReloadButton);
       await waitForElement(selectors.profileHeading);
     });
   });

--- a/src/profile/components/withAuthCheck/WithAuthCheck.tsx
+++ b/src/profile/components/withAuthCheck/WithAuthCheck.tsx
@@ -1,0 +1,42 @@
+import { User } from 'oidc-client';
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+
+import authService from '../../../auth/authService';
+import Loading from '../../../common/loading/Loading';
+import PageLayout from '../../../common/pageLayout/PageLayout';
+import { getLinkRedirectState } from '../../hooks/useHistoryListener';
+
+export type WithAuthCheckChildProps = { user: User };
+
+const WithAuthCheck = ({
+  AuthenticatedComponent,
+}: {
+  AuthenticatedComponent: React.FC<WithAuthCheckChildProps>;
+}): React.ReactElement => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const [user, setUser] = useState<User | null>(null);
+
+  useMemo(() => {
+    authService
+      .getAuthenticatedUser()
+      .then(authenticatedUser => {
+        setUser(authenticatedUser);
+      })
+      .catch(() => {
+        history.push('/login', getLinkRedirectState());
+      });
+  }, [history]);
+  if (!user) {
+    return (
+      <PageLayout title={t('appName')} disableFocusing>
+        <Loading isLoading loadingText={t('loading')} />
+      </PageLayout>
+    );
+  }
+  return <AuthenticatedComponent user={user} />;
+};
+
+export default WithAuthCheck;

--- a/src/profile/components/withAuthCheck/__tests__/WithAuthCheck.test.tsx
+++ b/src/profile/components/withAuthCheck/__tests__/WithAuthCheck.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { act, waitFor } from '@testing-library/react';
+import { User } from 'oidc-client';
+
+import { renderComponentWithMocksAndContexts } from '../../../../common/test/testingLibraryTools';
+import WithAuthCheck, { WithAuthCheckChildProps } from '../WithAuthCheck';
+import { MockedResponse } from '../../../../common/test/MockApolloClientProvider';
+import { mockUserCreator } from '../../../../common/test/userMocking';
+import authService from '../../../../auth/authService';
+import { getLinkRedirectState } from '../../../hooks/useHistoryListener';
+
+const mockedHistory = {
+  push: jest.fn(),
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn().mockImplementation(() => mockedHistory),
+}));
+
+describe('<WithAuthCheck /> ', () => {
+  const mockedUser = mockUserCreator();
+  const timeoutInMs = 60;
+  const getAuthenticatedUserMock = jest.fn();
+  const authenticatedUserTestId = 'authenticated-user';
+
+  const TestComponent = (props: WithAuthCheckChildProps) => (
+    <div data-testid={authenticatedUserTestId}>{props.user.access_token}</div>
+  );
+  const WithAuthCheckAndTestComponent = () => (
+    <WithAuthCheck AuthenticatedComponent={TestComponent} />
+  );
+  const renderTestSuite = () =>
+    renderComponentWithMocksAndContexts(
+      () => ({} as MockedResponse),
+      <WithAuthCheckAndTestComponent />
+    );
+
+  const mockAuthenticationProcess = (success = true) => {
+    const authPromise: Promise<User | null> = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        success ? resolve(mockedUser) : reject(null);
+      }, timeoutInMs);
+    });
+    jest.spyOn(authService, 'getAuthenticatedUser').mockImplementation(() => {
+      getAuthenticatedUserMock();
+      return authPromise;
+    });
+    return authPromise;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    getAuthenticatedUserMock.mockReset();
+    mockedHistory.push.mockReset();
+    // to end all possibly existing timeouts
+    jest.advanceTimersByTime(timeoutInMs * 10);
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders a load-indicator while waiting for user data.', async () => {
+    mockAuthenticationProcess(false);
+    await act(async () => {
+      const { waitForElement } = await renderTestSuite();
+      await waitForElement({ testId: 'load-indicator' });
+    });
+  });
+
+  it('redirects to /login when user is not authenticated.', async () => {
+    mockAuthenticationProcess(false);
+    await act(async () => {
+      await renderTestSuite();
+      await waitFor(() => {
+        expect(mockedHistory.push).toHaveBeenCalledTimes(1);
+        expect(mockedHistory.push).toHaveBeenLastCalledWith(
+          '/login',
+          getLinkRedirectState()
+        );
+      });
+    });
+  });
+  it('renders the child component when user is authenticated. User is passed as a prop.', async () => {
+    mockAuthenticationProcess(true);
+    await act(async () => {
+      const { waitForElement, getElement } = await renderTestSuite();
+      await waitForElement({ testId: authenticatedUserTestId });
+      const userAccessToken = getElement({ testId: authenticatedUserTestId })
+        ?.innerHTML;
+      expect(userAccessToken).toBe(mockedUser.access_token);
+    });
+  });
+});

--- a/src/profile/context/ProfileContext.tsx
+++ b/src/profile/context/ProfileContext.tsx
@@ -32,6 +32,7 @@ export type ProfileContextData = {
   isInitialized: boolean;
   isComplete: boolean;
   getName: (preferNickOrGivenName?: boolean) => string;
+  getProfile: () => ProfileRoot | null;
 };
 
 export const ProfileContext = createContext<ProfileContextData>({
@@ -46,6 +47,7 @@ export const ProfileContext = createContext<ProfileContextData>({
   isInitialized: false,
   isComplete: false,
   getName: () => '',
+  getProfile: () => null,
 });
 
 export const Provider = (props: ContextProps): React.ReactElement => {
@@ -145,6 +147,8 @@ export const Provider = (props: ContextProps): React.ReactElement => {
           : `${source.firstName} ${source.lastName}`;
       }
     },
+    getProfile: () =>
+      profileData && profileData.myProfile ? profileData : null,
   };
 
   return (

--- a/src/profile/context/__tests__/ProfileContext.test.tsx
+++ b/src/profile/context/__tests__/ProfileContext.test.tsx
@@ -28,6 +28,7 @@ describe('ProfileContext', () => {
     expect(context.loading).toEqual(false);
     expect(context.isInitialized).toEqual(false);
     expect(context.isComplete).toEqual(false);
+    expect(context.getProfile()).toBeNull();
   });
 
   it("after fetch(), context indicates 'loading' state and data updates when fetch is finished", async () => {
@@ -56,6 +57,24 @@ describe('ProfileContext', () => {
       expect(context.data?.myProfile?.firstName).toEqual('Teemu');
       expect(context.getName()).toEqual('Teemu Testaaja');
       expect(context.getName(true)).toEqual('Teme');
+      expect(context.getProfile()).toEqual(getMyProfile());
+    });
+  });
+  it("load is successful also when user's profile does not exist", async () => {
+    const responses: MockedResponse[] = [{ profileData: null }];
+    const { result, waitForUpdate } = createTestEnv(responses);
+    let context = result.current;
+    await act(async () => {
+      const loadingPromise = waitForUpdate();
+      context.fetch();
+      await loadingPromise;
+      context = result.current;
+      const dataLoadedPromise = waitForUpdate();
+      await dataLoadedPromise;
+      context = result.current;
+      expect(context.data).toEqual({ myProfile: null });
+      expect(context.isComplete).toEqual(true);
+      expect(context.getProfile()).toBeNull();
     });
   });
   it('Fetch errors are handled and listeners triggered and disposed', async () => {
@@ -80,6 +99,7 @@ describe('ProfileContext', () => {
       expect(context.loading).toEqual(false);
       expect(context.isInitialized).toEqual(true);
       expect(context.isComplete).toEqual(false);
+      expect(context.getProfile()).toBeNull();
       await waitFor(() => {
         expect(errorListener.mock.calls.length).toEqual(1);
         expect(errorListener2.mock.calls.length).toEqual(1);

--- a/src/profile/graphql/ProfileExistsQuery.graphql
+++ b/src/profile/graphql/ProfileExistsQuery.graphql
@@ -1,5 +1,0 @@
-query ProfileExistsQuery {
-  myProfile {
-    id
-  }
-}

--- a/src/profile/hooks/__tests__/useProfileLoadTracker.test.ts
+++ b/src/profile/hooks/__tests__/useProfileLoadTracker.test.ts
@@ -1,0 +1,299 @@
+import { waitFor } from '@testing-library/react';
+import { RenderHookResult, act } from '@testing-library/react-hooks';
+import { ApolloError } from '@apollo/client';
+
+import {
+  RenderHookResultsChildren,
+  cleanComponentMocks,
+} from '../../../common/test/testingLibraryTools';
+import {
+  createApolloErrorWithAllowedPermissionError,
+  MockedResponse,
+} from '../../../common/test/MockApolloClientProvider';
+import { getMyProfile } from '../../../common/test/myProfileMocking';
+import { ProfileRoot } from '../../../graphql/typings';
+import {
+  useProfileLoadTracker,
+  useProfileLoaderHookReturnType,
+} from '../useProfileLoadTracker';
+import { exposeHook } from '../../../common/test/exposeHooksForTesting';
+import * as profileQueryModule from '../useProfileQuery';
+
+type RenderResult = RenderHookResult<
+  RenderHookResultsChildren,
+  useProfileLoaderHookReturnType
+>;
+
+type UseProfileQueryReturnType = ReturnType<
+  typeof profileQueryModule['useProfileQuery']
+>;
+
+describe('useProfileLoader.ts ', () => {
+  let mockUseProfileQueryResult: UseProfileQueryReturnType;
+  const fetchProfileMock = jest.fn();
+  const refetchProfileMock = jest.fn();
+  const successfulProfileLoadData = { data: getMyProfile() };
+  const timeoutInMs = 60;
+  const advanceTimers = () => jest.advanceTimersByTime(timeoutInMs + 1);
+
+  // Mocking the useProfile hook. It is used by ProfileContext, which is used by useProfileLoadTracker
+  // Results from fetch() and refetch() are not used, only changes in the profile context.
+  // So those mocked functions can return undefined - except refetch must return profile data (typescript requirement)
+  const createUseProfileQueryResultMock = (): UseProfileQueryReturnType => ({
+    data: undefined,
+    loading: false,
+    error: undefined,
+    fetch: async () => {
+      fetchProfileMock();
+      return Promise.resolve();
+    },
+    refetch: async () => {
+      refetchProfileMock();
+      return Promise.resolve(successfulProfileLoadData);
+    },
+  });
+
+  // Update mockUseProfileQueryResult returned from useProfile hook (mocked)
+  const updateMockUseProfileQueryResult = (
+    props: Partial<UseProfileQueryReturnType>
+  ) => {
+    mockUseProfileQueryResult = {
+      ...mockUseProfileQueryResult,
+      ...props,
+    };
+  };
+
+  // Not setting this is beforeEach, because act() do not work with it.
+  const initTests = async (): Promise<RenderResult> => {
+    const renderHookResult = exposeHook<useProfileLoaderHookReturnType>(
+      () => ({} as MockedResponse),
+      () => useProfileLoadTracker(),
+      false
+    );
+    return Promise.resolve(renderHookResult);
+  };
+
+  // Better to simulate actual load process
+  // and not skip the loading phase.
+  // First { loading: true } is set
+  // and data / error after that
+  const mockProfileLoadProcess = ({
+    data,
+    error,
+  }: {
+    data?: ProfileRoot;
+    error?: ApolloError;
+  }) => {
+    const loadingPromise = new Promise(resolve => {
+      setTimeout(() => {
+        updateMockUseProfileQueryResult({ loading: true });
+        resolve(true);
+      }, timeoutInMs);
+    });
+    const dataIsSetPromise = new Promise(resolve => {
+      setTimeout(() => {
+        updateMockUseProfileQueryResult({
+          data,
+          error,
+          loading: false,
+        });
+        resolve(true);
+      }, timeoutInMs * 2);
+    });
+
+    return {
+      loadingPromise,
+      dataIsSetPromise,
+    };
+  };
+
+  const waitForProfileLoadToEnd = async (renderHookResult: RenderResult) =>
+    waitFor(async () => {
+      const currentHookProps = renderHookResult.result.current;
+      if (currentHookProps.isProfileLoadComplete() === false) {
+        advanceTimers();
+        renderHookResult.rerender();
+        throw new Error('Profile load is not complete');
+      }
+    });
+
+  // Function for advancing straight to point where
+  // profile loading is complete (success / failure)
+  const proceedToProfileLoadCompleteState = async ({
+    loadSuccess,
+    profileExist,
+    addAllowedGraphQLError,
+  }: {
+    loadSuccess: boolean;
+    profileExist: boolean;
+    addAllowedGraphQLError: boolean;
+  }) => {
+    const renderHookResult = await initTests();
+    const result = profileExist
+      ? { data: loadSuccess ? getMyProfile() : undefined }
+      : { data: { myProfile: null } };
+    const errorObj = addAllowedGraphQLError
+      ? createApolloErrorWithAllowedPermissionError()
+      : (({} as unknown) as ApolloError);
+    const error = loadSuccess ? undefined : errorObj;
+    mockProfileLoadProcess({ ...result, error });
+    await waitForProfileLoadToEnd(renderHookResult);
+    return { renderHookResult };
+  };
+
+  beforeEach(() => {
+    mockUseProfileQueryResult = createUseProfileQueryResultMock();
+    jest
+      .spyOn(profileQueryModule, 'useProfileQuery')
+      .mockImplementation(() => mockUseProfileQueryResult);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanComponentMocks();
+    jest.resetAllMocks();
+    // to end all possibly existing timeouts
+    jest.advanceTimersByTime(timeoutInMs * 10);
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('useProfileLoader() hook tracks changes in profile context.', () => {
+    it(`Profile should not be loaded at all, if it is already loaded. In this case
+        - hook.isProfileLoadComplete() returns true
+        - hook.hasExistingProfile() returns true
+        - hook.didProfileLoadFail() returns false`, async () => {
+      await act(async () => {
+        updateMockUseProfileQueryResult({
+          ...successfulProfileLoadData,
+          loading: false,
+        });
+
+        const renderHookResult = await initTests();
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.isProfileLoadComplete()).toBeTruthy();
+        expect(currentHookProps.hasExistingProfile()).toBeTruthy();
+        expect(fetchProfileMock).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it(`Profile should not be loaded at all, if context has an error. In this case
+        - hook.hasExistingProfile() returns false
+        - hook.didProfileLoadFail() returns true
+        - hook.isProfileLoadComplete() returns true`, async () => {
+      await act(async () => {
+        updateMockUseProfileQueryResult({
+          error: {} as ApolloError,
+          loading: false,
+        });
+
+        const renderHookResult = await initTests();
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.isProfileLoadComplete()).toBeTruthy();
+        expect(currentHookProps.hasExistingProfile()).toBeFalsy();
+        expect(fetchProfileMock).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it(`When profile load is successful and profile exists
+        - hook.hasExistingProfile() returns true
+        - hook.didProfileLoadFail() returns false
+        - hook.isProfileLoadComplete() returns true.
+        Response can include an allowed graphQL error.`, async () => {
+      await act(async () => {
+        const { renderHookResult } = await proceedToProfileLoadCompleteState({
+          loadSuccess: true,
+          profileExist: true,
+          addAllowedGraphQLError: true,
+        });
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.hasExistingProfile()).toBeTruthy();
+        expect(currentHookProps.didProfileLoadFail()).toBeFalsy();
+        expect(currentHookProps.isProfileLoadComplete()).toBeTruthy();
+        expect(fetchProfileMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it(`When profile load is successful, but profile does not exist, 
+        - hook.hasExistingProfile() returns false
+        - hook.didProfileLoadFail() returns false
+        - hook.isProfileLoadComplete() returns true`, async () => {
+      await act(async () => {
+        const { renderHookResult } = await proceedToProfileLoadCompleteState({
+          loadSuccess: true,
+          profileExist: false,
+          addAllowedGraphQLError: false,
+        });
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.hasExistingProfile()).toBeFalsy();
+        expect(currentHookProps.didProfileLoadFail()).toBeFalsy();
+        expect(currentHookProps.isProfileLoadComplete()).toBeTruthy();
+        expect(fetchProfileMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it(`When profile load fails
+        - hook.hasExistingProfile() returns false
+        - hook.didProfileLoadFail() returns true
+        - hook.isProfileLoadComplete() returns true`, async () => {
+      await act(async () => {
+        const { renderHookResult } = await proceedToProfileLoadCompleteState({
+          loadSuccess: false,
+          profileExist: true,
+          addAllowedGraphQLError: false,
+        });
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.isProfileLoadComplete()).toBeTruthy();
+        expect(currentHookProps.didProfileLoadFail()).toBeTruthy();
+        expect(currentHookProps.hasExistingProfile()).toBeFalsy();
+        expect(fetchProfileMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it(`Hook provides a reloadProfile() function for refetching profile when
+        - load fails
+        - profile is fetched after it is created for first time.`, async () => {
+      await act(async () => {
+        const { renderHookResult } = await proceedToProfileLoadCompleteState({
+          loadSuccess: false,
+          profileExist: true,
+          addAllowedGraphQLError: false,
+        });
+        const currentHookProps = renderHookResult.result.current;
+        expect(currentHookProps.didProfileLoadFail()).toBeTruthy();
+        expect(currentHookProps.hasExistingProfile()).toBeFalsy();
+        updateMockUseProfileQueryResult({
+          error: undefined,
+          loading: true,
+          data: undefined,
+        });
+        mockProfileLoadProcess({
+          ...successfulProfileLoadData,
+        });
+        currentHookProps.reloadProfile();
+
+        await waitForProfileLoadToEnd(renderHookResult);
+        const updatedHookProps = renderHookResult.result.current;
+        expect(updatedHookProps.didProfileLoadFail()).toBeFalsy();
+        expect(updatedHookProps.hasExistingProfile()).toBeTruthy();
+
+        expect(fetchProfileMock).toHaveBeenCalledTimes(1);
+        expect(refetchProfileMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('Hook.hasExistingProfile() throws, when used before profile load is complete', async () => {
+      await act(async () => {
+        const renderHookResult = await initTests();
+        const currentHookProps = renderHookResult.result.current;
+        expect(() => currentHookProps.hasExistingProfile()).toThrow();
+        mockProfileLoadProcess(successfulProfileLoadData);
+        await waitForProfileLoadToEnd(renderHookResult);
+        expect(() => currentHookProps.hasExistingProfile()).not.toThrow();
+      });
+    });
+  });
+});

--- a/src/profile/hooks/useProfileLoadTracker.ts
+++ b/src/profile/hooks/useProfileLoadTracker.ts
@@ -1,0 +1,115 @@
+import { useCallback, useContext, useEffect, useRef } from 'react';
+
+import { ProfileContext, ProfileContextData } from '../context/ProfileContext';
+import parseGraphQLError from '../helpers/parseGraphQLError';
+import { QueryResult } from './useProfileQuery';
+
+const STATUS_FAILED = -1;
+const STATUS_WAITING = 0;
+const STATUS_SHOULD_LOAD = 1;
+const STATUS_LOADING = 2;
+const STATUS_SUCCESS = 3;
+
+type Status =
+  | typeof STATUS_WAITING
+  | typeof STATUS_LOADING
+  | typeof STATUS_FAILED
+  | typeof STATUS_SUCCESS
+  | typeof STATUS_SHOULD_LOAD;
+
+export type useProfileLoaderHookReturnType = {
+  isProfileLoadComplete: () => boolean;
+  hasExistingProfile: () => boolean;
+  didProfileLoadFail: () => boolean;
+  reloadProfile: () => Promise<QueryResult>;
+};
+
+function shouldLoad(currentStatus?: Status): boolean {
+  return currentStatus === STATUS_SHOULD_LOAD;
+}
+
+function isLoading(currentStatus?: Status): boolean {
+  return currentStatus === STATUS_LOADING;
+}
+
+function didLoadFail(currentStatus?: Status): boolean {
+  return currentStatus === STATUS_FAILED;
+}
+
+function isLoadComplete(currentStatus?: Status): boolean {
+  return didLoadFail(currentStatus) || isLoadedSuccessfully(currentStatus);
+}
+
+function isLoadedSuccessfully(currentStatus?: Status): boolean {
+  return currentStatus === STATUS_SUCCESS;
+}
+
+function canStartLoading(currentStatus?: Status): boolean {
+  return !isLoading(currentStatus) && !isLoadComplete(currentStatus);
+}
+
+function resolveChangedStatus(
+  currentStatus: Status,
+  profileContext: ProfileContextData
+): Status | undefined {
+  if (isLoadComplete(currentStatus)) {
+    return undefined;
+  }
+
+  if (
+    profileContext.error &&
+    !parseGraphQLError(profileContext.error).isAllowedError
+  ) {
+    return STATUS_FAILED;
+  }
+
+  if (profileContext.data && !isLoadedSuccessfully(currentStatus)) {
+    return STATUS_SUCCESS;
+  }
+
+  if (canStartLoading(currentStatus) && !shouldLoad(currentStatus)) {
+    return STATUS_SHOULD_LOAD;
+  }
+
+  return undefined;
+}
+
+export function useProfileLoadTracker(): useProfileLoaderHookReturnType {
+  const profileContext = useContext(ProfileContext);
+  const statusRef = useRef<Status>(STATUS_WAITING);
+
+  const updateStatus = useCallback((updatedStatus?: Status): Status => {
+    if (!updatedStatus) {
+      return statusRef.current;
+    }
+    statusRef.current = updatedStatus;
+    return statusRef.current;
+  }, []);
+
+  const newStatus = resolveChangedStatus(statusRef.current, profileContext);
+  updateStatus(newStatus);
+
+  useEffect(() => {
+    if (shouldLoad(newStatus)) {
+      updateStatus(STATUS_LOADING);
+      profileContext.fetch();
+    }
+  }, [newStatus, updateStatus, profileContext]);
+
+  return {
+    isProfileLoadComplete: () => isLoadComplete(statusRef.current),
+    didProfileLoadFail: () => didLoadFail(statusRef.current),
+    hasExistingProfile: () => {
+      if (!isLoadComplete(statusRef.current)) {
+        throw new Error(
+          'hasExistingProfile cannot be used before profile load is complete. Check it with isProfileLoadComplete()'
+        );
+      }
+      return !!profileContext.getProfile();
+    },
+    reloadProfile: () => {
+      updateStatus(STATUS_LOADING);
+      return profileContext.refetch();
+    },
+  };
+}


### PR DESCRIPTION
The existence of a profile can be checked just by loading the user's profile. So the profile exists check is skipped now and removed completely.

Checking if user...
- is authenticated
- is loading a profile 
- has a profile 
- profile is loaded, but does not exist
- profile load failed
- authentication failed

...is a bit complicated. And due the nature of a SPA, user may navigate back and forth after any loading has started. Which makes checks even more complicated.

So added a hook which tracks the different scenarios reliably and with comprehensive tests.
