### PR TITLE
HP-1657: delete single service connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "test": "cross-env TEST=true npm run update-runtime-env && react-scripts test",
     "ci": "cross-env CI=true yarn test --coverage",
     "lint": "eslint --ext js,ts,tsx src",
-    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profiili-api.test.kuva.hel.ninja/graphql/ --useReadOnlyTypes --addTypename",
+    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profile-api.dev.hel.ninja/graphql/ --useReadOnlyTypes --addTypename",
     "update-translations": "ts-node -P ./scripts/tsconfig.json -r dotenv/config --files scripts/update-translations.ts",
     "update-runtime-env": "ts-node -P ./scripts/tsconfig.json --files scripts/update-runtime-env.ts",
     "update-country-calling-codes": "ts-node -P ./scripts/tsconfig.json --files scripts/update-country-calling-codes.ts"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "yup": "^0.32.5"
   },
   "scripts": {
-    "start": "npm run update-runtime-env && react-scripts start",
+    "start": "yarn clear-babel-cache && npm run update-runtime-env && react-scripts start",
     "build": "react-scripts build",
     "test": "cross-env TEST=true npm run update-runtime-env && react-scripts test",
     "ci": "cross-env CI=true yarn test --coverage",
@@ -80,7 +80,8 @@
     "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profile-api.dev.hel.ninja/graphql/ --useReadOnlyTypes --addTypename",
     "update-translations": "ts-node -P ./scripts/tsconfig.json -r dotenv/config --files scripts/update-translations.ts",
     "update-runtime-env": "ts-node -P ./scripts/tsconfig.json --files scripts/update-runtime-env.ts",
-    "update-country-calling-codes": "ts-node -P ./scripts/tsconfig.json --files scripts/update-country-calling-codes.ts"
+    "update-country-calling-codes": "ts-node -P ./scripts/tsconfig.json --files scripts/update-country-calling-codes.ts",
+    "clear-babel-cache": "rm -rf ./node_modules/.cache/@babel"
   },
   "browserslist": {
     "production": [

--- a/src/common/cssHelpers/common.module.css
+++ b/src/common/cssHelpers/common.module.css
@@ -2,3 +2,13 @@
   border: none;
   outline: none;
 }
+
+.text-button {
+  border: none;
+  outline: none;
+  color: var(--color-bus);
+  padding: 0;
+  margin: 0;
+  background: none;
+  cursor: pointer;
+}

--- a/src/common/expandingPanel/ExpandingPanel.tsx
+++ b/src/common/expandingPanel/ExpandingPanel.tsx
@@ -1,4 +1,9 @@
-import React, { PropsWithChildren, useEffect, useRef } from 'react';
+import React, {
+  PropsWithChildren,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 import {
   Button,
   Card,
@@ -41,9 +46,16 @@ function ExpandingPanel({
     container.current = ref;
   };
 
-  const { isOpen, buttonProps, contentProps } = useAccordion({
+  const { isOpen, buttonProps, contentProps, openAccordion } = useAccordion({
     initiallyOpen,
   });
+
+  useLayoutEffect(() => {
+    if (initiallyOpen && isOpen !== initiallyOpen) {
+      openAccordion();
+    }
+  }, [initiallyOpen, openAccordion, isOpen]);
+
   useEffect(() => {
     if (onChange) {
       onChange(isOpen);

--- a/src/common/loading/Loading.module.css
+++ b/src/common/loading/Loading.module.css
@@ -6,9 +6,20 @@
   box-sizing: border-box;
 }
 
+.wrapper-left-aligned {
+  width: 100%;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
 .content {
   display: flex;
   flex-direction: row;
+  padding-bottom: var(--spacing-m);
+  padding-top: var(--spacing-m);
+}
+
+.wrapper .content {
   align-content: center;
   justify-content: center;
   padding-bottom: var(--common-bottom-spacing);

--- a/src/common/loading/Loading.tsx
+++ b/src/common/loading/Loading.tsx
@@ -6,23 +6,29 @@ import styles from './Loading.module.css';
 type Props = React.PropsWithChildren<{
   isLoading: boolean;
   loadingText: string;
+  dataTestId?: string;
+  alignLeft?: boolean;
 }>;
 function Loading(props: Props): React.ReactElement {
+  const { isLoading, alignLeft, dataTestId, loadingText, children } = props;
   return (
     <>
-      {props.isLoading ? (
+      {isLoading ? (
         <div
-          className={styles.wrapper}
-          data-testid="load-indicator"
+          className={
+            alignLeft ? styles['wrapper-left-aligned'] : styles.wrapper
+          }
+          data-testid={dataTestId || 'load-indicator'}
           aria-live="polite"
+          aria-busy="true"
         >
           <div className={styles.content}>
             <LoadingSpinner small />
-            <p>{props.loadingText}</p>
+            <p>{loadingText}</p>
           </div>
         </div>
       ) : (
-        props.children
+        children
       )}
     </>
   );

--- a/src/common/test/MockApolloClientProvider.tsx
+++ b/src/common/test/MockApolloClientProvider.tsx
@@ -16,6 +16,8 @@ import {
   GdprDeleteMyProfileMutationVariables,
   GdprDeleteMyProfileMutation_deleteMyProfile,
   DownloadMyProfileQueryVariables,
+  GdprDeleteMyServiceDataMutationVariables,
+  GdprDeleteMyServiceDataMutation_deleteMyServiceData,
 } from '../../graphql/generatedTypes';
 
 export type MockedResponse = {
@@ -26,6 +28,9 @@ export type MockedResponse = {
   errorType?: 'networkError' | 'graphQLError';
   withAllowedPermissionError?: boolean;
   deleteMyProfile?: null | Partial<GdprDeleteMyProfileMutation_deleteMyProfile>;
+  deleteMyServiceData?: null | Partial<
+    GdprDeleteMyServiceDataMutation_deleteMyServiceData
+  >;
   downloadMyProfile?: null | unknown;
 };
 
@@ -35,6 +40,7 @@ export type ResponseProvider = (
     | ServiceConnectionsQueryVariables
     | GdprDeleteMyProfileMutationVariables
     | DownloadMyProfileQueryVariables
+    | GdprDeleteMyServiceDataMutationVariables
 ) => MockedResponse;
 
 type ErrorReturnType = { error: Error };
@@ -51,12 +57,16 @@ const getResponseData = (
     deleteMyProfile,
     downloadMyProfile,
     profileDataWithServiceConnections,
+    deleteMyServiceData,
   } = response;
   if (errorType) {
     return undefined;
   }
   if (deleteMyProfile) {
     return { deleteMyProfile };
+  }
+  if (deleteMyServiceData) {
+    return { deleteMyServiceData };
   }
   if (downloadMyProfile) {
     return { downloadMyProfile: JSON.stringify({ key: 'value' }) };

--- a/src/common/test/getMyProfileWithServiceConnections.ts
+++ b/src/common/test/getMyProfileWithServiceConnections.ts
@@ -4,6 +4,7 @@ import {
 } from '../../graphql/generatedTypes';
 import {
   Mutable,
+  Service,
   ServiceAllowedFieldsEdge,
   ServiceConnectionsRoot,
 } from '../../graphql/typings';
@@ -31,6 +32,7 @@ export default function getMyProfileWithServiceConnections(
             node: {
               createdAt: '2021-03-10T11:34:14.719531+00:00',
               service: {
+                name: 'Profiili service name',
                 title: 'Profiili käyttöliittymä',
                 description:
                   'Henkilön omien profiilitietojen hallintakäyttöliittymä.',
@@ -55,6 +57,7 @@ export default function getMyProfileWithServiceConnections(
             node: {
               createdAt: '2020-03-10T11:34:14.719531+00:00',
               service: {
+                name: 'Example service name',
                 title: 'Example UI',
                 description: 'Esimerkkiapplikaatio.',
                 allowedDataFields: {
@@ -88,8 +91,9 @@ export default function getMyProfileWithServiceConnections(
         GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service
       >;
       if (service) {
-        service.gdprQueryScope = '';
-        service.gdprDeleteScope = '';
+        const serviceData = (service as unknown) as Service;
+        service.gdprQueryScope = `${serviceData.name} gdprQueryScope`;
+        service.gdprDeleteScope = `${serviceData.name} gdprDeleteScope`;
       }
     });
   }

--- a/src/common/test/serviceConnectionDeleteMocking.ts
+++ b/src/common/test/serviceConnectionDeleteMocking.ts
@@ -1,0 +1,24 @@
+import {
+  GdprDeleteMyServiceDataMutation,
+  GdprDeleteMyServiceDataMutation_deleteMyServiceData_result,
+} from '../../graphql/generatedTypes';
+
+export function getServiceConnectionDeleteResult(errorCodes?: string[]) {
+  const success = !errorCodes;
+  const errors: GdprDeleteMyServiceDataMutation_deleteMyServiceData_result['errors'] = errorCodes
+    ? errorCodes.map(code => ({
+        __typename: 'ServiceConnectionDeletionError',
+        code,
+      }))
+    : [];
+  return {
+    deleteMyServiceData: {
+      __typename: 'DeleteMyServiceDataMutationPayload',
+      result: {
+        __typename: 'ServiceConnectionDeletionResult',
+        success,
+        errors,
+      },
+    },
+  } as GdprDeleteMyServiceDataMutation;
+}

--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -46,6 +46,7 @@ export type TestTools = RenderResult & {
   waitForIsComplete: () => Promise<void>;
   waitForDataChange: (previousChangeTime?: number) => Promise<void>;
   waitForElement: (selector: ElementSelector) => Promise<void>;
+  waitForElementNotToExist: (selector: ElementSelector) => Promise<void>;
   getTextOrInputValue: (
     selector: ElementSelector
   ) => Promise<string | undefined>;
@@ -208,6 +209,12 @@ export const renderComponentWithMocksAndContexts = async (
     });
   };
 
+  const waitForElementNotToExist: TestTools['waitForElementNotToExist'] = async selector => {
+    await waitFor(() => {
+      expect(() => getElement(selector)).toThrow();
+    });
+  };
+
   const getTextOrInputValue: TestTools['getTextOrInputValue'] = async selector => {
     let value: string | undefined;
     await waitFor(
@@ -347,6 +354,7 @@ export const renderComponentWithMocksAndContexts = async (
     setInputValue,
     waitForElementAndValue,
     comboBoxSelector,
+    waitForElementNotToExist,
   });
 };
 

--- a/src/gdprApi/__tests__/useDeleteServiceConnection.test.tsx
+++ b/src/gdprApi/__tests__/useDeleteServiceConnection.test.tsx
@@ -1,0 +1,388 @@
+import React, { useState } from 'react';
+import { act, waitFor } from '@testing-library/react';
+import { ApolloError } from '@apollo/client';
+
+import {
+  renderComponentWithMocksAndContexts,
+  TestTools,
+  cleanComponentMocks,
+  ElementSelector,
+} from '../../common/test/testingLibraryTools';
+import { ResponseProvider } from '../../common/test/MockApolloClientProvider';
+import useServiceConnectionsAuthorizationCode from '../useServiceConnectionsAuthorizationCode';
+import useDeleteServiceConnection from '../useDeleteServiceConnection';
+
+type UseServiceConnectionsHookOptions = Partial<
+  Parameters<typeof useServiceConnectionsAuthorizationCode>[0]
+>;
+type UseServiceConnectionsHookReturnTuple = ReturnType<
+  typeof useServiceConnectionsAuthorizationCode
+>;
+
+type UseDeleteServiceConnectionServiceName = Partial<
+  Parameters<typeof useDeleteServiceConnection>[0]
+>;
+type UseDeleteServiceConnectionHookReturnTuple = ReturnType<
+  typeof useDeleteServiceConnection
+>;
+type ServiceConnectionsLoadStatus = UseServiceConnectionsHookReturnTuple[1];
+
+const mockStartFetchingAuthorizationCode = jest.fn();
+
+const defaultTrackingData = {
+  returnValidAuthorizationCode: true,
+  authorizationCode: 'authCode',
+};
+
+const mockTrackingData = {
+  tracker: jest.fn(),
+  ...defaultTrackingData,
+};
+
+const defaultServiceName = 'defaultServiceName';
+
+let mockServiceConnectionsLoadStatus: ServiceConnectionsLoadStatus;
+
+const defaultServiceConnectionsLoadStatus: ServiceConnectionsLoadStatus = {
+  loading: false,
+  complete: false,
+  authorizationCode: undefined,
+  error: undefined,
+};
+
+const updateServiceConnectionsLoadStatus = (
+  newStatus: Partial<ServiceConnectionsLoadStatus>
+): void => {
+  mockServiceConnectionsLoadStatus = {
+    ...mockServiceConnectionsLoadStatus,
+    ...newStatus,
+  };
+};
+const resetServiceConnectionsLoadStatus = (): void => {
+  mockServiceConnectionsLoadStatus = {
+    ...defaultServiceConnectionsLoadStatus,
+  };
+};
+
+const mockApolloError = () => new ApolloError({ errorMessage: 'Error' });
+
+jest.mock(
+  '../useServiceConnectionsAuthorizationCode.ts',
+  () => (
+    options: UseServiceConnectionsHookOptions
+  ): UseServiceConnectionsHookReturnTuple => [
+    async () => {
+      mockStartFetchingAuthorizationCode();
+      await new Promise(resolve => {
+        setTimeout(resolve, 100);
+      });
+      if (mockTrackingData.returnValidAuthorizationCode) {
+        if (options.onCompleted) {
+          options.onCompleted(
+            defaultTrackingData.authorizationCode,
+            mockServiceConnectionsLoadStatus
+          );
+        }
+      } else {
+        if (options.onError) {
+          options.onError(mockApolloError(), mockServiceConnectionsLoadStatus);
+        }
+      }
+    },
+    mockServiceConnectionsLoadStatus,
+  ]
+);
+
+describe('<useDeleteServiceConnection /> ', () => {
+  let responseCounter = -1;
+
+  const queryTracker = jest.fn();
+  const onCompletedTracker = jest.fn();
+  const onErrorTracker = jest.fn();
+
+  const testIds = {
+    deleteButton: 'delete-button',
+    rerenderButton: 'rerender-button',
+    authorizationCodeIndicator: 'authorizationCode-indicator',
+    loadStatusIndicator: 'load-status-indicator',
+    status: 'status-output',
+    removeComponentButton: 'remove-component-button',
+  };
+
+  const OutputComponent = (props: {
+    data: Record<string, unknown>;
+    onClick: () => void;
+  }) => {
+    const { data, onClick } = props;
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid={testIds.deleteButton}
+          onClick={onClick}
+        >
+          Delete
+        </button>
+        <div data-testid={testIds.status}>{JSON.stringify(data)}</div>
+      </div>
+    );
+  };
+
+  const getTestId = (key: keyof typeof testIds): ElementSelector => ({
+    testId: testIds[key],
+  });
+
+  const getStatus = (
+    getElement: TestTools['getElement']
+  ): Partial<UseDeleteServiceConnectionHookReturnTuple[1]> => {
+    const statusElementContent = getElement(getTestId('status'))?.textContent;
+    return statusElementContent ? JSON.parse(statusElementContent) : {};
+  };
+
+  const ComponentWithHook = (props?: {
+    serviceName?: UseDeleteServiceConnectionServiceName;
+  }) => {
+    const [deleteConnection, status] = useDeleteServiceConnection(
+      props?.serviceName ? props.serviceName : defaultServiceName,
+      {
+        onCompleted: onCompletedTracker,
+        onError: onErrorTracker,
+      }
+    );
+    // useDeleteServiceConnection has no inner state which would cause re-render, so using forceRender
+    const [, forceRender] = useState<number>(0);
+    return (
+      <div>
+        <OutputComponent
+          data={{
+            hasCode: status.hasCode,
+            isDeleting: status.isDeleting,
+            isLoading: status.isLoading,
+          }}
+          onClick={() => deleteConnection()}
+        />
+        <button
+          type="button"
+          data-testid={testIds.rerenderButton}
+          onClick={() => forceRender(Date.now())}
+        >
+          Rerender
+        </button>
+      </div>
+    );
+  };
+
+  const renderTestSuite = (
+    errorResponseIndex = -1,
+    serviceName?: UseDeleteServiceConnectionServiceName
+  ) => {
+    const responseProvider: ResponseProvider = (...args: unknown[]) => {
+      responseCounter = responseCounter + 1;
+      queryTracker(...args);
+      if (responseCounter === errorResponseIndex) {
+        return { errorType: 'networkError' };
+      }
+      return {
+        deleteMyServiceData: {
+          __typename: 'DeleteMyServiceDataMutationPayload',
+          result: {
+            __typename: 'DeletionResultNode',
+            success: true,
+            errors: null,
+          },
+        },
+      };
+    };
+
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <ComponentWithHook serviceName={serviceName} />
+    );
+  };
+
+  beforeEach(() => {
+    responseCounter = -1;
+    Object.assign(mockTrackingData, defaultTrackingData);
+    resetServiceConnectionsLoadStatus();
+  });
+
+  afterEach(async () => {
+    // makes sure timeouts are complete before starting next test
+    await waitFor(() => {
+      if (
+        onCompletedTracker.mock.calls.length === 0 &&
+        onErrorTracker.mock.calls.length === 0
+      ) {
+        throw new Error('Test not finished');
+      }
+    });
+    cleanComponentMocks();
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const initTests = async (
+    serviceName?: UseDeleteServiceConnectionServiceName,
+    errorResponseIndex = -1
+  ): Promise<TestTools> => renderTestSuite(errorResponseIndex, serviceName);
+
+  it(`Gets the authorization code with useServiceConnectionsAuthorizationCode and
+      then runs the delete query.
+      `, async () => {
+    await act(async () => {
+      const { clickElement, getElement } = await initTests();
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        const status = getStatus(getElement);
+        expect(status.isLoading).toBeTruthy();
+      });
+
+      await waitFor(() => {
+        expect(mockStartFetchingAuthorizationCode).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+      });
+
+      updateServiceConnectionsLoadStatus({
+        loading: false,
+        authorizationCode: 'authCode',
+        complete: true,
+      });
+
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        await waitFor(() => {
+          expect(queryTracker).toHaveBeenCalledTimes(1);
+          expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+        });
+        expect(queryTracker).toHaveBeenLastCalledWith({
+          input: {
+            authorizationCode:
+              mockServiceConnectionsLoadStatus.authorizationCode,
+            dryRun: false,
+            serviceName: defaultServiceName,
+          },
+        });
+      });
+    });
+  });
+
+  it(`If service connection / authorization code load fails, the onError is called`, async () => {
+    await act(async () => {
+      mockTrackingData.returnValidAuthorizationCode = false;
+      const { clickElement, getElement } = await initTests(
+        defaultServiceName,
+        -1
+      );
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+        expect(getStatus(getElement).isLoading).toBeFalsy();
+        expect(getStatus(getElement).isDeleting).toBeFalsy();
+      });
+    });
+  });
+
+  it(`If deletion fails, the onError is called`, async () => {
+    await act(async () => {
+      const { clickElement, getElement } = await initTests(
+        defaultServiceName,
+        0
+      );
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(getStatus(getElement).isLoading).toBeTruthy();
+      });
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+        expect(getStatus(getElement).isLoading).toBeFalsy();
+        expect(getStatus(getElement).isDeleting).toBeFalsy();
+      });
+    });
+  });
+
+  it(`Deletion can be attempted multiple times`, async () => {
+    await act(async () => {
+      mockTrackingData.returnValidAuthorizationCode = false;
+      const { clickElement } = await initTests(defaultServiceName, 0);
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+        expect(queryTracker).toHaveBeenCalledTimes(0);
+      });
+      mockTrackingData.returnValidAuthorizationCode = true;
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(2);
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+      });
+
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(2);
+        expect(queryTracker).toHaveBeenCalledTimes(2);
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+      });
+
+      await clickElement(getTestId('deleteButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(2);
+        expect(queryTracker).toHaveBeenCalledTimes(3);
+        expect(onCompletedTracker).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+  it(`Hook's inner status changes with useServiceConnectionsAuthorizationCode state and 
+      when graphql query is executed
+      `, async () => {
+    await act(async () => {
+      const { clickElement, getElement } = await initTests();
+
+      updateServiceConnectionsLoadStatus({
+        loading: true,
+      });
+      await clickElement(getTestId('rerenderButton'));
+      await waitFor(() => {
+        const status = getStatus(getElement);
+        expect(status.isLoading).toBeTruthy();
+        expect(status.isDeleting).toBeFalsy();
+        expect(status.hasCode).toBeFalsy();
+      });
+
+      updateServiceConnectionsLoadStatus({
+        loading: false,
+        complete: true,
+        authorizationCode: defaultTrackingData.authorizationCode,
+      });
+      await clickElement(getTestId('rerenderButton'));
+      await waitFor(() => {
+        const status = getStatus(getElement);
+        expect(status.isLoading).toBeFalsy();
+        expect(status.isDeleting).toBeFalsy();
+        expect(status.hasCode).toBeTruthy();
+      });
+
+      await clickElement(getTestId('deleteButton'));
+
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+        const status = getStatus(getElement);
+        expect(status.isLoading).toBeTruthy();
+        expect(status.isDeleting).toBeTruthy();
+        expect(status.hasCode).toBeTruthy();
+      });
+
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        const status = getStatus(getElement);
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+        expect(status.isLoading).toBeFalsy();
+        expect(status.isDeleting).toBeFalsy();
+        expect(status.hasCode).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/gdprApi/__tests__/useDeleteServiceConnection.test.tsx
+++ b/src/gdprApi/__tests__/useDeleteServiceConnection.test.tsx
@@ -11,6 +11,7 @@ import {
 import { ResponseProvider } from '../../common/test/MockApolloClientProvider';
 import useServiceConnectionsAuthorizationCode from '../useServiceConnectionsAuthorizationCode';
 import useDeleteServiceConnection from '../useDeleteServiceConnection';
+import { getServiceConnectionDeleteResult } from '../../common/test/serviceConnectionDeleteMocking';
 
 type UseServiceConnectionsHookOptions = Partial<
   Parameters<typeof useServiceConnectionsAuthorizationCode>[0]
@@ -182,16 +183,7 @@ describe('<useDeleteServiceConnection /> ', () => {
       if (responseCounter === errorResponseIndex) {
         return { errorType: 'networkError' };
       }
-      return {
-        deleteMyServiceData: {
-          __typename: 'DeleteMyServiceDataMutationPayload',
-          result: {
-            __typename: 'DeletionResultNode',
-            success: true,
-            errors: null,
-          },
-        },
-      };
+      return getServiceConnectionDeleteResult();
     };
 
     return renderComponentWithMocksAndContexts(

--- a/src/gdprApi/__tests__/useServiceConnectionsAuthorizationCode.test.tsx
+++ b/src/gdprApi/__tests__/useServiceConnectionsAuthorizationCode.test.tsx
@@ -1,0 +1,324 @@
+import React, { useState } from 'react';
+import { act, waitFor } from '@testing-library/react';
+
+import {
+  renderComponentWithMocksAndContexts,
+  TestTools,
+  cleanComponentMocks,
+  ElementSelector,
+} from '../../common/test/testingLibraryTools';
+import { ResponseProvider } from '../../common/test/MockApolloClientProvider';
+import getMyProfileWithServiceConnections from '../../common/test/getMyProfileWithServiceConnections';
+import useServiceConnectionsAuthorizationCode from '../useServiceConnectionsAuthorizationCode';
+import { getDeleteScopes, getQueryScopes } from '../utils';
+import { GdprServiceConnectionsRoot } from '../../graphql/typings';
+
+const mockStartFetchingAuthorizationCode = jest.fn();
+const defaultTrackingData = {
+  returnValidAuthorizationCode: true,
+  authorizationCode: 'authCode',
+};
+const mockTrackingData = {
+  tracker: jest.fn(),
+  ...defaultTrackingData,
+};
+
+jest.mock(
+  '../useAuthorizationCode.ts',
+  () => (...args: [string, (code: string | null) => void]) => [
+    async (scopes: string[]) => {
+      const cb = args[1];
+      mockStartFetchingAuthorizationCode(scopes);
+      await new Promise(resolve => {
+        setTimeout(resolve, 100);
+      });
+      return cb(
+        mockTrackingData.returnValidAuthorizationCode
+          ? mockTrackingData.authorizationCode
+          : null
+      );
+    },
+    false,
+  ]
+);
+
+type HookOptions = Partial<
+  Parameters<typeof useServiceConnectionsAuthorizationCode>[0]
+>;
+
+describe('<useServiceConnectionsAuthorizationCode /> ', () => {
+  let responseCounter = -1;
+  const serviceConnections = getMyProfileWithServiceConnections(true);
+
+  const queryTracker = jest.fn();
+  const onCompletedTracker = jest.fn();
+  const onErrorTracker = jest.fn();
+
+  const testIds = {
+    loadButton: 'load-button',
+    rerenderButton: 'rerender-button',
+    authorizationCodeIndicator: 'authorizationCode-indicator',
+    loadStatusIndicator: 'load-status-indicator',
+    status: 'status-output',
+    removeComponentButton: 'remove-component-button',
+  };
+
+  const OutputComponent = (props: {
+    data: Record<string, unknown>;
+    onClick: () => void;
+  }) => {
+    const { data, onClick } = props;
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid={testIds.loadButton}
+          onClick={onClick}
+        >
+          Load
+        </button>
+        <div data-testid={testIds.status}>{JSON.stringify(data)}</div>
+      </div>
+    );
+  };
+
+  const getTestId = (key: keyof typeof testIds): ElementSelector => ({
+    testId: testIds[key],
+  });
+
+  const getStatus = (getElement: TestTools['getElement']) => {
+    const statusElementContent = getElement(getTestId('status'))?.textContent;
+    return statusElementContent ? JSON.parse(statusElementContent) : {};
+  };
+
+  const ComponentWithHook = (props?: { options?: HookOptions }) => {
+    const [load, status] = useServiceConnectionsAuthorizationCode({
+      requiredGdprScope: props?.options?.requiredGdprScope || 'delete',
+      deferredAction: 'testDeferredAction',
+      onCompleted: onCompletedTracker,
+      onError: e => {
+        onErrorTracker(e);
+      },
+    });
+    // useServiceConnectionsAuthorizationCode uses "useRef" to store its inner status
+    // Updating the data stored in useRef, does not cause re-render, so added a forceRender button here.
+    const [, forceRender] = useState<number>(0);
+    return (
+      <div>
+        <OutputComponent
+          data={{
+            loading: status.loading,
+            complete: status.complete,
+            authorizationCode: status.authorizationCode,
+          }}
+          onClick={() => load()}
+        />
+        <button
+          type="button"
+          data-testid={testIds.rerenderButton}
+          onClick={() => forceRender(Date.now())}
+        >
+          Rerender
+        </button>
+      </div>
+    );
+  };
+
+  const renderTestSuite = (
+    errorResponseIndex = -1,
+    hookOptions?: HookOptions
+  ) => {
+    const responseProvider: ResponseProvider = () => {
+      responseCounter = responseCounter + 1;
+      queryTracker();
+      if (responseCounter === errorResponseIndex) {
+        return { errorType: 'networkError' };
+      }
+      return { profileDataWithServiceConnections: serviceConnections };
+    };
+
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <ComponentWithHook options={hookOptions} />
+    );
+  };
+
+  beforeEach(() => {
+    responseCounter = -1;
+    Object.assign(mockTrackingData, defaultTrackingData);
+  });
+
+  afterEach(async () => {
+    // makes sure timeouts are complete before starting next test
+    await waitFor(() => {
+      if (
+        onCompletedTracker.mock.calls.length === 0 &&
+        onErrorTracker.mock.calls.length === 0
+      ) {
+        throw new Error('Test not finished');
+      }
+    });
+    cleanComponentMocks();
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const initTests = async (
+    errorResponseIndex = -1,
+    hookOptions?: HookOptions
+  ): Promise<TestTools> => renderTestSuite(errorResponseIndex, hookOptions);
+
+  it(`Loads service connections then gets the auth code with the returned scopes`, async () => {
+    await act(async () => {
+      const { clickElement, getElement } = await initTests();
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        const status = getStatus(getElement);
+        expect(status.loading).toBeTruthy();
+      });
+
+      await waitFor(() => {
+        expect(mockStartFetchingAuthorizationCode).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+      });
+
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        const status = getStatus(getElement);
+        expect(status.loading).toBeFalsy();
+        expect(status.complete).toBeTruthy();
+        expect(status.authorizationCode).toBe(
+          mockTrackingData.authorizationCode
+        );
+        expect(onCompletedTracker).toHaveBeenLastCalledWith(
+          mockTrackingData.authorizationCode,
+          {
+            authorizationCode: mockTrackingData.authorizationCode,
+            complete: true,
+            error: undefined,
+            loading: false,
+          }
+        );
+      });
+    });
+  });
+
+  it(`If service connection load fails, onError is called`, async () => {
+    await act(async () => {
+      const { clickElement, getElement } = await initTests(0);
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(getStatus(getElement).loading).toBeTruthy();
+      });
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+  describe('useAuthorizationCode is called with required scopes', () => {
+    const waitForLoadStart = async (
+      scopeType: HookOptions['requiredGdprScope']
+    ) => {
+      const { clickElement } = await initTests(-1, {
+        requiredGdprScope: scopeType,
+      });
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+        expect(mockStartFetchingAuthorizationCode).toHaveBeenCalledTimes(1);
+      });
+    };
+    const compareScopes = (scopePicker: typeof getQueryScopes) => {
+      const scopesInCall = mockStartFetchingAuthorizationCode.mock.calls[0][0];
+      const scopes = scopePicker(
+        serviceConnections as GdprServiceConnectionsRoot
+      );
+      expect(scopes).toHaveLength(2);
+      scopes.forEach(scope => {
+        expect(scopesInCall.includes(scope)).toBeTruthy();
+      });
+    };
+    it(`which are delete scopes when requiredGdprScope is 'delete' (default in tests)`, async () => {
+      await act(async () => {
+        await waitForLoadStart('delete');
+        compareScopes(getDeleteScopes);
+      });
+    });
+    it(`which are query scopes when requiredGdprScope is 'query'`, async () => {
+      await waitForLoadStart('query');
+      compareScopes(getQueryScopes);
+    });
+  });
+  it(`If authorization code load fails, onError is called`, async () => {
+    mockTrackingData.returnValidAuthorizationCode = false;
+    await act(async () => {
+      const { clickElement, getElement } = await initTests();
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(getStatus(getElement).loading).toBeTruthy();
+      });
+      await waitFor(async () => {
+        await clickElement(getTestId('rerenderButton'));
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+        expect(getStatus(getElement).loading).toBeFalsy();
+        expect(getStatus(getElement).complete).toBeFalsy();
+      });
+    });
+  });
+  it(`Code can be refetched multiple times`, async () => {
+    const getLastAuthorizationCode = (): string | null => {
+      const count = onCompletedTracker.mock.calls.length;
+      return onCompletedTracker.mock.calls[count - 1][0];
+    };
+    await act(async () => {
+      const { clickElement } = await renderTestSuite();
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+        expect(getLastAuthorizationCode()).toBe(
+          mockTrackingData.authorizationCode
+        );
+      });
+      mockTrackingData.authorizationCode = 'code2';
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(2);
+        expect(queryTracker).toHaveBeenCalledTimes(2);
+        expect(getLastAuthorizationCode()).toBe('code2');
+      });
+      mockTrackingData.returnValidAuthorizationCode = false;
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(onErrorTracker).toHaveBeenCalledTimes(1);
+        expect(queryTracker).toHaveBeenCalledTimes(3);
+      });
+      mockTrackingData.authorizationCode = 'code3';
+      mockTrackingData.returnValidAuthorizationCode = true;
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(3);
+        expect(queryTracker).toHaveBeenCalledTimes(4);
+        expect(getLastAuthorizationCode()).toBe('code3');
+      });
+    });
+  });
+  it(`When already loading, loading in not started again`, async () => {
+    await act(async () => {
+      const { clickElement } = await renderTestSuite();
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+        expect(onCompletedTracker).toHaveBeenCalledTimes(0);
+      });
+      await clickElement(getTestId('loadButton'));
+      await clickElement(getTestId('loadButton'));
+      await waitFor(() => {
+        expect(onCompletedTracker).toHaveBeenCalledTimes(1);
+        expect(queryTracker).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/gdprApi/graphql/GdprDeleteServiceData.graphql
+++ b/src/gdprApi/graphql/GdprDeleteServiceData.graphql
@@ -1,0 +1,12 @@
+mutation GdprDeleteMyServiceDataMutation(
+  $input: DeleteMyServiceDataMutationInput!
+) {
+  deleteMyServiceData(input: $input) {
+    result {
+      success
+      errors {
+        code
+      }
+    }
+  }
+}

--- a/src/gdprApi/graphql/GdprServiceConnectionsQuery.graphql
+++ b/src/gdprApi/graphql/GdprServiceConnectionsQuery.graphql
@@ -5,6 +5,7 @@ query GdprServiceConnectionsQuery {
       edges {
         node {
           service {
+            name
             gdprQueryScope
             gdprDeleteScope
           }

--- a/src/gdprApi/useDeleteProfile.ts
+++ b/src/gdprApi/useDeleteProfile.ts
@@ -3,7 +3,6 @@ import {
   useMutation,
   MutationHookOptions,
   MutationResult,
-  useLazyQuery,
 } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
@@ -11,14 +10,9 @@ import {
   GdprDeleteMyProfileMutation,
   GdprDeleteMyProfileMutationVariables,
 } from '../graphql/generatedTypes';
-import { GdprServiceConnectionsRoot } from '../graphql/typings';
-import { getDeleteScopes } from './utils';
-import useAuthorizationCode from './useAuthorizationCode';
+import useServiceConnectionsAuthorizationCode from './useServiceConnectionsAuthorizationCode';
 
 const DELETE_PROFILE = loader('./graphql/GdprDeleteMyProfileMutation.graphql');
-const SERVICE_CONNECTIONS = loader(
-  './graphql/GdprServiceConnectionsQuery.graphql'
-);
 
 function useDeleteProfile(
   options: MutationHookOptions<
@@ -39,7 +33,6 @@ function useDeleteProfile(
             authorizationCode,
           },
         };
-
         deleteProfile({
           variables: variablesWithAuthorizationCode,
         });
@@ -48,41 +41,24 @@ function useDeleteProfile(
     [deleteProfile]
   );
 
-  const [startFetchingAuthorizationCode, isAuthorizing] = useAuthorizationCode(
-    'useDeleteProfile',
-    handleAuthorizationCodeCallback
-  );
-
-  const handleDownloadActionInitialization = React.useCallback(
-    serviceConnectionsResult => {
-      const deleteScopes = getDeleteScopes(serviceConnectionsResult);
-
-      startFetchingAuthorizationCode(deleteScopes);
+  const [
+    getAuthorizationCode,
+    authorizationCodeStatus,
+  ] = useServiceConnectionsAuthorizationCode({
+    requiredGdprScope: 'delete',
+    deferredAction: 'useDeleteProfile',
+    onCompleted: e => {
+      handleAuthorizationCodeCallback(e);
     },
-    [startFetchingAuthorizationCode]
-  );
-
-  const [getServiceConnections] = useLazyQuery<GdprServiceConnectionsRoot>(
-    SERVICE_CONNECTIONS,
-    {
-      fetchPolicy: 'no-cache',
-      onCompleted: data => {
-        handleDownloadActionInitialization(data);
-      },
-      onError: e => {
-        if (options.onError) {
-          options.onError(e);
-        }
-      },
-    }
-  );
+    onError: options?.onError,
+  });
 
   const injectedMutationResult = {
     ...queryResult,
-    loading: isAuthorizing || queryResult.loading,
+    loading: authorizationCodeStatus.loading || queryResult.loading,
   };
 
-  return [getServiceConnections, injectedMutationResult];
+  return [getAuthorizationCode, injectedMutationResult];
 }
 
 export default useDeleteProfile;

--- a/src/gdprApi/useDeleteServiceConnection.ts
+++ b/src/gdprApi/useDeleteServiceConnection.ts
@@ -1,14 +1,8 @@
 import { useCallback } from 'react';
-import {
-  MutationHookOptions,
-  MutationResult,
-  useMutation,
-} from '@apollo/client';
+import { MutationHookOptions, useMutation } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
-import useServiceConnectionsAuthorizationCode, {
-  LoadStatus,
-} from './useServiceConnectionsAuthorizationCode';
+import useServiceConnectionsAuthorizationCode from './useServiceConnectionsAuthorizationCode';
 import {
   GdprDeleteMyServiceDataMutationVariables,
   GdprDeleteMyServiceDataMutation,
@@ -18,8 +12,7 @@ const DELETE_SERVICE_DATA = loader('./graphql/GdprDeleteServiceData.graphql');
 
 type ReturnTuple = [
   () => void,
-  MutationResult<GdprDeleteMyServiceDataMutation>,
-  LoadStatus
+  { hasCode: boolean; isDeleting: boolean; isLoading: boolean }
 ];
 
 function useDeleteServiceConnection(
@@ -58,14 +51,21 @@ function useDeleteServiceConnection(
     authorizationCodeStatus,
   ] = useServiceConnectionsAuthorizationCode({
     requiredGdprScope: 'delete',
-    deferredAction: 'useDeleteServiceConnection',
+    deferredAction: `useDeleteServiceConnection-${serviceName}`,
     onCompleted: e => {
       executeDeletion(e);
     },
     onError: options?.onError,
   });
 
-  return [getAuthorizationCode, queryResult, authorizationCodeStatus];
+  return [
+    getAuthorizationCode,
+    {
+      hasCode: !!authorizationCodeStatus.authorizationCode,
+      isLoading: queryResult.loading || authorizationCodeStatus.loading,
+      isDeleting: queryResult.loading,
+    },
+  ];
 }
 
 export default useDeleteServiceConnection;

--- a/src/gdprApi/useDeleteServiceConnection.ts
+++ b/src/gdprApi/useDeleteServiceConnection.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import {
+  MutationHookOptions,
+  MutationResult,
+  useMutation,
+} from '@apollo/client';
+import { loader } from 'graphql.macro';
+
+import useServiceConnectionsAuthorizationCode, {
+  LoadStatus,
+} from './useServiceConnectionsAuthorizationCode';
+import {
+  GdprDeleteMyServiceDataMutationVariables,
+  GdprDeleteMyServiceDataMutation,
+} from '../graphql/generatedTypes';
+
+const DELETE_SERVICE_DATA = loader('./graphql/GdprDeleteServiceData.graphql');
+
+type ReturnTuple = [
+  () => void,
+  MutationResult<GdprDeleteMyServiceDataMutation>,
+  LoadStatus
+];
+
+function useDeleteServiceConnection(
+  serviceName: string,
+  options: MutationHookOptions<
+    GdprDeleteMyServiceDataMutation,
+    GdprDeleteMyServiceDataMutationVariables
+  >
+): ReturnTuple {
+  const [deleteServiceData, queryResult] = useMutation<
+    GdprDeleteMyServiceDataMutation,
+    GdprDeleteMyServiceDataMutationVariables
+  >(DELETE_SERVICE_DATA, {
+    ...options,
+  });
+
+  const executeDeletion = useCallback(
+    (authorizationCode: string) => {
+      const variablesWithAuthorizationCode = {
+        input: {
+          authorizationCode,
+          serviceName,
+          dryRun: false,
+        },
+      };
+
+      deleteServiceData({
+        variables: variablesWithAuthorizationCode,
+      });
+    },
+    [deleteServiceData, serviceName]
+  );
+
+  const [
+    getAuthorizationCode,
+    authorizationCodeStatus,
+  ] = useServiceConnectionsAuthorizationCode({
+    requiredGdprScope: 'delete',
+    deferredAction: 'useDeleteServiceConnection',
+    onCompleted: e => {
+      executeDeletion(e);
+    },
+    onError: options?.onError,
+  });
+
+  return [getAuthorizationCode, queryResult, authorizationCodeStatus];
+}
+
+export default useDeleteServiceConnection;

--- a/src/gdprApi/useDeleteServiceConnection.ts
+++ b/src/gdprApi/useDeleteServiceConnection.ts
@@ -50,6 +50,7 @@ function useDeleteServiceConnection(
     getAuthorizationCode,
     authorizationCodeStatus,
   ] = useServiceConnectionsAuthorizationCode({
+    serviceName,
     requiredGdprScope: 'delete',
     deferredAction: `useDeleteServiceConnection-${serviceName}`,
     onCompleted: e => {

--- a/src/gdprApi/useServiceConnectionsAuthorizationCode.ts
+++ b/src/gdprApi/useServiceConnectionsAuthorizationCode.ts
@@ -2,7 +2,7 @@ import { useLazyQuery, ApolloError } from '@apollo/client';
 import { loader } from 'graphql.macro';
 import { useRef } from 'react';
 
-import { GdprServiceConnectionsRoot } from '../graphql/typings';
+import { GdprServiceConnectionsRoot, Service } from '../graphql/typings';
 import useAuthorizationCode from './useAuthorizationCode';
 import { getDeleteScopes, getQueryScopes } from './utils';
 
@@ -20,6 +20,7 @@ export type LoadStatus = {
 type Options = {
   requiredGdprScope: 'delete' | 'query';
   deferredAction: string;
+  serviceName?: Service['name'];
   onError?: (e: ApolloError, status: LoadStatus) => void;
   onCompleted?: (authorizationCode: string, status: LoadStatus) => void;
 };
@@ -71,8 +72,8 @@ function useServiceConnectionsAuthorizationCode(
       onCompleted: data => {
         const scopes =
           options.requiredGdprScope === 'query'
-            ? getQueryScopes(data)
-            : getDeleteScopes(data);
+            ? getQueryScopes(data, options.serviceName)
+            : getDeleteScopes(data, options.serviceName);
         getAuthorizationCode(scopes);
       },
       onError: error => {

--- a/src/gdprApi/useServiceConnectionsAuthorizationCode.ts
+++ b/src/gdprApi/useServiceConnectionsAuthorizationCode.ts
@@ -1,0 +1,107 @@
+import { useLazyQuery, ApolloError } from '@apollo/client';
+import { loader } from 'graphql.macro';
+import { useRef } from 'react';
+
+import { GdprServiceConnectionsRoot } from '../graphql/typings';
+import useAuthorizationCode from './useAuthorizationCode';
+import { getDeleteScopes, getQueryScopes } from './utils';
+
+const GDPR_SERVICE_CONNECTIONS = loader(
+  './graphql/GdprServiceConnectionsQuery.graphql'
+);
+
+export type LoadStatus = {
+  loading: boolean;
+  authorizationCode?: string | null;
+  complete: boolean;
+  error?: ApolloError;
+};
+
+type Options = {
+  requiredGdprScope: 'delete' | 'query';
+  deferredAction: string;
+  onError?: (e: ApolloError, status: LoadStatus) => void;
+  onCompleted?: (authorizationCode: string, status: LoadStatus) => void;
+};
+
+function useServiceConnectionsAuthorizationCode(
+  options: Options
+): [() => void, LoadStatus] {
+  // Using "useRef" instead of "useState", because "useState" is async
+  // When calling updateStatus and then onCompleted(status) the status object would be old version.
+  const loadStatusRef = useRef<LoadStatus>({
+    loading: false,
+    complete: false,
+  });
+  const updateStatus = (newProps: Partial<LoadStatus>) => {
+    loadStatusRef.current = { ...loadStatusRef.current, ...newProps };
+  };
+  const [getAuthorizationCode] = useAuthorizationCode(
+    options.deferredAction,
+    authorizationCode => {
+      if (!authorizationCode) {
+        const error = new ApolloError({
+          errorMessage: 'Authorization code not loaded',
+        });
+        updateStatus({
+          error,
+          loading: false,
+        });
+
+        if (options?.onError) {
+          options.onError(error, loadStatusRef.current);
+        }
+      } else {
+        updateStatus({
+          complete: true,
+          loading: false,
+          authorizationCode,
+        });
+        if (options?.onCompleted) {
+          options.onCompleted(authorizationCode, loadStatusRef.current);
+        }
+      }
+    }
+  );
+
+  const [getServiceConnections] = useLazyQuery<GdprServiceConnectionsRoot>(
+    GDPR_SERVICE_CONNECTIONS,
+    {
+      fetchPolicy: 'no-cache',
+      onCompleted: data => {
+        const scopes =
+          options.requiredGdprScope === 'query'
+            ? getQueryScopes(data)
+            : getDeleteScopes(data);
+        getAuthorizationCode(scopes);
+      },
+      onError: error => {
+        updateStatus({
+          error,
+          loading: false,
+        });
+        if (options?.onError) {
+          options.onError(error, loadStatusRef.current);
+        }
+      },
+    }
+  );
+
+  return [
+    () => {
+      if (loadStatusRef.current.loading) {
+        return;
+      }
+      updateStatus({
+        loading: true,
+        complete: false,
+        authorizationCode: undefined,
+        error: undefined,
+      });
+      getServiceConnections();
+    },
+    loadStatusRef.current,
+  ];
+}
+
+export default useServiceConnectionsAuthorizationCode;

--- a/src/gdprApi/utils.ts
+++ b/src/gdprApi/utils.ts
@@ -1,4 +1,4 @@
-import { GdprServiceConnectionsRoot } from '../graphql/typings';
+import { GdprServiceConnectionsRoot, Service } from '../graphql/typings';
 
 interface GdprServiceConnectionFields {
   gdprQueryScope: string;
@@ -6,7 +6,8 @@ interface GdprServiceConnectionFields {
 }
 
 const servicesSelector = (
-  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined | null
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined | null,
+  serviceName?: Service['name']
 ): GdprServiceConnectionFields[] => {
   if (
     serviceConnectionsQuery === null ||
@@ -29,6 +30,10 @@ const servicesSelector = (
       return undefined;
     }
 
+    if (serviceName && service.name !== serviceName) {
+      return undefined;
+    }
+
     return {
       gdprQueryScope: service.gdprQueryScope,
       gdprDeleteScope: service.gdprDeleteScope,
@@ -41,17 +46,19 @@ const servicesSelector = (
 };
 
 export function getDeleteScopes(
-  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined,
+  serviceName?: Service['name']
 ): string[] {
-  const services = servicesSelector(serviceConnectionsQuery);
+  const services = servicesSelector(serviceConnectionsQuery, serviceName);
 
   return services.map(service => service.gdprDeleteScope);
 }
 
 export function getQueryScopes(
-  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined
+  serviceConnectionsQuery: GdprServiceConnectionsRoot | undefined,
+  serviceName?: Service['name']
 ): string[] {
-  const services = servicesSelector(serviceConnectionsQuery);
+  const services = servicesSelector(serviceConnectionsQuery, serviceName);
 
   return services.map(service => service.gdprQueryScope);
 }

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -38,6 +38,58 @@ export interface GdprDeleteMyProfileMutationVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL mutation operation: GdprDeleteMyServiceDataMutation
+// ====================================================
+
+export interface GdprDeleteMyServiceDataMutation_deleteMyServiceData_result_errors {
+  readonly __typename: "ServiceConnectionDeletionError";
+  readonly code: string;
+}
+
+export interface GdprDeleteMyServiceDataMutation_deleteMyServiceData_result {
+  readonly __typename: "ServiceConnectionDeletionResult";
+  /**
+   * Was the data removed or not. Or can the data be removed if the request was a dry-run request
+   */
+  readonly success: boolean;
+  /**
+   * Errors if the deletion was not successful or the deletion is not possible
+   */
+  readonly errors: ReadonlyArray<GdprDeleteMyServiceDataMutation_deleteMyServiceData_result_errors>;
+}
+
+export interface GdprDeleteMyServiceDataMutation_deleteMyServiceData {
+  readonly __typename: "DeleteMyServiceDataMutationPayload";
+  readonly result: GdprDeleteMyServiceDataMutation_deleteMyServiceData_result;
+}
+
+export interface GdprDeleteMyServiceDataMutation {
+  /**
+   * Deletes the data of the profile which is linked to the currently authenticated user from one connected service.
+   * 
+   * Requires authentication.
+   * 
+   * Possible error codes:
+   * 
+   * * `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to the currently authenticated user.
+   * * `MISSING_GDPR_API_TOKEN_ERROR`: No API token available for accessing the service.
+   * * `SERVICE_CONNECTION_DOES_NOT_EXIST_ERROR`: The user is not connected to the service
+   * * `CONNECTED_SERVICE_DELETION_NOT_ALLOWED_ERROR`: The profile deletion is disallowed by the service
+   * * `CONNECTED_SERVICE_DELETION_FAILED_ERROR`: The profile deletion failed for the service.
+   */
+  readonly deleteMyServiceData: GdprDeleteMyServiceDataMutation_deleteMyServiceData | null;
+}
+
+export interface GdprDeleteMyServiceDataMutationVariables {
+  readonly input: DeleteMyServiceDataMutationInput;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: GdprServiceConnectionsQuery
 // ====================================================
 
@@ -399,9 +451,7 @@ export interface MyProfileQuery_myProfile {
    */
   readonly phones: MyProfileQuery_myProfile_phones | null;
   /**
-   * Personal information that has been verified to be true. Can result into
-   * `PERMISSION_DENIED_ERROR` if the requester has no required privileges to
-   * access this information.
+   * Personal information that has been verified to be true. Can result into `PERMISSION_DENIED_ERROR` if the requester has no required privileges to access this information.
    */
   readonly verifiedPersonalInformation: MyProfileQuery_myProfile_verifiedPersonalInformation | null;
 }
@@ -816,6 +866,14 @@ export interface CreatePhoneInput {
 
 export interface DeleteMyProfileMutationInput {
   readonly authorizationCode: string;
+  readonly dryRun?: boolean | null;
+  readonly clientMutationId?: string | null;
+}
+
+export interface DeleteMyServiceDataMutationInput {
+  readonly authorizationCode: string;
+  readonly serviceName: string;
+  readonly dryRun?: boolean | null;
   readonly clientMutationId?: string | null;
 }
 
@@ -823,7 +881,6 @@ export interface DeleteMyProfileMutationInput {
  * The following fields are deprecated:
  * 
  * * `image`
- * * `subscriptions`
  * 
  * There's no replacement for these.
  */
@@ -837,7 +894,6 @@ export interface ProfileInput {
   readonly addEmails?: ReadonlyArray<(CreateEmailInput | null)> | null;
   readonly addPhones?: ReadonlyArray<(CreatePhoneInput | null)> | null;
   readonly addAddresses?: ReadonlyArray<(CreateAddressInput | null)> | null;
-  readonly subscriptions?: ReadonlyArray<(SubscriptionInputType | null)> | null;
   readonly sensitivedata?: SensitiveDataFields | null;
   readonly updateEmails?: ReadonlyArray<(UpdateEmailInput | null)> | null;
   readonly removeEmails?: ReadonlyArray<(string | null)> | null;
@@ -849,11 +905,6 @@ export interface ProfileInput {
 
 export interface SensitiveDataFields {
   readonly ssn?: string | null;
-}
-
-export interface SubscriptionInputType {
-  readonly subscriptionTypeId: string;
-  readonly enabled: boolean;
 }
 
 export interface UpdateAddressInput {

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -481,6 +481,7 @@ export interface ServiceConnectionsQuery_myProfile_serviceConnections_edges_node
 
 export interface ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service {
   readonly __typename: "ServiceNode";
+  readonly name: string;
   readonly title: string | null;
   readonly description: string | null;
   readonly allowedDataFields: ServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service_allowedDataFields;

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -95,6 +95,7 @@ export interface GdprDeleteMyServiceDataMutationVariables {
 
 export interface GdprServiceConnectionsQuery_myProfile_serviceConnections_edges_node_service {
   readonly __typename: "ServiceNode";
+  readonly name: string;
   /**
    * GDPR API query operation scope
    */

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -43,7 +43,9 @@
     "delete": "Delete my information",
     "explanation": "By continuing you will lose all of your stored data and you can no longer use the following City of Helsinki services:",
     "noServiceExplanation": "By continuing you will lose all of your stored data.",
-    "title": "Are you sure you want to delete your information?"
+    "title": "Are you sure you want to delete your information?",
+    "contactServiceToDelete": "If you still want to delete the data, please contact <linkToExternalServiceList >the service</linkToExternalServiceList> directly and then retry deleting the profile.",
+    "urlToServiceList": "https://www.hel.fi/helsinki/en/administration/administration/services"
   },
   "deleteProfileErrorModal": {
     "notAllowed": "You cannot delete your profile because one of the services using it needs your information, for example, for invoicing.",
@@ -210,7 +212,15 @@
     "empty": "You currently don't have any services connected to your profile.",
     "explanation": "You have granted the following services the right to use the data stored on your Helsinki profile.",
     "servicePersonalData": "Information which the service will know about you:",
-    "title": "Services with permission to use your data"
+    "title": "Services with permission to use your data",
+    "deleteConnection": "If you want to delete your data from this service, <deleteButton>click here</deleteButton>.",
+    "connectionRemovalVerification": "By continuing, you will lose all the data stored in the {{serviceName}} service and will no longer be able to use the service until you re-register to the service.",
+    "connectionRemovalSuccess": "All the data we had stored in the {{serviceName}} service has been deleted successfully!",
+    "connectionRemovalForbidden": "We cannot delete data from this service, for example due to the transaction status or storage time.",
+    "connectionRemovalVerificationTitle": "Are you sure you want to delete your data?",
+    "connectionRemovalVerificationButtonText": "Delete data",
+    "connectionRemovalError": "For some reason, the deletion was not successful. Please, try again later!",
+    "contactServiceToDelete": "If you still want to delete the data, please contact <linkToExternalServiceList >the service</linkToExternalServiceList> directly and then retry deleting the data."
   },
   "skipToContent": "Skip to content",
   "validation": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -43,7 +43,9 @@
     "delete": "Poista omat tiedot",
     "explanation": "Jatkamalla menetät kaikki tallennetut tietosi etkä voi enää käyttää seuraavia Helsingin kaupungin palveluita:",
     "noServiceExplanation": "Jatkamalla menetät kaikki tallennetut tietosi.",
-    "title": "Haluatko varmasti poistaa kaikki tietosi?"
+    "title": "Haluatko varmasti poistaa kaikki tietosi?",
+    "contactServiceToDelete": "Jos haluat silti poistaa tiedot, ole suoraan yhteydessä <linkToExternalServiceList>kyseiseen palveluun</linkToExternalServiceList> ja yritä profiilin poistoa sen jälkeen uudestaan.",
+    "urlToServiceList": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/hallinto/palvelut"
   },
   "deleteProfileErrorModal": {
     "notAllowed": "Et voi poistaa profiiliasi, koska jokin sitä käyttävistä palveluista tarvitsee tietojasi esimerkiksi laskutukseen.",
@@ -210,7 +212,15 @@
     "empty": "Sinulla ei tällä hetkellä ole palveluita liitettynä profiiliisi.",
     "explanation": "Olet antanut seuraaville palveluille oikeuden käyttää Helsinki-profiiliin tallennettuja tietojasi.",
     "servicePersonalData": "Palvelu saa tietää sinusta:",
-    "title": "Palvelut, joilla on lupa käyttää tietojasi"
+    "title": "Palvelut, joilla on lupa käyttää tietojasi",
+    "deleteConnection": "Mikäli haluat poistaa tietosi tästä palvelusta <deleteButton>paina tästä</deleteButton>.",
+    "connectionRemovalVerification": "Jatkamalla menetät kaikki {{serviceName}} -palveluun tallennetut tiedot, etkä voi enää käyttää palvelua, ennen kuin rekisteröidyt palveluun uudelleen.",
+    "connectionRemovalSuccess": "Kaikki {{serviceName}} -palveluun tallentamamme tiedot on poistettu onnistuneesti!",
+    "connectionRemovalForbidden": "Emme voi poistaa tietoja tästä palvelusta esimerkiksi asioinnin tilan tai säilytysajan vuoksi.",
+    "connectionRemovalVerificationTitle": "Haluatko varmasti poistaa tietosi?",
+    "connectionRemovalVerificationButtonText": "Poista tiedot",
+    "connectionRemovalError": "Jostain syystä poisto ei onnistunut. Yritä hetken kuluttua uudelleen!",
+    "contactServiceToDelete": "Jos haluat silti poistaa tiedot, ole suoraan yhteydessä <linkToExternalServiceList>kyseiseen palveluun</linkToExternalServiceList> ja yritä tietojen poistoa sen jälkeen uudestaan."
   },
   "skipToContent": "Siirry suoraan sisältöön",
   "validation": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -43,7 +43,9 @@
     "delete": "Radera min information",
     "explanation": "Genom att fortsätta kommer du att förlora alla dina lagrade information och du kan inte längre använda följande Helsingfors stads tjänster:",
     "noServiceExplanation": "Genom att fortsätta kommer du att förlora alla dina lagrade information.",
-    "title": "Är du säker på att du vill radera din information?"
+    "title": "Är du säker på att du vill radera din information?",
+    "contactServiceToDelete": "Om du ändå vill ta bort uppgifterna, kontakta <linkToExternalServiceList>tjänsten</linkToExternalServiceList> i fråga direkt och försök därefter att ta bort profilen på nytt.",
+    "urlToServiceList": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/forvaltning/tjanster"
   },
   "deleteProfileErrorModal": {
     "notAllowed": "Du kan inte ta bort din profil eftersom någon av tjänsterna som används behöver dina uppgifter till exempel för fakturering.",
@@ -210,7 +212,15 @@
     "empty": "Du har för närvarande inga tjänster anslutna till din profil.",
     "explanation": "Du har gett följande tjänster rätt att använda uppgifterna som sparats i Helsingforsprofilen.",
     "servicePersonalData": "Information som tjänsten vet om dig:",
-    "title": "Tjänster som har tillstånd att använda dina uppgifter"
+    "title": "Tjänster som har tillstånd att använda dina uppgifter",
+    "deleteConnection": "Om du vill ta bort dina uppgifter från denna tjänst, <deleteButton>tryck här</deleteButton>.",
+    "connectionRemovalVerification": "Om du fortsätter, förlorar du alla uppgifter som du sparat i tjänsten {{serviceName}} och du kan inte längre använda tjänsten förrän du registrerar dig i tjänsten på nytt.",
+    "connectionRemovalSuccess": "Alla uppgifter som vi sparat i tjänsten {{serviceName}} har tagits bort på ett lyckat sätt!",
+    "connectionRemovalForbidden": "Vi kan inte radera data från denna tjänst, till exempel på grund av transaktionsstatus eller lagringstid.",
+    "connectionRemovalVerificationTitle": "Är du säker på att du vill radera data",
+    "connectionRemovalVerificationButtonText": "Radera data",
+    "connectionRemovalError": "Raderingen misslyckades av någon anledning. Försök igen senare!",
+    "contactServiceToDelete": "Om du ändå vill ta bort uppgifterna, kontakta <linkToExternalServiceList>tjänsten</linkToExternalServiceList> och försök att radera uppgifterna igen efteråt."
   },
   "skipToContent": "Hoppa till innehåll",
   "validation": {

--- a/src/profile/components/deleteProfile/DeleteProfile.tsx
+++ b/src/profile/components/deleteProfile/DeleteProfile.tsx
@@ -3,7 +3,7 @@ import { ApolloError, useLazyQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/browser';
-import { Button, LoadingSpinner, Notification } from 'hds-react';
+import { Button, Notification } from 'hds-react';
 import { useHistory } from 'react-router';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
@@ -20,6 +20,7 @@ import DeleteProfileError from '../modals/deleteProfileError/DeleteProfileError'
 import createServiceConnectionsQueryVariables from '../../helpers/createServiceConnectionsQueryVariables';
 import ProfileSection from '../../../common/profileSection/ProfileSection';
 import { useScrollIntoView } from '../../hooks/useScrollIntoView';
+import Loading from '../../../common/loading/Loading';
 
 const SERVICE_CONNECTIONS = loader(
   '../../graphql/ServiceConnectionsQuery.graphql'
@@ -127,15 +128,12 @@ function DeleteProfile(): React.ReactElement {
   };
 
   const LoadIndicator = ({ text }: { text: string }) => (
-    <div
-      className={styles['loading-info']}
-      aria-live="polite"
-      aria-busy="true"
-      data-testid="delete-profile-load-indicator"
-    >
-      <LoadingSpinner small />
-      <p>{text}</p>
-    </div>
+    <Loading
+      isLoading
+      loadingText={text}
+      dataTestId="delete-profile-load-indicator"
+      alignLeft
+    />
   );
   const ServiceConnectionLoadError = () => (
     <Notification label={t('notification.defaultErrorText')} type={'error'}>

--- a/src/profile/components/deleteProfile/deleteProfile.module.css
+++ b/src/profile/components/deleteProfile/deleteProfile.module.css
@@ -5,14 +5,3 @@
 .checkbox-container {
   margin-top: var(--spacing-l);
 }
-
-.loading-info {
-  display: flex;
-  align-items: center;
-  margin: var(--spacing-xs) 0;
-}
-
-.loading-info p {
-  margin: 0;
-  padding-left: var(--spacing-m);
-}

--- a/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
+++ b/src/profile/components/modals/confirmationModal/ConfirmationModal.tsx
@@ -10,7 +10,9 @@ export type Props = {
   onConfirm: () => void;
   title?: string;
   content?: React.FC<unknown> | string;
-  actionButtonText: string;
+  actionButtonText?: string;
+  closeButtonText?: string;
+  preventClosing?: boolean;
 };
 
 function ConfirmationModal({
@@ -20,10 +22,11 @@ function ConfirmationModal({
   title,
   content,
   actionButtonText,
+  closeButtonText,
+  preventClosing,
 }: Props): React.ReactElement {
   const { t } = useTranslation();
   const id = 'confirmation-modal';
-  const closeButtonText = t('confirmationModal.cancel');
   const {
     titleId,
     descriptionId,
@@ -33,7 +36,7 @@ function ConfirmationModal({
   } = getModalProps({
     id,
     onClose,
-    closeButtonText,
+    closeButtonText: closeButtonText || t('confirmationModal.cancel'),
   });
   const ContentComponent: React.FC<unknown> =
     typeof content === 'string' || typeof content === 'undefined'
@@ -53,6 +56,7 @@ function ConfirmationModal({
       isOpen={isOpen}
       targetElement={dialogTargetElement}
       {...dialogCloseProps}
+      {...(preventClosing && { close: undefined })}
     >
       {title && (
         <Dialog.Header
@@ -68,21 +72,27 @@ function ConfirmationModal({
           </div>
         </Dialog.Content>
       )}
-      <Dialog.ActionButtons>
-        <Button
-          onClick={onConfirm}
-          data-testid="confirmation-modal-confirm-button"
-        >
-          {actionButtonText}
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={onClose}
-          data-testid="confirmation-modal-cancel-button"
-        >
-          {closeButtonText}
-        </Button>
-      </Dialog.ActionButtons>
+      {!preventClosing && (actionButtonText || closeButtonText) && (
+        <Dialog.ActionButtons>
+          {actionButtonText && (
+            <Button
+              onClick={onConfirm}
+              data-testid="confirmation-modal-confirm-button"
+            >
+              {actionButtonText}
+            </Button>
+          )}
+          {closeButtonText !== '' && closeButtonLabelText && (
+            <Button
+              variant="secondary"
+              onClick={onClose}
+              data-testid="confirmation-modal-cancel-button"
+            >
+              {closeButtonLabelText}
+            </Button>
+          )}
+        </Dialog.ActionButtons>
+      )}
     </Dialog>
   );
 }

--- a/src/profile/components/serviceConnections/DeleteServiceConnectionModal.tsx
+++ b/src/profile/components/serviceConnections/DeleteServiceConnectionModal.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'hds-react';
+
+import ConfirmationModal from '../modals/confirmationModal/ConfirmationModal';
+import { ServiceConnectionData } from '../../helpers/getServiceConnectionData';
+import Loading from '../../../common/loading/Loading';
+import {
+  DeletionStatus,
+  STATUS_DELETE_FORBIDDEN,
+  STATUS_DONE,
+  STATUS_ERROR,
+  STATUS_LOADING,
+  STATUS_PENDING_CONFIRMATION,
+} from './ServiceConnection';
+
+function DeleteServiceConnectionModal(props: {
+  service: ServiceConnectionData;
+  status: DeletionStatus;
+  onConfirm: () => void;
+  onClose: () => void;
+}): React.ReactElement | null {
+  const { service, status, onConfirm, onClose } = props;
+  const { t } = useTranslation();
+
+  const cannotDelete = status === STATUS_DELETE_FORBIDDEN;
+  const hasError = status === STATUS_ERROR || cannotDelete;
+  const isLoading = status === STATUS_LOADING;
+  const isDone = status === STATUS_DONE;
+  const isPendingUserConfirmation = status === STATUS_PENDING_CONFIRMATION;
+  const isFinished = isDone || hasError;
+  const shouldShowModal =
+    isLoading || cannotDelete || isPendingUserConfirmation || isFinished;
+  const getModalTitle = () => {
+    if (hasError) {
+      return t('notification.removeError');
+    }
+    if (isDone) {
+      return t('notification.removeSuccess');
+    }
+    return t('serviceConnections.connectionRemovalVerificationTitle');
+  };
+
+  const getActionButtonText = () => {
+    if (isLoading || isFinished) {
+      return undefined;
+    }
+    return t('serviceConnections.connectionRemovalVerificationButtonText');
+  };
+
+  const getCloseButtonText = () => {
+    if (isLoading) {
+      return '';
+    }
+    if (isFinished) {
+      return t('confirmationModal.close');
+    }
+    return t('confirmationModal.cancel');
+  };
+
+  const onCloseConfirmationModal = () => {
+    if (isLoading) {
+      return;
+    }
+    onClose();
+  };
+
+  const onConfirmConfirmationModal = () => {
+    onConfirm();
+  };
+
+  const ModalContent = () => {
+    if (isLoading) {
+      return (
+        <Loading
+          isLoading
+          dataTestId="service-connection-delete-load-indicator"
+          loadingText={t('notification.removing')}
+          alignLeft
+        />
+      );
+    }
+    if (hasError) {
+      if (cannotDelete) {
+        return (
+          <>
+            <p data-testid="service-connection-delete-forbidden-text">
+              {t('serviceConnections.connectionRemovalForbidden')}
+            </p>
+            <Trans
+              i18nKey="serviceConnections.contactServiceToDelete"
+              components={{
+                linkToExternalServiceList: (
+                  <Link
+                    href={t('deleteProfileModal.urlToServiceList')}
+                    external
+                    openInNewTab
+                    size="M"
+                  >
+                    {''}
+                  </Link>
+                ),
+              }}
+            />
+          </>
+        );
+      }
+      return (
+        <p data-testid="service-connection-delete-failed-text">
+          {t('serviceConnections.connectionRemovalError')}
+        </p>
+      );
+    }
+    if (isDone) {
+      return (
+        <p data-testid="service-connection-delete-successful-text">
+          {t('serviceConnections.connectionRemovalSuccess', {
+            serviceName: service.title,
+          })}
+        </p>
+      );
+    }
+    return (
+      <p data-testid="service-connection-delete-verification-text">
+        {t('serviceConnections.connectionRemovalVerification', {
+          serviceName: service.title,
+        })}
+      </p>
+    );
+  };
+
+  if (!shouldShowModal) {
+    return null;
+  }
+  return (
+    <ConfirmationModal
+      isOpen={shouldShowModal}
+      onClose={onCloseConfirmationModal}
+      onConfirm={onConfirmConfirmationModal}
+      content={() => <ModalContent />}
+      title={getModalTitle()}
+      actionButtonText={getActionButtonText()}
+      closeButtonText={getCloseButtonText()}
+      preventClosing={isLoading}
+    />
+  );
+}
+
+export default DeleteServiceConnectionModal;

--- a/src/profile/components/serviceConnections/ServiceConnection.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnection.tsx
@@ -1,46 +1,173 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
+import * as Sentry from '@sentry/browser';
 
 import { ServiceConnectionData } from '../../helpers/getServiceConnectionData';
 import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
 import CheckedLabel from '../../../common/checkedLabel/CheckedLabel';
 import getAllowedDataFieldsFromService from '../../helpers/getAllowedDataFieldsFromService';
 import styles from './ServiceConnections.module.css';
+import useDeleteServiceConnection from '../../../gdprApi/useDeleteServiceConnection';
+import DeleteServiceConnectionModal from './DeleteServiceConnectionModal';
+import commonStyles from '../../../common/cssHelpers/common.module.css';
+import encodeServiceName from '../../helpers/encodeServiceName';
+
+export const STATUS_NONE = 0;
+export const STATUS_PENDING_CONFIRMATION = 1;
+export const STATUS_LOADING = 2;
+export const STATUS_ERROR = 3;
+export const STATUS_DELETE_FORBIDDEN = 4;
+export const STATUS_DONE = 5;
+export const STATUS_ACKNOWLEDGED = 6;
+export const STATUS_CLOSED = 7;
+
+export type DeletionStatus =
+  | typeof STATUS_NONE
+  | typeof STATUS_PENDING_CONFIRMATION
+  | typeof STATUS_LOADING
+  | typeof STATUS_ERROR
+  | typeof STATUS_DELETE_FORBIDDEN
+  | typeof STATUS_DONE
+  | typeof STATUS_CLOSED
+  | typeof STATUS_ACKNOWLEDGED;
 
 function ServiceConnection(props: {
   service: ServiceConnectionData;
   onDeletion: (deletedService: ServiceConnectionData) => void;
 }): React.ReactElement | null {
   const { service, onDeletion } = props;
+
+  const [deletionStatus, setDeletionStatus] = useState<DeletionStatus>(
+    STATUS_NONE
+  );
+
+  const isLoading = deletionStatus === STATUS_LOADING;
+  const isDone = deletionStatus === STATUS_DONE;
+
   const { t } = useTranslation();
+
   const getDateTime = (date: Date) => {
     const day = format(new Date(date), 'dd.MM.yyyy');
     const time = format(new Date(date), 'HH:mm');
     return `${day}, ${t('serviceConnections.clock')} ${time}`;
   };
+
+  const [deleteConnection, authorizationCodeState] = useDeleteServiceConnection(
+    service.name,
+    {
+      fetchPolicy: 'no-cache',
+      onError: errorEvent => {
+        if (errorEvent.graphQLErrors) {
+          errorEvent.graphQLErrors.forEach(graphQlError => {
+            Sentry.captureException(new Error(graphQlError.message));
+          });
+        } else {
+          Sentry.captureException(errorEvent);
+        }
+        setDeletionStatus(STATUS_ERROR);
+      },
+      onCompleted: data => {
+        if (!data.deleteMyServiceData?.result?.success) {
+          setDeletionStatus(STATUS_DELETE_FORBIDDEN);
+        } else {
+          setDeletionStatus(STATUS_DONE);
+        }
+      },
+    }
+  );
+
+  const getModalStatus = () => {
+    const authorizationIsActive =
+      authorizationCodeState.isLoading ||
+      authorizationCodeState.hasCode ||
+      authorizationCodeState.isDeleting;
+
+    if (deletionStatus === STATUS_NONE && authorizationIsActive) {
+      return STATUS_LOADING;
+    }
+
+    return deletionStatus;
+  };
+
+  const onDeleteClick = () => {
+    if (isLoading) {
+      return;
+    }
+    setDeletionStatus(STATUS_PENDING_CONFIRMATION);
+  };
+
+  const onClose = () => {
+    if (isLoading) {
+      return;
+    }
+    if (isDone) {
+      setDeletionStatus(STATUS_ACKNOWLEDGED);
+      onDeletion(service);
+      return;
+    }
+    setDeletionStatus(STATUS_CLOSED);
+  };
+
+  const onConfirm = () => {
+    setDeletionStatus(STATUS_LOADING);
+    deleteConnection();
+  };
+
+  const modalStatus = getModalStatus();
+  const encodedServiceName = encodeServiceName(service);
+
   return (
-    <ExpandingPanel
-      title={service.title || ''}
-      showInformationText
-      initiallyOpen={false}
-    >
-      <p>{service.description}</p>
-      <p className={styles['service-information']}>
-        {t('serviceConnections.servicePersonalData')}
-      </p>
-      {getAllowedDataFieldsFromService(service).map(node => (
-        <CheckedLabel
-          key={node.fieldName}
-          value={node.label || node.fieldName}
-          className={styles['allowed-data-field']}
+    <>
+      <ExpandingPanel
+        title={service.title || ''}
+        showInformationText
+        initiallyOpen={
+          modalStatus !== STATUS_CLOSED && modalStatus !== STATUS_NONE
+        }
+      >
+        <p>{service.description}</p>
+        <p
+          className={styles['service-information']}
+          data-testid={`service-connection-${encodedServiceName}-information`}
+        >
+          {t('serviceConnections.servicePersonalData')}
+        </p>
+        {getAllowedDataFieldsFromService(service).map(node => (
+          <CheckedLabel
+            key={node.fieldName}
+            value={node.label || node.fieldName}
+            className={styles['allowed-data-field']}
+          />
+        ))}
+        <p className={styles['created-at']}>
+          {t('serviceConnections.created')}
+        </p>
+        <p className={styles['date-and-time']}>
+          {getDateTime(service.connectionCreatedAt)}
+        </p>
+        <Trans
+          i18nKey="serviceConnections.deleteConnection"
+          components={{
+            deleteButton: (
+              <button
+                onClick={onDeleteClick}
+                className={commonStyles['text-button']}
+                data-testid={`delete-service-connection-${encodedServiceName}-button`}
+              >
+                {''}
+              </button>
+            ),
+          }}
         />
-      ))}
-      <p className={styles['created-at']}>{t('serviceConnections.created')}</p>
-      <p className={styles['date-and-time']}>
-        {getDateTime(service.connectionCreatedAt)}
-      </p>
-    </ExpandingPanel>
+      </ExpandingPanel>
+      <DeleteServiceConnectionModal
+        status={modalStatus}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        service={service}
+      />
+    </>
   );
 }
 

--- a/src/profile/components/serviceConnections/ServiceConnection.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnection.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { format } from 'date-fns';
+
+import { ServiceConnectionData } from '../../helpers/getServiceConnectionData';
+import ExpandingPanel from '../../../common/expandingPanel/ExpandingPanel';
+import CheckedLabel from '../../../common/checkedLabel/CheckedLabel';
+import getAllowedDataFieldsFromService from '../../helpers/getAllowedDataFieldsFromService';
+import styles from './ServiceConnections.module.css';
+
+function ServiceConnection(props: {
+  service: ServiceConnectionData;
+  onDeletion: (deletedService: ServiceConnectionData) => void;
+}): React.ReactElement | null {
+  const { service, onDeletion } = props;
+  const { t } = useTranslation();
+  const getDateTime = (date: Date) => {
+    const day = format(new Date(date), 'dd.MM.yyyy');
+    const time = format(new Date(date), 'HH:mm');
+    return `${day}, ${t('serviceConnections.clock')} ${time}`;
+  };
+  return (
+    <ExpandingPanel
+      title={service.title || ''}
+      showInformationText
+      initiallyOpen={false}
+    >
+      <p>{service.description}</p>
+      <p className={styles['service-information']}>
+        {t('serviceConnections.servicePersonalData')}
+      </p>
+      {getAllowedDataFieldsFromService(service).map(node => (
+        <CheckedLabel
+          key={node.fieldName}
+          value={node.label || node.fieldName}
+          className={styles['allowed-data-field']}
+        />
+      ))}
+      <p className={styles['created-at']}>{t('serviceConnections.created')}</p>
+      <p className={styles['date-and-time']}>
+        {getDateTime(service.connectionCreatedAt)}
+      </p>
+    </ExpandingPanel>
+  );
+}
+
+export default ServiceConnection;

--- a/src/profile/components/serviceConnections/__tests__/ServiceConnection.test.tsx
+++ b/src/profile/components/serviceConnections/__tests__/ServiceConnection.test.tsx
@@ -1,0 +1,359 @@
+import React, { useState } from 'react';
+import { act, waitFor } from '@testing-library/react';
+import { ApolloError } from '@apollo/client';
+
+import {
+  renderComponentWithMocksAndContexts,
+  TestTools,
+  cleanComponentMocks,
+  ElementSelector,
+} from '../../../../common/test/testingLibraryTools';
+import { ResponseProvider } from '../../../../common/test/MockApolloClientProvider';
+import useDeleteServiceConnection from '../../../../gdprApi/useDeleteServiceConnection';
+import { GdprDeleteMyServiceDataMutation } from '../../../../graphql/generatedTypes';
+import getMyProfileWithServiceConnections from '../../../../common/test/getMyProfileWithServiceConnections';
+import ServiceConnection from '../ServiceConnection';
+import getServiceConnectionData, {
+  ServiceConnectionData,
+} from '../../../helpers/getServiceConnectionData';
+import encodeServiceName from '../../../helpers/encodeServiceName';
+import i18n from '../../../../common/test/testi18nInit';
+import { getServiceConnectionDeleteResult } from '../../../../common/test/serviceConnectionDeleteMocking';
+
+type UseDeleteServiceConnectionOptions = Parameters<
+  typeof useDeleteServiceConnection
+>[1];
+
+type UseDeleteServiceConnectionHookReturnTuple = ReturnType<
+  typeof useDeleteServiceConnection
+>;
+
+type DeletionStatus = UseDeleteServiceConnectionHookReturnTuple[1];
+
+const mockDeleteConnection = jest.fn();
+const mockCompletedTracker = jest.fn();
+const mockErrorTracker = jest.fn();
+const mockHookTracker = jest.fn();
+
+const defaultQueryTracker: {
+  returnValidResponse: boolean;
+  response: null | GdprDeleteMyServiceDataMutation;
+} = {
+  returnValidResponse: true,
+  response: null,
+};
+
+const mockQueryTracker = {
+  tracker: jest.fn(),
+  ...defaultQueryTracker,
+};
+
+const defaultDeleteConnectionStatus: DeletionStatus = {
+  isLoading: false,
+  isDeleting: false,
+  hasCode: false,
+};
+
+let mockDeleteConnectionStatus: DeletionStatus = {
+  ...defaultDeleteConnectionStatus,
+};
+
+const updateDeleteConnectionStatus = (
+  newStatus: Partial<DeletionStatus>
+): void => {
+  mockDeleteConnectionStatus = {
+    ...mockDeleteConnectionStatus,
+    ...newStatus,
+  };
+};
+
+const resetDeleteConnectionStatus = (): void => {
+  mockDeleteConnectionStatus = {
+    ...defaultDeleteConnectionStatus,
+  };
+};
+
+const mockApolloError = () => new ApolloError({ errorMessage: 'Error' });
+
+jest.mock(
+  '../../../../gdprApi/useDeleteServiceConnection.ts',
+  () => (
+    serviceName: string,
+    options: UseDeleteServiceConnectionOptions
+  ): UseDeleteServiceConnectionHookReturnTuple => {
+    mockHookTracker(serviceName, options);
+    return [
+      async () => {
+        updateDeleteConnectionStatus({
+          isLoading: true,
+        });
+        mockDeleteConnection();
+        await new Promise(resolve => {
+          setTimeout(resolve, 100);
+        });
+        updateDeleteConnectionStatus({
+          isDeleting: false,
+          isLoading: false,
+          hasCode: true,
+        });
+        if (mockQueryTracker.returnValidResponse) {
+          mockCompletedTracker();
+          if (options.onCompleted) {
+            options.onCompleted(
+              mockQueryTracker.response as GdprDeleteMyServiceDataMutation
+            );
+          }
+        } else {
+          mockErrorTracker();
+          if (options.onError) {
+            options.onError(mockApolloError());
+          }
+        }
+      },
+      mockDeleteConnectionStatus,
+    ];
+  }
+);
+
+describe('<ServiceConnection /> ', () => {
+  const onDeleteTracker = jest.fn();
+
+  const queryResultWithServiceConnection = getMyProfileWithServiceConnections();
+  const serviceConnectionDataList = getServiceConnectionData(
+    queryResultWithServiceConnection
+  );
+  const defaultServiceConnectionData = serviceConnectionDataList[0];
+
+  const testIds = {
+    deleteButton: 'delete-button',
+    rerenderButton: 'rerender-button',
+    confirmButton: 'confirmation-modal-confirm-button',
+    cancelButton: 'confirmation-modal-cancel-button',
+    deleteVerificationText: 'service-connection-delete-verification-text',
+    loadIndicator: 'service-connection-delete-load-indicator',
+  };
+
+  const t = i18n.getFixedT('fi');
+
+  const getTestId = (key: keyof typeof testIds): ElementSelector => ({
+    testId: testIds[key],
+  });
+
+  const getDeleteButtonSelector = (
+    service: ServiceConnectionData
+  ): ElementSelector => ({
+    testId: `delete-service-connection-${encodeServiceName(service)}-button`,
+  });
+
+  const getServiceInformationSelector = (
+    service: ServiceConnectionData
+  ): ElementSelector => ({
+    testId: `service-connection-${encodeServiceName(service)}-information`,
+  });
+
+  const getExpandableSelector = (
+    service: ServiceConnectionData
+  ): ElementSelector => ({
+    querySelector: `button[title="${service.title}"]`,
+  });
+
+  const TestingComponent = (props: { service: ServiceConnectionData }) => {
+    // useDeleteServiceConnection is mocked, so nothing will force re-render
+    const [, forceRender] = useState<number>(0);
+    return (
+      <div>
+        <ServiceConnection
+          service={props.service}
+          onDeletion={onDeleteTracker}
+        />
+        <button
+          type="button"
+          data-testid={testIds.rerenderButton}
+          onClick={() => forceRender(Date.now())}
+        >
+          Rerender
+        </button>
+      </div>
+    );
+  };
+
+  const renderTestSuite = (service: ServiceConnectionData) => {
+    const responseProvider: ResponseProvider = () => ({
+      errorType: 'networkError',
+    });
+
+    return renderComponentWithMocksAndContexts(
+      responseProvider,
+      <TestingComponent service={service} />
+    );
+  };
+
+  beforeEach(() => {
+    Object.assign(mockQueryTracker, defaultQueryTracker);
+    resetDeleteConnectionStatus();
+  });
+
+  afterEach(async () => {
+    // makes sure timeouts are complete before starting next test
+    if (mockDeleteConnection.mock.calls.length) {
+      await waitFor(() => {
+        if (
+          mockCompletedTracker.mock.calls.length === 0 &&
+          mockErrorTracker.mock.calls.length === 0
+        ) {
+          throw new Error('Test not finished');
+        }
+      });
+    }
+    cleanComponentMocks();
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const initTests = async (
+    service?: ServiceConnectionData
+  ): Promise<TestTools> =>
+    renderTestSuite(service || defaultServiceConnectionData);
+
+  it(`Shows the service title and the accordion can be expanded. 
+      Expanding shows service connection info and a remove button. 
+      Service name is passed to the useDeleteServiceConnection hook`, async () => {
+    await act(async () => {
+      const { clickElement, getByText, waitForElement } = await initTests();
+      expect(
+        getByText(defaultServiceConnectionData.title as string)
+      ).toBeDefined();
+      expect(
+        getByText(defaultServiceConnectionData.description as string)
+      ).toBeDefined();
+      await clickElement(getExpandableSelector(defaultServiceConnectionData));
+      await waitForElement(
+        getDeleteButtonSelector(defaultServiceConnectionData)
+      );
+      await waitForElement(
+        getServiceInformationSelector(defaultServiceConnectionData)
+      );
+      expect(mockHookTracker.mock.calls[0][0]).toBe(
+        defaultServiceConnectionData.name
+      );
+    });
+  });
+  it(`Clicking the remove button shows the confirmation modal. Close button closes it.`, async () => {
+    await act(async () => {
+      const {
+        clickElement,
+        waitForElement,
+        waitForElementNotToExist,
+      } = await initTests();
+
+      await clickElement(getExpandableSelector(defaultServiceConnectionData));
+      await waitFor(async () => {
+        await clickElement(
+          getDeleteButtonSelector(defaultServiceConnectionData)
+        );
+      });
+      await waitForElement(getTestId('deleteVerificationText'));
+      await clickElement(getTestId('cancelButton'));
+      await waitForElementNotToExist(getTestId('cancelButton'));
+    });
+  });
+  it(`If deletion succeeds, a success text is shown in the modal and 
+      closing the modal calls the onDelete-callback.
+      `, async () => {
+    mockQueryTracker.response = getServiceConnectionDeleteResult();
+
+    await act(async () => {
+      const { clickElement, waitForElement } = await initTests();
+      await clickElement(getExpandableSelector(defaultServiceConnectionData));
+      await waitFor(async () => {
+        await clickElement(
+          getDeleteButtonSelector(defaultServiceConnectionData)
+        );
+        await clickElement(getTestId('confirmButton'));
+      });
+      await waitFor(async () => {
+        expect(mockDeleteConnection).toHaveBeenCalledTimes(1);
+      });
+      await waitForElement({ text: t('notification.removeSuccess') });
+      await clickElement(getTestId('cancelButton'));
+      await waitFor(async () => {
+        expect(onDeleteTracker).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+  it(`When delete is confirmed, loading is indicated. 
+      Note: IRL the browser jumps to Tunnistamo.
+      If deletion fails with a graphQL error, an specific error text is shown in the modal.
+      `, async () => {
+    mockQueryTracker.returnValidResponse = false;
+
+    await act(async () => {
+      const { clickElement, waitForElement } = await initTests(
+        defaultServiceConnectionData
+      );
+
+      await clickElement(getExpandableSelector(defaultServiceConnectionData));
+      await waitFor(async () => {
+        await clickElement(
+          getDeleteButtonSelector(defaultServiceConnectionData)
+        );
+        await clickElement(getTestId('confirmButton'));
+      });
+      await waitForElement(getTestId('loadIndicator'));
+      await waitFor(async () => {
+        expect(mockDeleteConnection).toHaveBeenCalledTimes(1);
+      });
+      await waitForElement({ text: t('notification.removeError') });
+      await waitForElement({
+        text: t('serviceConnections.connectionRemovalError'),
+      });
+      await clickElement(getTestId('cancelButton'));
+      await waitFor(async () => {
+        expect(onDeleteTracker).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+  it(`If deletion query succeeds but returns errors, 
+      a different error text is shown in the modal.
+      `, async () => {
+    mockQueryTracker.response = getServiceConnectionDeleteResult(['errorCode']);
+
+    await act(async () => {
+      const { clickElement, waitForElement } = await initTests();
+      await clickElement(getExpandableSelector(defaultServiceConnectionData));
+      await waitFor(async () => {
+        await clickElement(
+          getDeleteButtonSelector(defaultServiceConnectionData)
+        );
+        await clickElement(getTestId('confirmButton'));
+      });
+      await waitFor(async () => {
+        expect(mockDeleteConnection).toHaveBeenCalledTimes(1);
+      });
+      await waitForElement({
+        text: t('serviceConnections.connectionRemovalForbidden'),
+      });
+      await clickElement(getTestId('cancelButton'));
+      await waitFor(async () => {
+        expect(onDeleteTracker).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+  it(`When browser returns from Tunnistamo, 
+      accordion is auto-opened, 
+      modal is rendered and
+      load indicator is shown in the modal.`, async () => {
+    updateDeleteConnectionStatus({
+      isLoading: true,
+      hasCode: true,
+    });
+    mockQueryTracker.response = getServiceConnectionDeleteResult();
+    await act(async () => {
+      const { waitForElement } = await initTests();
+      await waitForElement(
+        getServiceInformationSelector(defaultServiceConnectionData)
+      );
+      await waitForElement(getTestId('loadIndicator'));
+    });
+  });
+});

--- a/src/profile/graphql/ServiceConnectionsQuery.graphql
+++ b/src/profile/graphql/ServiceConnectionsQuery.graphql
@@ -5,6 +5,7 @@ query ServiceConnectionsQuery($language: TranslationLanguage!) {
       edges {
         node {
           service {
+            name
             title(language: $language)
             description(language: $language)
             allowedDataFields {

--- a/src/profile/helpers/encodeServiceName.ts
+++ b/src/profile/helpers/encodeServiceName.ts
@@ -1,0 +1,10 @@
+import { Service } from '../../graphql/typings';
+import { ServiceConnectionData } from './getServiceConnectionData';
+
+export default function encodeServiceName(
+  service: Service | ServiceConnectionData
+) {
+  return String(service.name)
+    .toLowerCase()
+    .replace(/[\W]/g, '-');
+}

--- a/src/profile/helpers/getServiceConnectionData.ts
+++ b/src/profile/helpers/getServiceConnectionData.ts
@@ -2,15 +2,16 @@ import { ServiceConnectionsRoot, Service } from '../../graphql/typings';
 
 export type ServiceConnectionData = Pick<
   Service,
-  'title' | 'description' | 'allowedDataFields'
+  'title' | 'description' | 'allowedDataFields' | 'name'
 > & { connectionCreatedAt: Date };
 
 function createServiceConnectionData(
   service: Service,
   createdAt: Date
 ): ServiceConnectionData {
-  const { title, description, allowedDataFields } = service;
+  const { title, description, allowedDataFields, name } = service;
   return {
+    name,
     title,
     description,
     allowedDataFields,


### PR DESCRIPTION
Added service connection deletion to UI.

Also combined fetching service connections and the authorization code as the same process is now used in three places: download and delete profile and delete service connection.

This branch is currently deployed in dev.

Note about errors:
- if a network or a graphQL error is returned, then a generic error text "Error occured. Try again later" is shown
- if the deletion request succeeds, but returned data has success: false, another error is displayed saying "the data could not be deleted, contact the service to delete them".

To test this, you can add and remove service connections from a user in Profile BE. Only "Esimerkkipalvelu & UI" and "Test service GDPR deletion" can be deleted. Other ones do not have GDPR apis in dev.

"Esimerkkipalvelu" will return error, if pet name is set to "nodelete"

"Test service GDPR deletion" is using free API testing tool "beeceptor.com" as an endpoint. It has daily query limit of 50, so it might return status 429 anytime.