### PR TITLE
HP-1377: handle multiple graphql errors with download and delete profile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@apollo/client": "3.5.6",
+    "@apollo/client": "3.6.5",
     "@datapunt/matomo-tracker-react": "^0.5.1",
     "@react-aria/visually-hidden": "^3.2.1",
     "@sentry/browser": "^6.19.7",

--- a/src/gdprApi/useDownloadProfile.ts
+++ b/src/gdprApi/useDownloadProfile.ts
@@ -65,6 +65,11 @@ function useDownloadProfile<TQuery>(
       onCompleted: data => {
         handleDownloadActionInitialization(data);
       },
+      onError: error => {
+        if (options?.onError) {
+          options.onError(error);
+        }
+      },
     }
   );
 

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -212,6 +212,9 @@ function EmailEditor(): React.ReactElement | null {
           {t('profileForm.addEmail')}
         </Button>
       )}
+      {!willSendEmailVerificationCode && (
+        <EditingNotifications content={content} dataType={dataType} />
+      )}
     </ProfileSection>
   );
 }

--- a/src/profile/components/emailEditor/__tests__/EmailEditor.test.tsx
+++ b/src/profile/components/emailEditor/__tests__/EmailEditor.test.tsx
@@ -154,9 +154,14 @@ describe('<EmailEditor /> ', () => {
         selector: { testId: `${dataType}-save-indicator` },
         value: t('notification.saving'),
       };
+      const waitForAfterSaveNotification: WaitForElementAndValueProps = {
+        selector: { id: `${dataType}-edit-notifications` },
+        value: t('notification.saveSuccess'),
+      };
       // submit and wait for "saving" notification
       await submit({
         waitForOnSaveNotification,
+        waitForAfterSaveNotification,
       });
       // "verify email" notification should not be rendered with current amr
       expect(() => getElement(verifyEmailSelector)).toThrow();
@@ -167,7 +172,12 @@ describe('<EmailEditor /> ', () => {
   });
   it("will render email verification information when user's amr is tunnistusSuomifiAMR", async () => {
     await act(async () => {
-      const { clickElement, setInputValue, waitForElement } = await initTests();
+      const {
+        clickElement,
+        setInputValue,
+        waitForElement,
+        getElement,
+      } = await initTests();
       await clickElement(editButtonSelector);
       await setEmailToInput(setInputValue, validEmailValue);
       // add the graphQL response
@@ -183,6 +193,10 @@ describe('<EmailEditor /> ', () => {
       await clickElement(submitButtonSelector);
       // "verify email" notification should be rendered
       await waitForElement(verifyEmailSelector);
+      // save success is not rendered with verify notification
+      expect(() =>
+        getElement({ id: `${dataType}-edit-notifications` })
+      ).toThrow();
     });
   });
   it('on send error shows error notification and stays in edit mode. Cancel-button resets data', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,23 +19,23 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apollo/client@3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.6.tgz#911929df073280689efd98e5603047b79e0c39a2"
-  integrity sha512-XHoouuEJ4L37mtfftcHHO1caCRrKKAofAwqRoq28UQIPMJk+e7n3X9OtRRNXKk/9tmhNkwelSary+EilfPwI7A==
+"@apollo/client@3.6.5":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.5.tgz#6a7baaf05852187b0eac1c6064e721d47326d70c"
+  integrity sha512-xGAZzv1f5abyH45MSU5eOLyGQuP4Ps0OhP36pSCtt6pCICI3n4yDkdftFCPvqDVqVTuciX1kkyeJPfGodz5kwg==
   dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
+    "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.6.0"
     "@wry/equality" "^0.5.0"
     "@wry/trie" "^0.3.0"
-    graphql-tag "^2.12.3"
+    graphql-tag "^2.12.6"
     hoist-non-react-statics "^3.3.2"
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.4"
+    ts-invariant "^0.10.3"
     tslib "^2.3.0"
-    zen-observable-ts "^1.2.0"
+    zen-observable-ts "^1.2.5"
 
 "@apollo/federation@0.27.0":
   version "0.27.0"
@@ -2072,7 +2072,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@graphql-typed-document-node/core@^3.0.0":
+"@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
@@ -7314,7 +7314,7 @@ graphql-tag@2.12.4:
   dependencies:
     tslib "^2.1.0"
 
-graphql-tag@^2.10.1, graphql-tag@^2.12.3:
+graphql-tag@^2.10.1, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -12270,19 +12270,19 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-invariant@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
-
-ts-invariant@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
-  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
-  dependencies:
-    tslib "^2.1.0"
 
 ts-node@^8, ts-node@^8.8.2:
   version "8.10.2"
@@ -13202,10 +13202,10 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable-ts@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
-  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
   dependencies:
     zen-observable "0.8.15"
 


### PR DESCRIPTION
The original error seems to resolve after updating Apollo/client. Errors are shown multiple times now. Tested with Chrome and network throttling.

Added missing error handling to service connection fetching. 

Also changed displaying errors in download -component to match other Profile components: notification instead of toast.

While testing found a new bug: while saving emails, the save success message was not shown anymore. Fixed that.