### PR TITLE
HP-1336: Fixed expading content button text for screen readers

### DIFF
--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -62,7 +62,7 @@ function ExpandingPanel({
         <h2>{title}</h2>
         <div className={styles['right-side-information']}>
           <Button
-            title={`${buttonText}: ${title}`}
+            title={title}
             variant={'supplementary'}
             iconRight={<Icon aria-hidden />}
             {...buttonProps}


### PR DESCRIPTION
The button text had a "clarifying" text which indicated, if the content is open or not.

That text conflicted with screen readers ability to detect expanding content.

The text read aloud was about "Show information <Content title> , closed" or "Hide information <Content title>, opened".

Resolution is to use just "<Content title>, closed/opened"