### PR TITLE
HP-1337: set page focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hds-core": "1.6.0",
     "hds-design-tokens": "1.6.0",
     "hds-react": "1.6.0",
+    "history": "^4.9.0",
     "http-status-typed": "^1.0.0",
     "i18n-iso-countries": "^6.8.0",
     "i18next": "^20.3.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import ToastProvider from './toast/ToastProvider';
 import authService from './auth/authService';
 import config from './config';
 import PageNotFound from './common/pageNotFound/PageNotFound';
+import { useHistoryListener } from './profile/hooks/useHistoryListener';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -44,6 +45,8 @@ function App(): React.ReactElement {
   if (location.pathname === '/loginsso') {
     authService.login();
   }
+
+  useHistoryListener();
 
   return (
     <ApolloProvider client={graphqlClient}>

--- a/src/accessibilityStatement/AccessibilityStatement.tsx
+++ b/src/accessibilityStatement/AccessibilityStatement.tsx
@@ -39,7 +39,7 @@ function AccessibilityStatement(): React.ReactElement {
             styles['content'],
           ])}
         >
-          <main className={styles['inner-content']}>{selectStatement()}</main>
+          <div className={styles['inner-content']}>{selectStatement()}</div>
         </div>
       </div>
     </PageLayout>

--- a/src/accessibilityStatement/AccessibilityStatementEn.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementEn.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment, ReactElement } from 'react';
 
 import { Link } from '../common/copyOfHDSLink/Link';
