### PR TITLE
HP-962: Fix language error in cookie content

### DIFF
--- a/src/cookieConsents/CookieConsentModal.tsx
+++ b/src/cookieConsents/CookieConsentModal.tsx
@@ -3,13 +3,16 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
+import getLanguageCode from '../common/helpers/getLanguageCode';
 import { handleCookieConsentChange } from '../common/helpers/tracking/matomoTracking';
 import config from '../config';
 import { getCookieContent } from './cookieContentSource';
 
 function CookieConsentModal(): React.ReactElement | null {
   const { i18n } = useTranslation();
-  const currentLanguage = i18n.language as ContentSource['currentLanguage'];
+  const currentLanguage = getLanguageCode(
+    i18n.language
+  ) as ContentSource['currentLanguage'];
   const { t, changeLanguage } = i18n;
   const location = useLocation();
   const currentPath = location.pathname;

--- a/src/cookieConsents/CookieConsentPage.tsx
+++ b/src/cookieConsents/CookieConsentPage.tsx
@@ -7,10 +7,13 @@ import PageLayout from '../common/pageLayout/PageLayout';
 import { getCookieContent } from './cookieContentSource';
 import commonContentStyles from '../common/cssHelpers/content.module.css';
 import { handleCookieConsentChange } from '../common/helpers/tracking/matomoTracking';
+import getLanguageCode from '../common/helpers/getLanguageCode';
 
 function CookieConsentPage(): React.ReactElement | null {
   const { i18n } = useTranslation();
-  const currentLanguage = i18n.language as ContentSource['currentLanguage'];
+  const currentLanguage = getLanguageCode(
+    i18n.language
+  ) as ContentSource['currentLanguage'];
   const { t } = i18n;
   const contentSource: ContentSource = useMemo(
     () => ({


### PR DESCRIPTION
i18n might return language with region in some browsers. "en-BG" instead of "en". This breaks cookie content builds, because that language does not exist.

Added a function that parses out the "-GB" part