### PR TITLE
HP-962: cookie consents

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "formik": "^2.0.4",
     "graphql": "^15.2.0",
     "graphql.macro": "^1.4.2",
-    "hds-core": "1.13.0",
-    "hds-design-tokens": "1.13.0",
-    "hds-react": "1.13.0",
+    "hds-core": "2.10.0",
+    "hds-design-tokens": "2.10.0",
+    "hds-react": "2.10.0",
     "history": "^4.9.0",
     "http-status-typed": "^1.0.0",
     "i18n-iso-countries": "^7.0.0",
@@ -81,7 +81,8 @@
     "update-translations": "ts-node -P ./scripts/tsconfig.json -r dotenv/config --files scripts/update-translations.ts",
     "update-runtime-env": "ts-node -P ./scripts/tsconfig.json --files scripts/update-runtime-env.ts",
     "update-country-calling-codes": "ts-node -P ./scripts/tsconfig.json --files scripts/update-country-calling-codes.ts",
-    "clear-babel-cache": "rm -rf ./node_modules/.cache/@babel"
+    "clear-babel-cache": "rm -rf ./node_modules/.cache/@babel",
+    "typecheck": "tsc --skipLibCheck --noEmit --project tsconfig.json"
   },
   "browserslist": {
     "production": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import { Switch, Route } from 'react-router';
 import { ApolloProvider } from '@apollo/client';
 import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react';
@@ -18,12 +17,12 @@ import ErrorPage from './profile/components/errorPage/ErrorPage';
 import AccessibilityStatement from './accessibilityStatement/AccessibilityStatement';
 import GdprAuthorizationCodeManagerCallback from './gdprApi/GdprAuthorizationCodeManagerCallback';
 import ToastProvider from './toast/ToastProvider';
-import authService from './auth/authService';
 import config from './config';
 import PageNotFound from './common/pageNotFound/PageNotFound';
 import { useHistoryListener } from './profile/hooks/useHistoryListener';
 import WithAuthCheck from './profile/components/withAuthCheck/WithAuthCheck';
 import CookieConsentPage from './cookieConsents/CookieConsentPage';
+import LoginSSO from './auth/components/loginsso/LoginSSO';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -35,14 +34,7 @@ const instance = createInstance({
 });
 
 function App(): React.ReactElement {
-  const location = useLocation();
-
-  if (location.pathname === '/loginsso') {
-    authService.login();
-  }
-
   useHistoryListener();
-
   return (
     <ApolloProvider client={graphqlClient}>
       <ToastProvider>
@@ -68,7 +60,9 @@ function App(): React.ReactElement {
               <Route path={config.errorPagePath} exact>
                 <ErrorPage />
               </Route>
-              <Route path="/loginsso" exact />
+              <Route path={config.autoSSOLoginPath} exact>
+                <LoginSSO />
+              </Route>
               <Route path={config.cookiePagePath} exact>
                 <CookieConsentPage />
               </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router';
 import { ApolloProvider } from '@apollo/client';
-import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react';
+import { MatomoProvider } from '@datapunt/matomo-tracker-react';
 import countries from 'i18n-iso-countries';
 import fi from 'i18n-iso-countries/langs/fi.json';
 import en from 'i18n-iso-countries/langs/en.json';
@@ -23,18 +23,15 @@ import { useHistoryListener } from './profile/hooks/useHistoryListener';
 import WithAuthCheck from './profile/components/withAuthCheck/WithAuthCheck';
 import CookieConsentPage from './cookieConsents/CookieConsentPage';
 import LoginSSO from './auth/components/loginsso/LoginSSO';
+import { useTrackingInstance } from './common/helpers/tracking/matomoTracking';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
 countries.registerLocale(sv);
 
-const instance = createInstance({
-  urlBase: 'https://analytics.hel.ninja/',
-  siteId: 60,
-});
-
 function App(): React.ReactElement {
   useHistoryListener();
+  const instance = useTrackingInstance();
   return (
     <ApolloProvider client={graphqlClient}>
       <ToastProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import config from './config';
 import PageNotFound from './common/pageNotFound/PageNotFound';
 import { useHistoryListener } from './profile/hooks/useHistoryListener';
 import WithAuthCheck from './profile/components/withAuthCheck/WithAuthCheck';
+import CookieConsentPage from './cookieConsents/CookieConsentPage';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -75,6 +76,9 @@ function App(): React.ReactElement {
                 <ErrorPage />
               </Route>
               <Route path="/loginsso" exact />
+              <Route path={config.cookiePagePath} exact>
+                <CookieConsentPage />
+              </Route>
               <Route path="*">
                 <PageNotFound />
               </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,13 +34,6 @@ const instance = createInstance({
   siteId: 60,
 });
 
-// Prevent non-production data from being submitted to Matomo
-// by pretending to require consent to process analytics data and never ask for it.
-// https://developer.matomo.org/guides/tracking-javascript-guide#step-1-require-consent
-if (window._env_.REACT_APP_ENVIRONMENT !== 'production') {
-  window._paq.push(['requireConsent']);
-}
-
 function App(): React.ReactElement {
   const location = useLocation();
 

--- a/src/BrowserApp.test.tsx
+++ b/src/BrowserApp.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import BrowserApp from './BrowserApp';
+import { getMockCallArgs } from './common/test/jestMockHelper';
+
+describe('BrowserApp', () => {
+  const pushTracker = jest.fn();
+  beforeAll(() => {
+    ((global.window as unknown) as { _paq: { push: jest.Mock } })._paq = {
+      push: pushTracker,
+    };
+  });
+  it('renders without crashing and commands tracker to wait for consent', () => {
+    shallow(<BrowserApp />);
+    const calls = getMockCallArgs(pushTracker) as string[];
+    expect(calls).toEqual([['requireCookieConsent'], ['requireConsent']]);
+  });
+});

--- a/src/BrowserApp.tsx
+++ b/src/BrowserApp.tsx
@@ -5,8 +5,10 @@ import { I18nextProvider } from 'react-i18next';
 import App from './App';
 import i18n from './i18n/i18nInit';
 import CookieConsentModal from './cookieConsents/CookieConsentModal';
+import { disableTrackingCookiesUntilConsentGiven } from './common/helpers/tracking/matomoTracking';
 
 function BrowserApp(): React.ReactElement {
+  disableTrackingCookiesUntilConsentGiven();
   return (
     <I18nextProvider i18n={i18n}>
       <BrowserRouter>

--- a/src/BrowserApp.tsx
+++ b/src/BrowserApp.tsx
@@ -4,14 +4,16 @@ import { I18nextProvider } from 'react-i18next';
 
 import App from './App';
 import i18n from './i18n/i18nInit';
+import CookieConsentModal from './cookieConsents/CookieConsentModal';
 
 function BrowserApp(): React.ReactElement {
   return (
-    <BrowserRouter>
-      <I18nextProvider i18n={i18n}>
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <CookieConsentModal />
         <App />
-      </I18nextProvider>
-    </BrowserRouter>
+      </BrowserRouter>
+    </I18nextProvider>
   );
 }
 

--- a/src/auth/components/loginsso/LoginSSO.tsx
+++ b/src/auth/components/loginsso/LoginSSO.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import pageLayoutStyles from '../../../common/pageLayout/PageLayout.module.css';
+import authService from '../../authService';
+import Loading from '../../../common/loading/Loading';
+
+function LoginSSO(): React.ReactElement {
+  const { t } = useTranslation();
+  authService.login();
+  return (
+    <div className={pageLayoutStyles.wrapper}>
+      <main className={pageLayoutStyles.content}>
+        <Loading isLoading loadingText={t('oidc.authenticating')} />
+      </main>
+    </div>
+  );
+}
+
+export default LoginSSO;

--- a/src/common/footer/Footer.tsx
+++ b/src/common/footer/Footer.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 
 import styles from './Footer.module.css';
 import getLanguageCode from '../helpers/getLanguageCode';
+import config from '../../config';
 
 function Footer(): React.ReactElement {
   const { t, i18n } = useTranslation();
@@ -56,6 +57,9 @@ function Footer(): React.ReactElement {
         </HDSFooter.Item>
         <HDSFooter.Item as={Link} to="/accessibility">
           {t('footer.accessibility')}
+        </HDSFooter.Item>
+        <HDSFooter.Item as={Link} to={config.cookiePagePath}>
+          {t('cookies.pageName')}
         </HDSFooter.Item>
       </HDSFooter.Base>
     </HDSFooter>

--- a/src/common/formikDropdown/FormikDropdown.tsx
+++ b/src/common/formikDropdown/FormikDropdown.tsx
@@ -11,7 +11,7 @@ type Props = {
   toggleButtonAriaLabel?: string;
   allowSearch?: boolean;
   virtualized?: boolean;
-} & Omit<SingleSelectProps<OptionType>, 'defaultOption' | 'value'>;
+} & Exclude<SingleSelectProps<OptionType>, 'defaultOption' | 'value'>;
 
 export type OptionType = {
   value: string;

--- a/src/common/helpers/tracking/matomoTracking.ts
+++ b/src/common/helpers/tracking/matomoTracking.ts
@@ -1,3 +1,6 @@
+import { createInstance } from '@datapunt/matomo-tracker-react';
+import { useMemo } from 'react';
+
 import { trackingCookieId } from '../../../cookieConsents/cookieContentSource';
 
 type TrackingEvent = string[];
@@ -54,4 +57,31 @@ export function handleCookieConsentChange(
   } else {
     disableTrackingCookies();
   }
+}
+
+export function useTrackingInstance(): ReturnType<typeof createInstance> {
+  return useMemo(() => {
+    // matomo.js is not loaded, if window._paq.length > 0
+    // so clearing it before creating the instance.
+    // events are pushed back below
+    const existingTrackingEvents = Array.isArray(window._paq)
+      ? [...window._paq]
+      : [];
+
+    const hadExistingEvents = existingTrackingEvents.length;
+    if (hadExistingEvents) {
+      window._paq.length = 0;
+    }
+
+    const matomo = createInstance({
+      urlBase: 'https://analytics.hel.ninja/',
+      siteId: 60,
+    });
+
+    if (hadExistingEvents) {
+      existingTrackingEvents.forEach(pushEvent);
+    }
+
+    return matomo;
+  }, []);
 }

--- a/src/common/helpers/tracking/matomoTracking.ts
+++ b/src/common/helpers/tracking/matomoTracking.ts
@@ -1,0 +1,57 @@
+import { trackingCookieId } from '../../../cookieConsents/cookieContentSource';
+
+type TrackingEvent = string[];
+type Tracker = { push: (event: TrackingEvent) => void };
+
+const disableEvents = ['requireCookieConsent', 'requireConsent'];
+const enableEvents = ['rememberCookieConsentGiven', 'rememberConsentGiven'];
+const forgetEvents = ['forgetCookieConsentGiven', 'forgetConsentGiven'];
+
+function getTrackingObject(): Tracker {
+  if (!window._paq) {
+    window._paq = [];
+  }
+  return (window._paq as unknown) as Tracker;
+}
+
+function pushEvent(events: TrackingEvent): void {
+  const tracker = getTrackingObject();
+  events.forEach(event => {
+    tracker.push([event]);
+  });
+}
+
+export function disableTrackingCookiesUntilConsentGiven() {
+  pushEvent(disableEvents);
+}
+
+export function enableTrackingCookies() {
+  // never enable tracking in non-prod
+  if (window._env_.REACT_APP_ENVIRONMENT !== 'production') {
+    return;
+  }
+  pushEvent(enableEvents);
+}
+
+export function disableTrackingCookies() {
+  pushEvent(forgetEvents);
+}
+
+// At the moment all tracking is disabled / enabled at the same time.
+// Tracking with cookies and without cookies are bundled in to one tracking type.
+// That's why only single cookie consent is checked here.
+export function areTrackingCookiesEnabled(
+  cookies: Record<string, boolean>
+): boolean {
+  return cookies[trackingCookieId] === true;
+}
+
+export function handleCookieConsentChange(
+  cookies: Record<string, boolean>
+): void {
+  if (areTrackingCookiesEnabled(cookies)) {
+    enableTrackingCookies();
+  } else {
+    disableTrackingCookies();
+  }
+}

--- a/src/common/test/jestMockHelper.ts
+++ b/src/common/test/jestMockHelper.ts
@@ -1,0 +1,4 @@
+export const getMockCallArgs = (
+  mockFn: jest.Mock,
+  argumentIndex = 0
+): unknown[] => mockFn.mock.calls.map(call => call[argumentIndex]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ const config = {
   ),
   oidcAuthority: window._env_.REACT_APP_OIDC_AUTHORITY,
   errorPagePath: '/error',
+  cookiePagePath: '/cookies',
+  autoSSOLoginPath: '/loginsso',
 };
 
 export default config;

--- a/src/cookieConsents/CookieConsentModal.tsx
+++ b/src/cookieConsents/CookieConsentModal.tsx
@@ -1,0 +1,38 @@
+import { ContentSource, CookieModal } from 'hds-react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+import { handleCookieConsentChange } from '../common/helpers/tracking/matomoTracking';
+import config from '../config';
+import { getCookieContent } from './cookieContentSource';
+
+function CookieConsentModal(): React.ReactElement | null {
+  const { i18n } = useTranslation();
+  const currentLanguage = i18n.language as ContentSource['currentLanguage'];
+  const { t, changeLanguage } = i18n;
+  const location = useLocation();
+  const currentPath = location.pathname;
+  const disallowedPaths = [config.autoSSOLoginPath, config.cookiePagePath];
+  const contentSource: ContentSource = useMemo(
+    () => ({
+      ...getCookieContent(t),
+      currentLanguage,
+      focusTargetSelector: 'h1',
+      language: {
+        onLanguageChange: changeLanguage,
+      },
+      onAllConsentsGiven: handleCookieConsentChange,
+      onConsentsParsed: handleCookieConsentChange,
+    }),
+    [currentLanguage, changeLanguage, t]
+  );
+
+  if (disallowedPaths.includes(currentPath)) {
+    return null;
+  }
+
+  return <CookieModal contentSource={contentSource} />;
+}
+
+export default CookieConsentModal;

--- a/src/cookieConsents/CookieConsentPage.tsx
+++ b/src/cookieConsents/CookieConsentPage.tsx
@@ -1,0 +1,38 @@
+import { ContentSource, CookiePage } from 'hds-react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
+
+import PageLayout from '../common/pageLayout/PageLayout';
+import { getCookieContent } from './cookieContentSource';
+import commonContentStyles from '../common/cssHelpers/content.module.css';
+import { handleCookieConsentChange } from '../common/helpers/tracking/matomoTracking';
+
+function CookieConsentPage(): React.ReactElement | null {
+  const { i18n } = useTranslation();
+  const currentLanguage = i18n.language as ContentSource['currentLanguage'];
+  const { t } = i18n;
+  const contentSource: ContentSource = useMemo(
+    () => ({
+      ...getCookieContent(t),
+      currentLanguage,
+      onAllConsentsGiven: handleCookieConsentChange,
+    }),
+    [currentLanguage, t]
+  );
+
+  return (
+    <PageLayout title={'cookies.pageName'}>
+      <div
+        className={classNames([
+          commonContentStyles['common-content-area'],
+          commonContentStyles['common-bottom-padding'],
+        ])}
+      >
+        <CookiePage contentSource={contentSource} />
+      </div>
+    </PageLayout>
+  );
+}
+
+export default CookieConsentPage;

--- a/src/cookieConsents/__mocks__/CookieModalAndPage.tsx
+++ b/src/cookieConsents/__mocks__/CookieModalAndPage.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { RenderResult } from '@testing-library/react';
+import { ContentSource } from 'hds-react';
+
+import { AnyObject } from '../../graphql/typings';
+import { getMockCallArgs } from '../../common/test/jestMockHelper';
+
+export async function setCookieConsents(
+  result: RenderResult,
+  consents: AnyObject<boolean>
+) {
+  const el = await result.findByTestId('cookie-consents');
+  if (!el) {
+    throw new Error('No cookie-consents element');
+  }
+  el.textContent = JSON.stringify(consents);
+}
+
+export async function clickButton(result: RenderResult, testId: string) {
+  const el = await result.findByTestId(testId);
+  if (!el) {
+    throw new Error('No trigger element');
+  }
+  el.click();
+}
+
+export async function triggerOnConsentsParsed(result: RenderResult) {
+  return clickButton(result, 'trigger-on-consents-parsed');
+}
+
+export async function triggeronAllConsentsGiven(result: RenderResult) {
+  return clickButton(result, 'trigger-on-all-consents-given');
+}
+
+export function verifyTrackingCookiesAreRemembered(mockFn: jest.Mock) {
+  const calls = getMockCallArgs(mockFn) as string[];
+  expect(calls).toEqual([
+    ['rememberCookieConsentGiven'],
+    ['rememberConsentGiven'],
+  ]);
+}
+
+export function verifyTrackingCookiesAreForgotten(mockFn: jest.Mock) {
+  const calls = getMockCallArgs(mockFn) as string[];
+  expect(calls).toEqual([['forgetCookieConsentGiven'], ['forgetConsentGiven']]);
+}
+
+function CookieModalAndPageMock({
+  contentSource,
+}: {
+  contentSource: ContentSource;
+}) {
+  const getConsents = (): AnyObject<boolean> => {
+    const el = document.querySelector('*[data-testid="cookie-consents"]');
+    if (!el || !el.textContent) {
+      return {};
+    }
+    return JSON.parse(el.textContent);
+  };
+  const onConsentsParsedClick = () => {
+    if (contentSource.onConsentsParsed) {
+      contentSource.onConsentsParsed(getConsents(), false);
+    }
+  };
+  const onAllConsentsGivenClick = () => {
+    if (contentSource.onAllConsentsGiven) {
+      contentSource.onAllConsentsGiven(getConsents());
+    }
+  };
+  return (
+    <div data-testid="mock-cookie-modal-and-page">
+      <button
+        type="button"
+        data-testid="trigger-on-consents-parsed"
+        onClick={onConsentsParsedClick}
+      ></button>
+      <button
+        type="button"
+        data-testid="trigger-on-all-consents-given"
+        onClick={onAllConsentsGivenClick}
+      ></button>
+      <span data-testid="cookie-consents"></span>
+    </div>
+  );
+}
+
+export default CookieModalAndPageMock;

--- a/src/cookieConsents/__tests__/CookieConsentModal.test.tsx
+++ b/src/cookieConsents/__tests__/CookieConsentModal.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ContentSource } from 'hds-react';
+
+import CookieConsentModal from '../CookieConsentModal';
+import MockCookieModal, {
+  triggerOnConsentsParsed,
+  triggeronAllConsentsGiven,
+  setCookieConsents,
+  verifyTrackingCookiesAreRemembered,
+  verifyTrackingCookiesAreForgotten,
+} from '../__mocks__/CookieModalAndPage';
+import { trackingCookieId } from '../cookieContentSource';
+import config from '../../config';
+
+jest.mock('hds-react', () => ({
+  ...jest.requireActual('hds-react'),
+  CookieModal: (props: { contentSource: ContentSource }) => (
+    <MockCookieModal contentSource={props.contentSource} />
+  ),
+}));
+
+const mockUseLocationValue = {
+  pathname: '/',
+  search: '',
+  hash: '',
+  state: null,
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockImplementation(() => mockUseLocationValue),
+}));
+
+describe('CookieConsentModal', () => {
+  const pushTracker = jest.fn();
+  const initialEnv = window._env_.REACT_APP_ENVIRONMENT;
+  const renderComponent = () => render(<CookieConsentModal />);
+  beforeAll(() => {
+    ((global.window as unknown) as { _paq: { push: jest.Mock } })._paq = {
+      push: pushTracker,
+    };
+    window._env_.REACT_APP_ENVIRONMENT = 'production';
+  });
+  afterEach(() => {
+    mockUseLocationValue.pathname = '/';
+    pushTracker.mockReset();
+  });
+  afterAll(() => {
+    window._env_.REACT_APP_ENVIRONMENT = initialEnv;
+  });
+  describe('renders HDS cookieModal and calls onConsentsParsed', () => {
+    it('and tracking is disabled, if consent is not given.', async () => {
+      const result = renderComponent();
+      await triggerOnConsentsParsed(result);
+      verifyTrackingCookiesAreForgotten(pushTracker);
+      expect(() =>
+        result.getByTestId('mock-cookie-modal-and-page')
+      ).not.toThrow();
+    });
+    it('and tracking is enabled, if consent is given.', async () => {
+      const result = renderComponent();
+      await setCookieConsents(result, { [trackingCookieId]: true });
+      await triggerOnConsentsParsed(result);
+      verifyTrackingCookiesAreRemembered(pushTracker);
+    });
+  });
+
+  describe('does not render HDS cookieModal', () => {
+    it('if route is config.autoSSOLoginPath', async () => {
+      mockUseLocationValue.pathname = config.autoSSOLoginPath;
+      const result = renderComponent();
+      expect(() => result.getByTestId('mock-cookie-modal-and-page')).toThrow();
+      expect(pushTracker).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('when modal is closed and onAllConsentsGiven is called', () => {
+    it('tracking cookies are remembered, if consent is given', async () => {
+      const result = renderComponent();
+      await setCookieConsents(result, { [trackingCookieId]: true });
+      await triggeronAllConsentsGiven(result);
+      verifyTrackingCookiesAreRemembered(pushTracker);
+    });
+    it('tracking cookies are forgotten, if consent is not given', async () => {
+      const result = renderComponent();
+      await triggeronAllConsentsGiven(result);
+      verifyTrackingCookiesAreForgotten(pushTracker);
+    });
+  });
+});

--- a/src/cookieConsents/__tests__/CookieConsentPage.test.tsx
+++ b/src/cookieConsents/__tests__/CookieConsentPage.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ContentSource } from 'hds-react';
+import { MemoryRouter } from 'react-router';
+
+import CookieConsentPage from '../CookieConsentPage';
+import MockCookieModal, {
+  triggerOnConsentsParsed,
+  triggeronAllConsentsGiven,
+  setCookieConsents,
+  verifyTrackingCookiesAreRemembered,
+  verifyTrackingCookiesAreForgotten,
+} from '../__mocks__/CookieModalAndPage';
+import { trackingCookieId } from '../cookieContentSource';
+
+jest.mock('hds-react', () => ({
+  ...jest.requireActual('hds-react'),
+  CookiePage: (props: { contentSource: ContentSource }) => (
+    <MockCookieModal contentSource={props.contentSource} />
+  ),
+}));
+
+describe('CookieConsentPage', () => {
+  const pushTracker = jest.fn();
+  const initialEnv = window._env_.REACT_APP_ENVIRONMENT;
+  const renderComponent = () =>
+    render(
+      <MemoryRouter>
+        <CookieConsentPage />
+      </MemoryRouter>
+    );
+  beforeAll(() => {
+    ((global.window as unknown) as { _paq: { push: jest.Mock } })._paq = {
+      push: pushTracker,
+    };
+    window._env_.REACT_APP_ENVIRONMENT = 'production';
+  });
+  afterAll(() => {
+    window._env_.REACT_APP_ENVIRONMENT = initialEnv;
+  });
+  afterEach(() => {
+    pushTracker.mockReset();
+  });
+
+  describe('renders HDS cookiePage and does not call onConsentsParsed because page does not track it.', () => {
+    it('and tracking is disabled, if consent is not given.', async () => {
+      const result = renderComponent();
+      await triggerOnConsentsParsed(result);
+      expect(pushTracker).toHaveBeenCalledTimes(0);
+      expect(() =>
+        result.getByTestId('mock-cookie-modal-and-page')
+      ).not.toThrow();
+    });
+  });
+
+  describe('renders HDS cookiePage and when onAllConsentsGiven is called', () => {
+    it('tracking cookies are remembered, if consent is given', async () => {
+      const result = renderComponent();
+      await setCookieConsents(result, { [trackingCookieId]: true });
+      await triggeronAllConsentsGiven(result);
+      verifyTrackingCookiesAreRemembered(pushTracker);
+    });
+    it('tracking cookies are forgotten, if consent is not given', async () => {
+      await triggeronAllConsentsGiven(renderComponent());
+      verifyTrackingCookiesAreForgotten(pushTracker);
+    });
+  });
+});

--- a/src/cookieConsents/cookieContentSource.ts
+++ b/src/cookieConsents/cookieContentSource.ts
@@ -1,0 +1,117 @@
+import { ContentSource } from 'hds-react';
+import { TFunction } from 'react-i18next';
+
+export const trackingCookieId = 'matomo';
+
+export function getCookieContent(
+  t: TFunction
+): Pick<
+  ContentSource,
+  'requiredCookies' | 'optionalCookies' | 'texts' | 'siteName'
+> {
+  const securityCookieDescription = t('cookies.securityCookieDescription');
+  const loadBalancerCookieName = t('cookies.loadBalancerCookieName');
+  const loadBalancerCookieDescription = t(
+    'cookies.loadBalancerCookieDescription'
+  );
+  const languageCookieDescription = t('cookies.languageCookieDescription');
+  const trackingCookieDescription = t('cookies.trackingCookieDescription');
+  const consentStorageDescription = t('cookies.consentStorageDescription');
+  const sessionExpiration = t('cookies.sessionExpiration');
+  const daysPlural = t('cookies.daysPlural');
+  const minutesPlural = t('cookies.minutesPlural');
+  const mainText = t('cookies.mainText');
+  const siteName = t('appName');
+
+  const tunnistusHostName = 'tunnistus.hel.fi';
+  const profiiliHostName = 'profiili.hel.fi';
+  const tunnistamoAndProfileBeHostName = 'api.hel.fi';
+  const anyHelFiHostName = '*.hel.fi';
+
+  return {
+    siteName,
+    texts: {
+      sections: {
+        main: {
+          text: mainText,
+        },
+      },
+    },
+    requiredCookies: {
+      groups: [
+        { commonGroup: 'tunnistamoLogin' },
+        {
+          commonGroup: 'informationSecurity',
+          cookies: [
+            {
+              id: 'tunnistamo-csrftoken',
+              name: 'tunnistamo_prod-csrftoken',
+              hostName: tunnistamoAndProfileBeHostName,
+              description: securityCookieDescription,
+              expiration: `365 ${daysPlural}`,
+            },
+            {
+              id: 'profiili-csrftoken',
+              name: 'profiili-prod-csrftoken',
+              hostName: tunnistamoAndProfileBeHostName,
+              description: securityCookieDescription,
+              expiration: `365 ${daysPlural}`,
+            },
+          ],
+        },
+        {
+          commonGroup: 'language',
+          cookies: [
+            { commonCookie: 'keycloak-language' },
+            { commonCookie: 'suomifi-language' },
+            {
+              id: 'profile-language',
+              name: 'i18next',
+              hostName: profiiliHostName,
+              description: languageCookieDescription,
+              expiration: sessionExpiration,
+            },
+          ],
+        },
+        {
+          commonGroup: 'loadBalancing',
+          cookies: [
+            {
+              id: 'loadbalancer',
+              name: loadBalancerCookieName,
+              hostName: `${profiiliHostName}, ${tunnistamoAndProfileBeHostName}, ${tunnistusHostName}`,
+              description: loadBalancerCookieDescription,
+              expiration: sessionExpiration,
+            },
+          ],
+        },
+      ],
+    },
+    optionalCookies: {
+      groups: [
+        {
+          commonGroup: 'statistics',
+          cookies: [
+            {
+              commonCookie: trackingCookieId,
+            },
+            {
+              id: 'matomo-session',
+              name: '_pk_ses*',
+              hostName: anyHelFiHostName,
+              description: trackingCookieDescription,
+              expiration: `30 ${minutesPlural}`,
+            },
+            {
+              id: 'matomo-cookie-consent',
+              name: 'mtm_.*',
+              hostName: anyHelFiHostName,
+              description: consentStorageDescription,
+              expiration: `400 ${daysPlural}`,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -248,5 +248,18 @@
   "accessibilityStatement": "Accessibility Statement",
   "cityOfHelsinki": "City of Helsinki",
   "pageNotFoundTitle": "Page not found",
-  "pageNotFoundText": "Check the spelling of the URL (upper and lower case letters and punctuation marks). Or click the Back button on your browser to return to the previous page. You can also go to the front page via the link below."
+  "pageNotFoundText": "Check the spelling of the URL (upper and lower case letters and punctuation marks). Or click the Back button on your browser to return to the previous page. You can also go to the front page via the link below.",
+  "cookies": {
+    "pageName": "Cookie settings",
+    "securityCookieDescription": "A security control",
+    "loadBalancerCookieName": "A random 32-character long string",
+    "loadBalancerCookieDescription": "Technical routing of requests.",
+    "languageCookieDescription": "Required to persist the user's chosen language.",
+    "sessionExpiration": "Session",
+    "daysPlural": "days",
+    "minutesPlural": "minutes",
+    "mainText": "This website uses required cookies to ensure the basic functionality and performance. In addition, we use targeting cookies to perform analytics.",
+    "trackingCookieDescription": "This cookie is used to store a few details about the user such as the unique visitor ID.",
+    "consentStorageDescription": "Cookie stores consent for using analytics cookies."
+  }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -248,5 +248,18 @@
   "accessibilityStatement": "Saavutettavuusseloste",
   "cityOfHelsinki": "Helsingin kaupunki",
   "pageNotFoundTitle": "Sivua ei löytynyt",
-  "pageNotFoundText": "Tarkista URL-osoitteen oikeinkirjoitus (tarkista isot ja pienet kirjaimet sekä välimerkit). Tai palaa edelliselle sivulle napsauttamalla selaimen Edellinen-painiketta. Voit mennä myös etusivulle alla olevasta linkistä."
+  "pageNotFoundText": "Tarkista URL-osoitteen oikeinkirjoitus (tarkista isot ja pienet kirjaimet sekä välimerkit). Tai palaa edelliselle sivulle napsauttamalla selaimen Edellinen-painiketta. Voit mennä myös etusivulle alla olevasta linkistä.",
+  "cookies": {
+    "pageName": "Evästeasetukset",
+    "securityCookieDescription": "Tietoturvakontrolli",
+    "loadBalancerCookieName": "Satunnainen 32 merkin pituinen merkkijono",
+    "loadBalancerCookieDescription": "Verkkoliikenteen tekninen reititys.",
+    "languageCookieDescription": "Eväste vaaditaan jotta käyttäjän kielivalinta säilyisi.",
+    "sessionExpiration": "Istunto",
+    "daysPlural": "päivää",
+    "minutesPlural": "minuuttia",
+    "mainText": "Tämä sivusto käyttää välttämättömiä evästeitä sivun perustoimintojen ja suorituskyvyn varmistamiseksi. Lisäksi käytämme kohdennusevästeitä analytiikkaa varten.",
+    "trackingCookieDescription": "Eväste kerää tietoa kävijän liikkeistä sivustolla.",
+    "consentStorageDescription": "Evästeeseen tallennetaan suostumus tilastointievästeisiin."
+  }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -248,5 +248,18 @@
   "accessibilityStatement": "Tillgänglighetsutlåtande",
   "cityOfHelsinki": "Helsingfors stad",
   "pageNotFoundTitle": "Vi kunde inte hitta webbplatsen.",
-  "pageNotFoundText": "Kontrollera att URL-adressen är rätt skriven (kontrollera stora och små bokstäver och skiljetecken). Eller gå tillbaka till föregående sida genom att klicka på tangenten Föregående i webbläsaren. Du kan också gå tillbaka till första sidan via länken här nedan."
+  "pageNotFoundText": "Kontrollera att URL-adressen är rätt skriven (kontrollera stora och små bokstäver och skiljetecken). Eller gå tillbaka till föregående sida genom att klicka på tangenten Föregående i webbläsaren. Du kan också gå tillbaka till första sidan via länken här nedan.",
+  "cookies": {
+    "pageName": "Kakinställningar",
+    "securityCookieDescription": "Datasäkerhetskontroll",
+    "loadBalancerCookieName": "En slumpmässig teckensträng med 32 tecken",
+    "loadBalancerCookieDescription": "Teknisk routning av webbtrafiken.",
+    "languageCookieDescription": "Kakan krävs för att spara användarens språkval.",
+    "sessionExpiration": "Session",
+    "daysPlural": "dagar",
+    "minutesPlural": "minuter",
+    "mainText": "Denna webbplats använder nödvändiga kakor för att säkerställa basfunktionerna och prestandan. Dessutom använder vi inriktningskakor för analys.",
+    "trackingCookieDescription": "Statistiksystemets kaka samlar information om hur webbplatsen används.",
+    "consentStorageDescription": "Kakan lagrar samtycke för användning av statistikkakorna."
+  }
 }

--- a/src/toast/__tests__/__snapshots__/Toast.test.jsx.snap
+++ b/src/toast/__tests__/__snapshots__/Toast.test.jsx.snap
@@ -14,7 +14,6 @@ exports[`Toast should render correct toast 1`] = `
             class="notification"
           >
             <section
-              aria-atomic="true"
               aria-label="Notification"
               class="Notification-module_notification__2hN3H notification_hds-notification__2DQPN Notification-module_error__2sn9y notification_hds-notification--error__3T1Of"
             >
@@ -120,31 +119,28 @@ exports[`Toast should render correct toast 1`] = `
               onClose={[Function]}
               type="error"
             >
-              <su
+              <ka
                 visuallyHidden={false}
               >
                 <Animated(section)
-                  aria-atomic="true"
                   aria-label="Notification"
                   className="Notification-module_notification__2hN3H notification_hds-notification__2DQPN Notification-module_error__2sn9y notification_hds-notification--error__3T1Of"
                   style={Object {}}
                 >
                   <section
-                    aria-atomic="true"
                     aria-label="Notification"
                     className="Notification-module_notification__2hN3H notification_hds-notification__2DQPN Notification-module_error__2sn9y notification_hds-notification--error__3T1Of"
                     style={Object {}}
                   >
                     <div
                       className="Notification-module_content__ZZKvE notification_hds-notification__content__5ylSS"
-                      role={null}
                     >
                       <div
                         aria-level={2}
                         className="Notification-module_label__1bhNu notification_hds-notification__label__2t1lR"
                         role="heading"
                       >
-                        <V
+                        <U
                           aria-hidden={true}
                           className="Notification-module_icon__1ans7 notification_hds-icon__29HQM"
                         >
@@ -170,12 +166,12 @@ exports[`Toast should render correct toast 1`] = `
                               />
                             </g>
                           </svg>
-                        </V>
-                        <su
+                        </U>
+                        <ka
                           visuallyHidden={false}
                         >
                           test title
-                        </su>
+                        </ka>
                       </div>
                       <div
                         className="Notification-module_body__9BSAD notification_hds-notification__body__3cobH"
@@ -194,7 +190,7 @@ exports[`Toast should render correct toast 1`] = `
                       title="notification.closeButtonText"
                       type="button"
                     >
-                      <j
+                      <P
                         aria-hidden={true}
                       >
                         <svg
@@ -219,11 +215,11 @@ exports[`Toast should render correct toast 1`] = `
                             />
                           </g>
                         </svg>
-                      </j>
+                      </P>
                     </button>
                   </section>
                 </Animated(section)>
-              </su>
+              </ka>
             </ForwardRef>
           </div>
         </NotificationComponent>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,10 +2651,10 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@popperjs/core@2.5.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
-  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+"@popperjs/core@2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@reach/observe-rect@^1.1.0":
   version "1.2.0"
@@ -3171,6 +3171,11 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/dompurify@^2.2.2":
   version "2.2.2"
@@ -5418,6 +5423,11 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-js-compat@^3.14.0, core-js-compat@^3.15.0:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.15.1.tgz#1afe233716d37ee021956ef097594071b2b585a7"
@@ -5490,6 +5500,14 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crc-32@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
 
 cross-env@^7.0.3:
   version "7.0.3"
@@ -6690,6 +6708,11 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -7067,6 +7090,13 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-double@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/function-double/-/function-double-1.0.4.tgz#46074f215a171594036d816fa963c2902b482c86"
+  integrity sha512-J+vMIwmWx/uY3Fc4TNeyPyQOjSbaWpHO/xj+tv8RbViLfPipFGohgOWN+kSkuWTwSZPZxMfYopECUA/9Tq8YJA==
+  dependencies:
+    util-arity "^1.1.0"
+
 function.prototype.name@^1.1.2, function.prototype.name@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.4.tgz#e4ea839b9d3672ae99d0efd9f38d9191c5eaac83"
@@ -7399,39 +7429,49 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hds-core@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.13.0.tgz#7c17f205526a27ae9f05612769dd90cc6a5b1b68"
-  integrity sha512-j3fZFqo6AgyBrlwxOd+9wN7DL8gaEFIB8ahxCZ72BHQf5ETtpE0LE8FRygJPH5H5W67kOr7CmIBOtPp7aOxwNQ==
+hds-core@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-2.10.0.tgz#bbead215341313cc15591387c0a8d3f013caff4a"
+  integrity sha512-bWVMtSC9PrsiCFDR2myMgXH9vh0iAP+UsuiW/jEo538WCQmAsQPqEAWsRps4GFtRZEAb+OWX+LTNNLwjAHvo1A==
 
-hds-design-tokens@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.13.0.tgz#0574150114cdc6544003b33d4110e4ea353a1484"
-  integrity sha512-KegIS/O9kuBSMZQlN3xzfftNHoWhmkIItWDxvzjGVP8b/IeB1IiFQNLWKzTVx6HKBTFTMdJBIS27Hp3YvxAYXA==
+hds-design-tokens@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-2.10.0.tgz#a4c88a54d1366584d9291a43cbe161d63eb5bd6b"
+  integrity sha512-h4YdTiE3nBa8BbnHqoujZSmfcW3SIZ/o75NrFDr/Y4/AahPuaX8HFR5jqaGmn+VsBZvV2gV89lT188AvO28Law==
 
-hds-react@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.13.0.tgz#eee10733b4628cbbec9091a17edb3dcab89509d1"
-  integrity sha512-p63nrXFjuLBMI06qmt4vguUL1loyUprqPHTA667yIxVvZeOkCvZh2GgZm45UVY6KQIeLqyBj3t6OX/o7k26H+g==
+hds-react@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-2.10.0.tgz#f536b49cc206cf5d10ef6fb877622a0d85dbfbfa"
+  integrity sha512-a3r0Iv67F2qJvORVXatFAFcW4F6ngHYjXNm4eH1Uc0OsZMNaAnlTDaI6CP2y6L2JQBr/70Q/FbjBE/6MHyL1XA==
   dependencies:
     "@babel/runtime" "7.11.2"
     "@emotion/styled-base" "^11.0.0"
     "@juggle/resize-observer" "3.2.0"
-    "@popperjs/core" "2.5.3"
+    "@popperjs/core" "2.11.5"
     "@react-aria/visually-hidden" "3.2.0"
+    "@types/cookie" "^0.4.1"
+    cookie "^0.4.1"
+    crc-32 "1.2.0"
     date-fns "2.16.1"
     downshift "6.0.6"
-    hds-core "1.13.0"
+    hds-core "2.10.0"
+    kashe "1.0.4"
+    lodash.get "^4.4.2"
     lodash.isequal "4.5.0"
     lodash.isfunction "3.0.9"
+    lodash.isobject "3.0.2"
+    lodash.isundefined "3.0.1"
+    lodash.pick "^4.4.0"
+    lodash.pickby "^4.6.0"
     lodash.uniqueid "4.0.1"
     lodash.xor "^4.5.0"
+    memoize-one "5.2.1"
+    postcss "7.0.36"
     react-merge-refs "1.1.0"
-    react-popper "2.2.3"
+    react-popper "2.2.5"
     react-spring "9.3.0"
     react-use-measure "2.0.1"
     react-virtual "2.2.7"
-    typescript "4.5.5"
 
 he@^1.2.0:
   version "1.2.0"
@@ -8790,6 +8830,14 @@ jsx-ast-utils@^3.2.1:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
+kashe@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/kashe/-/kashe-1.0.4.tgz#72f538d641f220eb4533a050f1f39b3acac7fafb"
+  integrity sha512-d4N2iljhOrTUszc+fRdfaFRPeu0+hZNbSlXnuTdVcN+IWFMByTNmQzA3SKb1bWctNVXi5RmYQYQjOWqu1mDXpw==
+  dependencies:
+    function-double "^1.0.4"
+    reselect "^4.0.0"
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -8982,10 +9030,10 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4:
+lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.identity@3.0.0:
   version "3.0.0"
@@ -9002,6 +9050,16 @@ lodash.isfunction@3.0.9:
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
   integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
 
+lodash.isobject@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==
+
+lodash.isundefined@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
+  integrity sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -9012,10 +9070,15 @@ lodash.merge@^4.6.1, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.pickby@4.6.0:
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
+
+lodash.pickby@4.6.0, lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
+  integrity sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -9163,6 +9226,11 @@ memfs@^3.1.2, memfs@^3.4.1:
   integrity sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==
   dependencies:
     fs-monkey "1.0.3"
+
+memoize-one@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -10472,6 +10540,15 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
+postcss@7.0.36:
+  version "7.0.36"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^7.0.35:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
@@ -10542,6 +10619,11 @@ pretty-format@^28.0.1:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -10829,10 +10911,10 @@ react-merge-refs@1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-popper@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+react-popper@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
@@ -11182,6 +11264,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.7.tgz#56480d9ff3d3188970ee2b76527bd94a95567a42"
+  integrity sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
@@ -12010,6 +12097,13 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -12516,6 +12610,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+util-arity@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/util-arity/-/util-arity-1.1.0.tgz#59d01af1fdb3fede0ac4e632b0ab5f6ce97c9330"
+  integrity sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Cookie consents are asked in a modal which is shown on all pages - except there is also a cookie settings page where modal is not shown. The settings page has same content, so no need to show both. Modal is rendered again when user navigates to another page.

Matomo tracking is disabled when cookie consent is not given. Even anonymous, non-cookie tracking. There is currently no verification from GDPR-lawyers can users be tracked without consent even if cookies are not used. 

Matomo tracking is never enabled in non-production environments. To test Matomo tracking, modify `enableTrackingCookies()` in tracking.ts. Events should be pushed, so comment out the `return` in the if-clause.