+import FocusableH1 from '../common/focusableH1/FocusableH1';
 
 function AccessibilityStatementEn(): ReactElement {
   return (
     <Fragment>
-      <h1>Accessibility Statement</h1>
+      <FocusableH1>Accessibility Statement</FocusableH1>
       <p>
         This accessibility statement applies to the Helsinki Profile website.
         The site address is https://hel.fi/profiili

--- a/src/accessibilityStatement/AccessibilityStatementFi.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementFi.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment, ReactElement } from 'react';
 
 import { Link } from '../common/copyOfHDSLink/Link';
+import FocusableH1 from '../common/focusableH1/FocusableH1';
 
 function AccessibilityStatementFi(): ReactElement {
   return (
     <Fragment>
-      <h1>Saavutettavuusseloste</h1>
+      <FocusableH1>Saavutettavuusseloste</FocusableH1>
 
       <p>
         Tämä saavutettavuusseloste koskee Helsinki profiili- sivustoa. Sivuston

--- a/src/accessibilityStatement/AccessibilityStatementSv.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementSv.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment } from 'react';
 
 import { Link } from '../common/copyOfHDSLink/Link';
+import FocusableH1 from '../common/focusableH1/FocusableH1';
 
 function AccessibilityStatementSv(): React.ReactElement {
   return (
     <Fragment>
-      <h1>Tillgänglighetsutlåtande</h1>
+      <FocusableH1>Tillgänglighetsutlåtande</FocusableH1>
       <p>
         Detta tillgänglighetsutlåtande gäller Helsingfors stads webbplats
         Helsingfors-profil. Webbplatsens adress är https://hel.fi/profiili

--- a/src/auth/components/login/Login.tsx
+++ b/src/auth/components/login/Login.tsx
@@ -9,6 +9,7 @@ import styles from './Login.module.css';
 import PageLayout from '../../../common/pageLayout/PageLayout';
 import commonContentStyles from '../../../common/cssHelpers/content.module.css';
 import authService from '../../authService';
+import FocusableH1 from '../../../common/focusableH1/FocusableH1';
 
 function Login(): React.ReactElement {
   const { t } = useTranslation();
@@ -24,7 +25,7 @@ function Login(): React.ReactElement {
           ])}
         >
           <HelsinkiLogo />
-          <h1>{t('login.title')}</h1>
+          <FocusableH1>{t('login.title')}</FocusableH1>
           <p className={styles.ingress}>{t('login.description')}</p>
           <Button
             variant="primary"

--- a/src/auth/components/oidcCallback/OidcCallback.tsx
+++ b/src/auth/components/oidcCallback/OidcCallback.tsx
@@ -7,6 +7,7 @@ import { LoadingSpinner } from 'hds-react';
 import authService from '../../authService';
 import { useErrorPageRedirect } from '../../../profile/hooks/useErrorPageRedirect';
 import styles from './OidcCallback.module.css';
+import { getLinkRedirectState } from '../../../profile/hooks/useHistoryListener';
 
 function OidcCallback({
   history,
@@ -18,7 +19,7 @@ function OidcCallback({
     authService
       .endLogin()
       .then(() => {
-        history.replace('/');
+        history.replace('/', getLinkRedirectState());
       })
       .catch((error: Error) => {
         // Handle error caused by device time being more than 5 minutes off

--- a/src/common/cssHelpers/common.module.css
+++ b/src/common/cssHelpers/common.module.css
@@ -1,0 +1,4 @@
+.hide-focus-borders:focus {
+  border: none;
+  outline: none;
+}

--- a/src/common/explanation/Explanation.module.css
+++ b/src/common/explanation/Explanation.module.css
@@ -2,7 +2,10 @@
   padding-bottom: var(--spacing-xl);
   margin: 0 var(--content-horizontal-padding);
 }
-
+.container h1 {
+  font-size: var(--h2-size);
+}
+.container h1,
 .container h2,
 .container h3 {
   margin-top: 0;

--- a/src/common/explanation/Explanation.tsx
+++ b/src/common/explanation/Explanation.tsx
@@ -2,28 +2,20 @@ import React from 'react';
 import classNames from 'classnames';
 
 import styles from './Explanation.module.css';
+import { usePageLoadFocusSetter } from '../../profile/hooks/usePageLoadFocusSetter';
+import FocusableH1 from '../focusableH1/FocusableH1';
 
 type Props = {
   heading: string;
   text: string;
   className?: string;
-  titleVariant?: 'h2' | 'h3';
 };
 
-function Explanation({
-  className,
-  heading,
-  text,
-  titleVariant = 'h2',
-}: Props): React.ReactElement {
-  const HeadingTagName = `${
-    titleVariant
-    // eslint-disable-next-line no-undef
-  }` as keyof JSX.IntrinsicElements;
-
+function Explanation({ className, heading, text }: Props): React.ReactElement {
+  usePageLoadFocusSetter();
   return (
     <div className={classNames(styles.container, className)}>
-      <HeadingTagName>{heading}</HeadingTagName>
+      <FocusableH1>{heading}</FocusableH1>
       <p>{text}</p>
     </div>
   );

--- a/src/common/focusableH1/FocusableH1.tsx
+++ b/src/common/focusableH1/FocusableH1.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import commonStyles from '../cssHelpers/common.module.css';
+import { pageLoadFocusTargetClassName } from '../../profile/hooks/usePageLoadFocusSetter';
+
+type Props = {
+  children: string;
+} & React.HTMLAttributes<HTMLHeadingElement>;
+
+export default function FocusableH1(props: Props): React.ReactElement {
+  const { children, ...rest } = props;
+  return (
+    <h1
+      {...rest}
+      tabIndex={-1}
+      className={classNames([
+        pageLoadFocusTargetClassName,
+        commonStyles['hide-focus-borders'],
+      ])}
+    >
+      {children}
+    </h1>
+  );
+}

--- a/src/common/footer/Footer.tsx
+++ b/src/common/footer/Footer.tsx
@@ -54,11 +54,7 @@ function Footer(): React.ReactElement {
         >
           <IconLinkExternal aria-hidden size={'xs'} />
         </HDSFooter.Item>
-        <HDSFooter.Item
-          as={Link}
-          to="/accessibility"
-          title={t('footer.accessibility')}
-        >
+        <HDSFooter.Item as={Link} to="/accessibility">
           {t('footer.accessibility')}
         </HDSFooter.Item>
       </HDSFooter.Base>

--- a/src/common/loading/Loading.tsx
+++ b/src/common/loading/Loading.tsx
@@ -11,7 +11,11 @@ function Loading(props: Props): React.ReactElement {
   return (
     <>
       {props.isLoading ? (
-        <div className={styles.wrapper} data-testid="load-indicator">
+        <div
+          className={styles.wrapper}
+          data-testid="load-indicator"
+          aria-live="polite"
+        >
           <div className={styles.content}>
             <LoadingSpinner small />
             <p>{props.loadingText}</p>

--- a/src/common/pageHeading/PageHeading.module.css
+++ b/src/common/pageHeading/PageHeading.module.css
@@ -8,8 +8,10 @@
   text-align: center;
 }
 
-.page-heading h1 {
+.page-heading span {
   margin: 0;
+  font-size: var(--h1-size);
+  font-weight: bold;
 }
 
 .user-icon {
@@ -29,7 +31,7 @@
     height: 77px;
     margin-bottom: 0;
   }
-  .page-heading h1 {
+  .page-heading span {
     margin-left: var(--spacing-layout-xs);
   }
 }

--- a/src/common/pageHeading/PageHeading.tsx
+++ b/src/common/pageHeading/PageHeading.tsx
@@ -17,7 +17,7 @@ function PageHeading(props: Props): React.ReactElement {
       data-testid={props.dataTestId}
     >
       <UserIcon className={styles['user-icon']} aria-hidden={'true'} />
-      <h1>{props.text}</h1>
+      <span>{props.text}</span>
     </div>
   );
 }

--- a/src/common/pageLayout/PageLayout.tsx
+++ b/src/common/pageLayout/PageLayout.tsx
@@ -8,16 +8,23 @@ import Header from '../header/Header';
 import Footer from '../footer/Footer';
 import styles from './PageLayout.module.css';
 import PageMeta from '../pageMeta/PageMeta';
+import { usePageLoadFocusSetter } from '../../profile/hooks/usePageLoadFocusSetter';
 
 type Props = React.PropsWithChildren<{
   className?: string;
   title?: string;
+  disableFocusing?: boolean;
+  focusElementSelector?: string;
 }>;
 
 function PageLayout(props: Props): React.ReactElement {
   const { trackPageView } = useMatomo();
   const { t } = useTranslation();
-  const { title = 'appName' } = props;
+  const {
+    focusElementSelector,
+    disableFocusing = false,
+    title = 'appName',
+  } = props;
 
   const pageTitle =
     props.title !== 'appName' ? `${t(title)} - ${t('appName')}` : t('appName');
@@ -28,6 +35,8 @@ function PageLayout(props: Props): React.ReactElement {
       href: window.location.href,
     });
   }, [trackPageView, pageTitle]);
+
+  usePageLoadFocusSetter({ disableFocusing, selector: focusElementSelector });
 
   return (
     <div className={styles.wrapper}>

--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -112,13 +112,18 @@ export const waitForElementAttributeValue = async (
   });
 };
 
+export const getActiveElement = (
+  anyElement?: ElementGetterResult
+): Element | null =>
+  anyElement ? anyElement.ownerDocument.activeElement : null;
+
 export const waitForElementFocus = async (
   elementGetter: () => ElementGetterResult
 ): Promise<void> =>
   waitFor(() => {
     const target = elementGetter();
     if (target) {
-      expect(target.ownerDocument.activeElement).toEqual(target);
+      expect(getActiveElement(target)).toEqual(target);
     }
   });
 

--- a/src/profile/components/additionalInformation/AdditionalInformation.tsx
+++ b/src/profile/components/additionalInformation/AdditionalInformation.tsx
@@ -65,9 +65,9 @@ function AdditionalInformation(): React.ReactElement | null {
 
   return (
     <ProfileSection>
-      <h3 className={commonFormStyles['section-title']}>
+      <h2 className={commonFormStyles['section-title']}>
         {t('profileForm.language')}
-      </h3>
+      </h2>
       <div className={commonFormStyles['multi-item-wrapper']}>
         <Formik
           initialValues={{ language }}

--- a/src/profile/components/basicData/BasicData.tsx
+++ b/src/profile/components/basicData/BasicData.tsx
@@ -106,9 +106,9 @@ function BasicData(): React.ReactElement | null {
       >
         {(formikProps: FormikProps<FormikValues>) => (
           <ProfileSection>
-            <h3 className={commonFormStyles['section-title']}>
+            <h2 className={commonFormStyles['section-title']}>
               {t('profileForm.basicData')}
-            </h3>
+            </h2>
             <RequiredFieldsNote />
             <Form>
               <FocusKeeper targetId={`${basicDataType}-firstName`}>
@@ -181,9 +181,9 @@ function BasicData(): React.ReactElement | null {
   return (
     <ProfileSection>
       <div className={commonFormStyles['content-wrapper']}>
-        <h3 className={commonFormStyles['section-title']}>
+        <h2 className={commonFormStyles['section-title']}>
           {t('profileForm.basicData')}
-        </h3>
+        </h2>
         <div className={commonFormStyles['multi-item-wrapper']}>
           <LabeledValue
             label={t(formFields.firstName.translationKey)}

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -109,9 +109,9 @@ function EmailEditor(): React.ReactElement | null {
       >
         {(formikProps: FormikProps<EmailValue>) => (
           <ProfileSection>
-            <h3 className={commonFormStyles['section-title']}>
+            <h2 className={commonFormStyles['section-title']}>
               {t('profileForm.email')}
-            </h3>
+            </h2>
             <div className={commonFormStyles['content-wrapper']}>
               <Form>
                 <FocusKeeper targetId={`${dataType}-email`}>
@@ -160,9 +160,9 @@ function EmailEditor(): React.ReactElement | null {
   return (
     <ProfileSection>
       <div className={commonFormStyles['content-wrapper']}>
-        <h3 className={commonFormStyles['section-title']}>
+        <h2 className={commonFormStyles['section-title']}>
           {t('profileForm.email')}
-        </h3>
+        </h2>
         <div className={styles['text-content-wrapper']}>
           <span
             className={commonFormStyles['value']}

--- a/src/profile/components/errorPage/ErrorPage.tsx
+++ b/src/profile/components/errorPage/ErrorPage.tsx
@@ -61,7 +61,13 @@ function ErrorPage(props?: ErrorPageProps): React.ReactElement {
   const isAuthenticated = authService.isAuthenticated();
 
   return (
-    <PageLayout title={notificationTitle} data-testid="error-page-layout">
+    <PageLayout
+      title={notificationTitle}
+      data-testid="error-page-layout"
+      focusElementSelector={
+        '*[data-testid="error-page-notification"] *[role="heading"]'
+      }
+    >
       <div
         className={classNames([
           commonContentStyles['common-content-area'],

--- a/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
+++ b/src/profile/components/multiItemAddressRow/MultiItemAddressRow.tsx
@@ -88,11 +88,11 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
       >
         {(formikProps: FormikProps<FormikValues>) => (
           <Form className={commonFormStyles['multi-item-form']}>
-            <h4 className={commonFormStyles['section-title']}>
+            <h3 className={commonFormStyles['section-title']}>
               {primary
                 ? t('profileInformation.primaryAddress')
                 : t('profileInformation.address')}
-            </h4>
+            </h3>
             <RequiredFieldsNote />
             <FocusKeeper targetId={`${testId}-address`}>
               <div className={commonFormStyles['multi-item-wrapper']}>
@@ -181,11 +181,11 @@ function MultiItemAddressRow(props: RowItemProps): React.ReactElement {
         commonFormStyles['multi-item-content-wrapper'],
       ])}
     >
-      <h4 className={commonFormStyles['section-title']}>
+      <h3 className={commonFormStyles['section-title']}>
         {primary
           ? t('profileInformation.primaryAddress')
           : t('profileInformation.address')}
-      </h4>
+      </h3>
       <div className={commonFormStyles['multi-item-wrapper']}>
         <LabeledValue
           label={t(formFields.address.translationKey)}

--- a/src/profile/components/multiItemEditor/MultiItemEditor.tsx
+++ b/src/profile/components/multiItemEditor/MultiItemEditor.tsx
@@ -143,9 +143,9 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
   const NoItemsMessage = () => (
     <React.Fragment>
       {dataType === 'addresses' && (
-        <h3 className={commonFormStyles['section-title']}>
+        <h2 className={commonFormStyles['section-title']}>
           {texts.listNumberTitle}
-        </h3>
+        </h2>
       )}
       <p>{texts.noContent}</p>
     </React.Fragment>
@@ -153,14 +153,14 @@ function MultiItemEditor({ dataType }: Props): React.ReactElement | null {
 
   return (
     <ProfileSection>
-      <h3
+      <h2
         className={classNames([
           commonFormStyles['section-title'],
           hasAddressList && commonFormStyles['visually-hidden'],
         ])}
       >
         {texts.title}
-      </h3>
+      </h2>
 
       {!editDataList || (!editDataList.length && <NoItemsMessage />)}
       <ul aria-label={texts.listAriaLabel} className={commonFormStyles['list']}>

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -129,7 +129,7 @@ function Profile(): React.ReactElement {
   }
 
   return (
-    <PageLayout title={getPageTitle()}>
+    <PageLayout title={getPageTitle()} disableFocusing>
       <Loading
         isLoading={isDoingProfileChecks || isLoadingProfile}
         loadingText={t('profile.loading')}

--- a/src/profile/components/profile/Profile.tsx
+++ b/src/profile/components/profile/Profile.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../context/ProfileContext';
 import parseGraphQLError from '../../helpers/parseGraphQLError';
 import useToast from '../../../toast/useToast';
+import { getLinkRedirectState } from '../../hooks/useHistoryListener';
 
 const PROFILE_EXISTS = loader('../../graphql/ProfileExistsQuery.graphql');
 
@@ -62,7 +63,7 @@ function Profile(): React.ReactElement {
         setIsCheckingAuthState(false);
         return undefined;
       })
-      .catch(() => history.push('/login'));
+      .catch(() => history.push('/login', getLinkRedirectState()));
   }, [checkProfileExists, history]);
 
   const isDoingProfileChecks = isCheckingAuthState || loading;

--- a/src/profile/components/profileDeleted/ProfileDeleted.tsx
+++ b/src/profile/components/profileDeleted/ProfileDeleted.tsx
@@ -6,6 +6,7 @@ import styles from './ProfileDeleted.module.css';
 import PageLayout from '../../../common/pageLayout/PageLayout';
 import authService from '../../../auth/authService';
 import commonContentStyles from '../../../common/cssHelpers/content.module.css';
+import FocusableH1 from '../../../common/focusableH1/FocusableH1';
 
 function ProfileDeleted(): React.ReactElement {
   const [timeUntilLogout, setTimeUntilLogout] = useState(10);
@@ -35,7 +36,7 @@ function ProfileDeleted(): React.ReactElement {
           ])}
         >
           <div className={styles['inner-content']}>
-            <h1>{title}</h1>
+            <FocusableH1>{title}</FocusableH1>
             <p>{t('profileDeleted.message', { time: timeUntilLogout })}</p>
           </div>
         </div>

--- a/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
+++ b/src/profile/components/verifiedPersonalInformation/VerifiedPersonalInformation.tsx
@@ -63,14 +63,14 @@ function VerifiedPersonalInformation(): React.ReactElement | null {
     const country = getCountry(address.countryCode, lang);
     return (
       <React.Fragment key={type}>
-        <h3
+        <h2
           className={commonFormStyles['section-title']}
           data-testid={`vpi-address-${type}`}
         >
           {type === 'permanent'
             ? t('profileInformation.permanentAddress')
             : t('profileInformation.permanentForeignAddress')}
-        </h3>
+        </h2>
         <div className={commonFormStyles['multi-item-wrapper']}>
           <LabeledValue
             label={t('profileForm.address')}
@@ -136,12 +136,12 @@ function VerifiedPersonalInformation(): React.ReactElement | null {
 
   return (
     <ProfileSection hasVerifiedUserData>
-      <h3
+      <h2
         className={commonFormStyles['section-title']}
         aria-label={t('profileInformation.verifiedBasicData')}
       >
         {t('profileForm.basicData')}
-      </h3>
+      </h2>
       <LongDescription forAria />
       <div className={commonFormStyles['multi-item-wrapper']}>
         <LabeledValue

--- a/src/profile/helpers/getElementAndSetFocus.ts
+++ b/src/profile/helpers/getElementAndSetFocus.ts
@@ -1,0 +1,22 @@
+export default function getElementAndSetFocus(
+  selector: string,
+  setFocusableAttributeIfNeeded = true
+): boolean {
+  const element = document.querySelector(selector) as HTMLElement;
+  if (element) {
+    if (document.activeElement === element) {
+      return true;
+    }
+    element.focus();
+    if (
+      document.activeElement !== element &&
+      element.getAttribute('tabindex') === null &&
+      setFocusableAttributeIfNeeded
+    ) {
+      element.setAttribute('tabindex', '-1');
+      element.focus();
+    }
+    return document.activeElement === element;
+  }
+  return false;
+}

--- a/src/profile/hooks/__tests__/useHistoryListener.test.tsx
+++ b/src/profile/hooks/__tests__/useHistoryListener.test.tsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import { act, render, waitFor, cleanup } from '@testing-library/react';
+import { Location } from 'history';
+
+import { createDomHelpersWithTesting } from '../../../common/test/testingLibraryTools';
+import {
+  checkForInternalPageLoads,
+  getLinkRedirectState,
+  useHistoryListener,
+  useHistoryTracker,
+} from '../useHistoryListener';
+
+type HistoryListener = (e: Location) => void;
+type DomHelpers = ReturnType<typeof createDomHelpersWithTesting>;
+
+const stopListeningMock = jest.fn();
+const startListeningMock = jest.fn();
+const mockHistory = {
+  listeners: new Set<HistoryListener>(),
+  listen(listener: HistoryListener) {
+    this.listeners.add(listener);
+    startListeningMock();
+    return () => {
+      stopListeningMock();
+      this.listeners.delete(listener);
+    };
+  },
+};
+
+const triggerHistoryEvent = (e: Location) => {
+  mockHistory.listeners.forEach(f => f(e));
+};
+
+const createLocationWithRedirectState = () =>
+  ({ state: getLinkRedirectState() } as Location);
+
+const resetMockHistory = () => {
+  mockHistory.listeners = new Set();
+  stopListeningMock.mockClear();
+  startListeningMock.mockClear();
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn().mockImplementation(() => mockHistory),
+}));
+
+describe('useHistoryListener.ts ', () => {
+  describe('helper function checkForInternalPageLoads', () => {
+    it('Returns true when there are non-redirect events in history tracker.', () => {
+      expect(
+        checkForInternalPageLoads([
+          {} as Location,
+          createLocationWithRedirectState(),
+        ])
+      ).toBeTruthy();
+      expect(
+        checkForInternalPageLoads([
+          createLocationWithRedirectState(),
+          {} as Location,
+        ])
+      ).toBeTruthy();
+    });
+    it('Returns false when there are no non-redirect events in history tracker.', () => {
+      expect(checkForInternalPageLoads([])).toBeFalsy();
+      expect(
+        checkForInternalPageLoads([
+          createLocationWithRedirectState(),
+          createLocationWithRedirectState(),
+        ])
+      ).toBeFalsy();
+    });
+  });
+  describe('Hooks', () => {
+    let appForceRender: () => void | undefined = () => undefined;
+
+    const selectors = {
+      appRenderCountId: 'app-render-count',
+      hasInternalPageLoadsId: 'has-internal-page-loads',
+    };
+
+    const getAppRenderCount = async (helpers: DomHelpers) => {
+      const el = await helpers.findById(selectors.appRenderCountId);
+      return parseInt((el as HTMLElement).innerHTML, 10);
+    };
+
+    const getHasInternalPageLoads = async (helpers: DomHelpers) => {
+      const el = await helpers.findById(selectors.hasInternalPageLoadsId);
+      return (el as HTMLElement).innerHTML === 'true';
+    };
+
+    const TestChild = () => {
+      const trackingResult = useHistoryTracker();
+      return (
+        <div>
+          <span id={selectors.hasInternalPageLoadsId}>
+            {String(trackingResult.hasInternalPageLoads)}
+          </span>
+        </div>
+      );
+    };
+
+    const TestApp = () => {
+      useHistoryListener();
+      const [renderCount, renderApp] = useState<number>(0);
+      appForceRender = () => {
+        renderApp(n => n + 1);
+      };
+      return (
+        <div>
+          <TestChild />
+          <span id={selectors.appRenderCountId}>{renderCount}</span>
+        </div>
+      );
+    };
+
+    const renderAndReturnHelpers = () =>
+      createDomHelpersWithTesting(render(<TestApp />));
+
+    afterEach(() => {
+      resetMockHistory();
+      cleanup();
+    });
+
+    describe('useHistoryListener', () => {
+      it('Starts to listen history once and only once', async () => {
+        await act(async () => {
+          const helpers = renderAndReturnHelpers();
+          const appRenderCount = await getAppRenderCount(helpers);
+          expect(startListeningMock).toHaveBeenCalledTimes(1);
+          await waitFor(async () => {
+            appForceRender();
+            const count = await getAppRenderCount(helpers);
+            if (count === appRenderCount) {
+              throw new Error('App not re-rendered');
+            }
+          });
+          expect(startListeningMock).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      it('Stops listening to history when internal page load is detected', async () => {
+        await act(async () => {
+          renderAndReturnHelpers();
+
+          // redirects are not internal page loads
+          triggerHistoryEvent(createLocationWithRedirectState());
+          appForceRender();
+          expect(startListeningMock).toHaveBeenCalledTimes(1);
+          expect(stopListeningMock).toHaveBeenCalledTimes(0);
+
+          triggerHistoryEvent({} as Location);
+          appForceRender();
+          expect(startListeningMock).toHaveBeenCalledTimes(1);
+          expect(stopListeningMock).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('useHistoryTracker returns an object with hasInternalPageLoads ', () => {
+      it('which is false until a internal page load is detected', async () => {
+        await act(async () => {
+          const helpers = renderAndReturnHelpers();
+          const value = await getHasInternalPageLoads(helpers);
+          let newValue;
+          triggerHistoryEvent(createLocationWithRedirectState());
+          appForceRender();
+          expect(value).toBeFalsy();
+
+          triggerHistoryEvent({} as Location);
+          await waitFor(async () => {
+            appForceRender();
+            newValue = await getHasInternalPageLoads(helpers);
+            if (newValue === value) {
+              throw new Error('hasInternalPageLoads not changed');
+            }
+          });
+          expect(newValue).toBeTruthy();
+        });
+      });
+    });
+  });
+});

--- a/src/profile/hooks/__tests__/usePageLoadFocusSetter.test.tsx
+++ b/src/profile/hooks/__tests__/usePageLoadFocusSetter.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import {
+  act,
+  render,
+  waitFor,
+  cleanup,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router, Route, Switch, useLocation, Link } from 'react-router-dom';
+
+import { getActiveElement } from '../../../common/test/testingLibraryTools';
+import {
+  pageLoadFocusTargetClassName,
+  usePageLoadFocusSetter,
+} from '../usePageLoadFocusSetter';
+import { useHistoryListener } from '../useHistoryListener';
+import FocusableH1 from '../../../common/focusableH1/FocusableH1';
+
+const focusableH1 = 'focusableH1';
+const plainH1 = 'plainH1';
+const className = 'className';
+const noFocusableElement = 'noFocusableElement';
+const disabledFocus = 'disabledFocus';
+const selectorDefined = 'selectorDefined';
+
+const scenarios = [
+  focusableH1,
+  plainH1,
+  className,
+  noFocusableElement,
+  disabledFocus,
+  selectorDefined,
+] as const;
+
+type TestScenario = typeof scenarios[number];
+
+let mockHistory: ReturnType<typeof createMemoryHistory>;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn().mockImplementation(() => mockHistory),
+  useLocation: jest.fn().mockImplementation(() => mockHistory.location),
+}));
+
+describe('usePageLoadFocusSetter.ts ', () => {
+  const pathIndicatorTestId = 'current-path';
+  const stripBackLashes = (str: string) => str.replace(/\//g, '');
+  const getLinkText = (path: string) => `Link to ${path}`;
+  const getLinkTestId = (path: string) => `link-to-${stripBackLashes(path)}`;
+  const getElementTestId = (path: string) =>
+    `element-for-${stripBackLashes(path)}`;
+
+  const focusTracker = jest.fn();
+  const onElemenFocus = (source: TestScenario) => {
+    focusTracker(source);
+  };
+
+  const TestWrapper = ({
+    scenario,
+    children,
+  }: {
+    scenario: TestScenario;
+    children: React.ReactElement | null;
+  }) => {
+    const selector =
+      scenario === 'selectorDefined' ? '#selectorDefined' : undefined;
+    const disableFocusing = scenario === 'disabledFocus';
+    usePageLoadFocusSetter({ selector, disableFocusing });
+    return (
+      <div>
+        <Nav />
+        <button
+          type="button"
+          tabIndex={0}
+          onFocus={() => focusTracker('invalid')}
+        >
+          Focusable button trying to steal focus
+        </button>
+        {children}
+      </div>
+    );
+  };
+
+  const Nav = () => {
+    const location = useLocation();
+    return (
+      <div>
+        {scenarios.map(path => (
+          <Link to={path} data-testid={getLinkTestId(path)} key={path}>
+            {getLinkText(path)}
+          </Link>
+        ))}
+        <span data-testid={pathIndicatorTestId}>{location.pathname}</span>
+      </div>
+    );
+  };
+
+  const Root = () => (
+    <main>
+      <Nav />
+      <p>This is root page</p>
+    </main>
+  );
+
+  const getTestElement = (
+    scenario: TestScenario
+  ): React.ReactElement | null => {
+    const onFocus = () => onElemenFocus(scenario);
+    const commonProps = {
+      onFocus,
+      'data-testid': getElementTestId(scenario),
+    };
+    if (scenario === focusableH1 || scenario === disabledFocus) {
+      return <FocusableH1 {...commonProps}>I'm focusable h1</FocusableH1>;
+    }
+    if (scenario === plainH1) {
+      return <h1 {...commonProps}>Just a plain h1</h1>;
+    }
+    if (scenario === className) {
+      return (
+        <button {...commonProps} className={pageLoadFocusTargetClassName}>
+          Button
+        </button>
+      );
+    }
+    if (scenario === noFocusableElement) {
+      return (
+        <textarea
+          tabIndex={0}
+          {...commonProps}
+          defaultValue="Should not focus me!"
+        ></textarea>
+      );
+    }
+    if (scenario === selectorDefined) {
+      return (
+        <div {...commonProps} id="selectorDefined">
+          Should focus me by id!
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  const getWrappedTestElement = (
+    scenario: TestScenario
+  ): React.ReactElement => (
+    <TestWrapper scenario={scenario}>{getTestElement(scenario)}</TestWrapper>
+  );
+
+  const TestApp = () => {
+    useHistoryListener();
+    return (
+      <div>
+        <Switch>
+          <Route exact path="/">
+            <Root />
+          </Route>
+          {scenarios.map(path => (
+            <Route path={`/${path}`} key={path}>
+              {getWrappedTestElement(path)}
+            </Route>
+          ))}
+        </Switch>
+      </div>
+    );
+  };
+
+  const navigateTo = async (targetPath: string): Promise<void> => {
+    fireEvent.click(screen.getByTestId(getLinkTestId(targetPath)));
+    await waitFor(() => {
+      const path = stripBackLashes(
+        screen.getByTestId(pathIndicatorTestId).innerHTML
+      );
+      if (path !== targetPath) {
+        throw new Error(`Path ${path} is not ${targetPath}`);
+      }
+    });
+  };
+
+  const waitForFocus = async (testId: string): Promise<void> => {
+    await waitFor(async () => {
+      const element = screen.getByTestId(getElementTestId(testId));
+      const activeElement = getActiveElement(element);
+      expect(element).not.toBeNull();
+      expect(activeElement).not.toBeNull();
+      expect(element).toBe(activeElement);
+    });
+  };
+
+  const navigateAndCheckFocus = async (
+    scenario: TestScenario | '',
+    initialEntries: string[] = [''],
+    shouldFocus = true
+  ): Promise<void> => {
+    mockHistory = createMemoryHistory({ initialEntries });
+    render(
+      <Router history={mockHistory}>
+        <TestApp />
+      </Router>
+    );
+
+    if (scenario) {
+      await navigateTo(scenario);
+    }
+
+    if (shouldFocus) {
+      await waitForFocus(scenario);
+      expect(focusTracker).toHaveBeenCalledTimes(1);
+      expect(focusTracker).toHaveBeenLastCalledWith(scenario);
+    } else {
+      expect(focusTracker).toHaveBeenCalledTimes(0);
+    }
+  };
+
+  afterEach(() => {
+    cleanup();
+    focusTracker.mockReset();
+  });
+
+  describe('Focuses to an element, if history has an internal page load', () => {
+    it('Targeted element is by default an element with a certain className', async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(focusableH1);
+      });
+    });
+
+    it(`Targeted element is h1, if element with a certain className is not found. 
+        Tabindex="-1" is added to a non-focusable element.
+        In this test it is a h1 element.`, async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(plainH1);
+        const element = screen.getByTestId(getElementTestId(plainH1));
+        expect(element.getAttribute('tabindex')).toBe('-1');
+      });
+    });
+
+    it(`Targeted element can be any element with a certain className.
+        Tabindex is not set if element can be focused without it.
+        In this test it is a button element.
+        `, async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(className);
+        const element = screen.getByTestId(getElementTestId(className));
+        expect(element.getAttribute('tabindex')).toBeNull();
+      });
+    });
+    it(`Targeted element can defined with a selector.
+        Tabindex="-1" is added to a non-focusable element
+        In this test it is a div element.`, async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(selectorDefined);
+        const element = screen.getByTestId(getElementTestId(selectorDefined));
+        expect(element.getAttribute('tabindex')).toBe('-1');
+      });
+    });
+  });
+  describe('Does not set focus ', () => {
+    it(`if history has no internal page load. 
+        History is initialized with a route.
+        Route is not changed.`, async () => {
+      await act(async () => {
+        await navigateAndCheckFocus('', [`/${focusableH1}`], false);
+        const element = screen.getByTestId(getElementTestId(focusableH1));
+        // check the focusable element was rendered
+        expect(element).not.toBeNull();
+      });
+    });
+    it('when there is no element to target', async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(noFocusableElement, undefined, false);
+      });
+    });
+    it('when hook is disabled', async () => {
+      await act(async () => {
+        await navigateAndCheckFocus(disabledFocus, undefined, false);
+        const element = screen.getByTestId(getElementTestId(disabledFocus));
+        // check the focusable element was rendered
+        expect(element).not.toBeNull();
+      });
+    });
+  });
+});

--- a/src/profile/hooks/useHistoryListener.ts
+++ b/src/profile/hooks/useHistoryListener.ts
@@ -1,0 +1,62 @@
+import { useMemo, useRef } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Location } from 'history';
+
+type TrackingResult = {
+  hasInternalPageLoads: boolean;
+};
+
+type RedirectState = {
+  state: {
+    isRedirect: boolean;
+  };
+};
+
+let historyTracker: Location[] | null = null;
+
+export function checkForInternalPageLoads(events: Location[] | null): boolean {
+  if (!events) {
+    return true;
+  }
+  if (events.length === 0) {
+    return false;
+  }
+  const nonRedirectsInHistory = events.filter(
+    location => !location.state || !(location as RedirectState).state.isRedirect
+  );
+  return nonRedirectsInHistory.length > 0;
+}
+
+export function useHistoryListener(): void {
+  const history = useHistory();
+  const historyListenerRef = useRef<() => void>();
+  historyListenerRef.current = useMemo(() => {
+    historyTracker = [];
+    return history.listen(e => {
+      if (!historyTracker) {
+        return;
+      }
+      historyTracker.push(e);
+      if (
+        historyListenerRef.current &&
+        checkForInternalPageLoads(historyTracker)
+      ) {
+        historyListenerRef.current();
+        historyListenerRef.current = undefined;
+        historyTracker = null;
+      }
+    });
+  }, [history]);
+}
+
+export function useHistoryTracker(): TrackingResult {
+  return {
+    hasInternalPageLoads: checkForInternalPageLoads(historyTracker),
+  };
+}
+
+export function getLinkRedirectState(): RedirectState['state'] {
+  return {
+    isRedirect: true,
+  };
+}

--- a/src/profile/hooks/usePageLoadFocusSetter.ts
+++ b/src/profile/hooks/usePageLoadFocusSetter.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import getElementAndSetFocus from '../helpers/getElementAndSetFocus';
+import { useHistoryTracker } from './useHistoryListener';
+
+export const pageLoadFocusTargetClassName = 'page-load-focus-element';
+
+export function usePageLoadFocusSetter(props?: {
+  selector?: string;
+  disableFocusing?: boolean;
+}): void {
+  const trackingData = useHistoryTracker();
+  const { disableFocusing = false, selector } = props || {};
+
+  useEffect(() => {
+    if (disableFocusing) {
+      return;
+    }
+    if (trackingData.hasInternalPageLoads) {
+      if (selector) {
+        getElementAndSetFocus(selector);
+      } else {
+        getElementAndSetFocus(`.${pageLoadFocusTargetClassName}`) ||
+          getElementAndSetFocus('h1');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
Some screen readers place focus to a random element when SPA renders new content. This was reported in accessibility audit.

Page focus is now controlled and set when a new page is rendered. The focused element is usually h1. User's name used to be h1 on Profile page, so had to change that, because it is useless heading for screen readers. That change forced to change other headings too to keep them in order.

Focus is **not** set on first page load, because focus would jump over heading etc which are important on first load. There is "skip to content" -link anyway. 

Sometimes the app redirects the user, so those redirects must also be taken in to account, when determining is current page the first one.
