### PR TITLE
HP-1335: indicate required fields

### DIFF
--- a/src/common/cssHelpers/form.module.css
+++ b/src/common/cssHelpers/form.module.css
@@ -117,6 +117,12 @@
   display: none;
 }
 
+.note {
+  display: inline-block;
+  font-size: var(--fontsize-body-s);
+  padding-bottom: var(--spacing-xs);
+}
+
 @media (min-width: 768px) {
   .multi-item-wrapper {
     display: flex;

--- a/src/common/requiredFieldsNote/RequiredFieldsNote.tsx
+++ b/src/common/requiredFieldsNote/RequiredFieldsNote.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import commonFormStyles from '../cssHelpers/form.module.css';
+
+export function RequiredFieldsNote(): React.ReactElement {
+  const { t } = useTranslation();
+  return (
+    <span className={commonFormStyles['note']} aria-hidden>
+      {t('validation.requiredFieldIndication')}
+    </span>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -232,7 +232,8 @@
     "required": "This field is required.",
     "errorTitleForScreenReaders": "The form has the following errors:",
     "countryCallingCodeRequiredIfNumber": "Country code is required with phone number",
-    "numbersOnly": "Only numbers allowed"
+    "numbersOnly": "Only numbers allowed",
+    "requiredFieldIndication": "Fields marked with an * are compulsory."
   },
   "identityProvider": {
     "helsinkiAccount": "Helsinki Profile user ID",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -232,7 +232,8 @@
     "required": "Tämä kenttä on pakollinen.",
     "errorTitleForScreenReaders": "Lomakkeella on seuraavat virheet:",
     "countryCallingCodeRequiredIfNumber": "Maan suuntanumero on annettava puhelinnumerolle",
-    "numbersOnly": "Vain numerot sallittu"
+    "numbersOnly": "Vain numerot sallittu",
+    "requiredFieldIndication": "Tähdellä (*) merkityt kentät ovat pakollisia."
   },
   "identityProvider": {
     "helsinkiAccount": "Helsinki-profiilin käyttäjätunnus",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -232,7 +232,8 @@
     "required": "Detta fält krävs.",
     "errorTitleForScreenReaders": "Blanketten har följande fel:",
     "countryCallingCodeRequiredIfNumber": "SV: Maan suuntanumero on annettava puhelinnumerolle",
-    "numbersOnly": "SV: Vain numerot sallittu"
+    "numbersOnly": "SV: Vain numerot sallittu",
+    "requiredFieldIndication": "Fälten markerade med en asterisk (*) är obligatoriska."
   },
   "identityProvider": {
     "helsinkiAccount": "Användarnamnet för Helsingfors-profilen",

--- a/src/profile/components/basicData/BasicData.tsx
+++ b/src/profile/components/basicData/BasicData.tsx
@@ -30,6 +30,7 @@ import createActionAriaLabels from '../../helpers/createActionAriaLabels';
 import FocusKeeper from '../../../common/focusKeeper/FocusKeeper';
 import AccessibleFormikErrors from '../accessibleFormikErrors/AccessibleFormikErrors';
 import AccessibilityFieldHelpers from '../../../common/accessibilityFieldHelpers/AccessibilityFieldHelpers';
+import { RequiredFieldsNote } from '../../../common/requiredFieldsNote/RequiredFieldsNote';
 
 type FormikValues = BasicDataValue;
 
@@ -108,6 +109,7 @@ function BasicData(): React.ReactElement | null {
             <h3 className={commonFormStyles['section-title']}>
               {t('profileForm.basicData')}
             </h3>
+            <RequiredFieldsNote />
             <Form>
               <FocusKeeper targetId={`${basicDataType}-firstName`}>
                 <div className={commonFormStyles['multi-item-wrapper']}>
@@ -120,7 +122,7 @@ function BasicData(): React.ReactElement | null {
                     invalid={hasFieldError(formikProps, 'firstName')}
                     aria-invalid={hasFieldError(formikProps, 'firstName')}
                     errorText={getFieldErrorMessage(formikProps, 'firstName')}
-                    label={t(formFields.firstName.translationKey)}
+                    label={`${t(formFields.firstName.translationKey)} *`}
                     aria-labelledby="basic-data-firstName-helper"
                     autoFocus
                   />
@@ -145,7 +147,7 @@ function BasicData(): React.ReactElement | null {
                     invalid={hasFieldError(formikProps, 'lastName')}
                     aria-invalid={hasFieldError(formikProps, 'lastName')}
                     errorText={getFieldErrorMessage(formikProps, 'lastName')}
-                    label={t(formFields.lastName.translationKey)}
+                    label={`${t(formFields.lastName.translationKey)} *`}
                     aria-labelledby={`${basicDataType}-lastName-helper`}
                   />
                 </div>

--- a/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
+++ b/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
@@ -24,6 +24,7 @@ import { RowItemProps } from '../multiItemEditor/MultiItemEditor';
 import createActionAriaLabels from '../../helpers/createActionAriaLabels';
 import FocusKeeper from '../../../common/focusKeeper/FocusKeeper';
 import AccessibleFormikErrors from '../accessibleFormikErrors/AccessibleFormikErrors';
+import { RequiredFieldsNote } from '../../../common/requiredFieldsNote/RequiredFieldsNote';
 
 type FormikValues = AddressValue;
 
@@ -92,6 +93,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
                 ? t('profileInformation.primaryAddress')
                 : t('profileInformation.address')}
             </h4>
+            <RequiredFieldsNote />
             <FocusKeeper targetId={`${testId}-address`}>
               <div className={commonFormStyles['multi-item-wrapper']}>
                 <Field
@@ -102,7 +104,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
                   invalid={hasFieldError(formikProps, 'address')}
                   aria-invalid={hasFieldError(formikProps, 'address')}
                   errorText={getFieldErrorMessage(formikProps, 'address')}
-                  label={t(formFields.address.translationKey)}
+                  label={`${t(formFields.address.translationKey)} *`}
                   autoFocus
                   aria-labelledby={`${dataType}-address-helper`}
                   className={formFieldStyle}
@@ -115,7 +117,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
                   invalid={hasFieldError(formikProps, 'postalCode')}
                   aria-invalid={hasFieldError(formikProps, 'postalCode')}
                   errorText={getFieldErrorMessage(formikProps, 'postalCode')}
-                  label={t(formFields.postalCode.translationKey)}
+                  label={`${t(formFields.postalCode.translationKey)} *`}
                   aria-labelledby={`${dataType}-postalCode-helper`}
                   className={formFieldStyle}
                 />
@@ -127,7 +129,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
                   invalid={hasFieldError(formikProps, 'city')}
                   aria-invalid={hasFieldError(formikProps, 'city')}
                   errorText={getFieldErrorMessage(formikProps, 'city')}
-                  label={t(formFields.city.translationKey)}
+                  label={`${t(formFields.city.translationKey)} *`}
                   aria-labelledby={`${dataType}-city-helper`}
                   className={formFieldStyle}
                 />
@@ -136,7 +138,7 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
                     name="countryCode"
                     id={`${testId}-countryCode`}
                     options={countryOptions}
-                    label={t(formFields.countryCode.translationKey)}
+                    label={`${t(formFields.countryCode.translationKey)} *`}
                     defaultOption={defaultCountryOption}
                     invalid={hasFieldError(formikProps, 'countryCode')}
                     error={getFieldErrorMessage(formikProps, 'countryCode')}


### PR DESCRIPTION
Added (*) to form fields which are required in address and basic data forms.

Didn't add them to phone and email fields because the is no need for extra descriptions.

Screen readers already have the information so the note has "aria-hidden" 