### PR TITLE
HP-1734 end idle user's session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import WithAuthCheck from './profile/components/withAuthCheck/WithAuthCheck';
 import CookieConsentPage from './cookieConsents/CookieConsentPage';
 import LoginSSO from './auth/components/loginsso/LoginSSO';
 import { useTrackingInstance } from './common/helpers/tracking/matomoTracking';
+import ActivityTracker from './auth/components/activityTracker/ActivityTracker';
 
 countries.registerLocale(fi);
 countries.registerLocale(en);
@@ -67,6 +68,7 @@ function App(): React.ReactElement {
                 <PageNotFound />
               </Route>
             </Switch>
+            <ActivityTracker />
           </ProfileProvider>
         </MatomoProvider>
       </ToastProvider>

--- a/src/auth/__tests__/authService.test.js
+++ b/src/auth/__tests__/authService.test.js
@@ -447,6 +447,35 @@ describe('authService', () => {
     });
   });
 
+  describe('waitForAuthentication ', () => {
+    it('should resolve when user is already authenticated', async () => {
+      setSession({
+        validUser: true,
+        validApiToken: true,
+      });
+      await authService.waitForAuthentication();
+
+      expect(authService.isAuthenticated()).toBeTruthy();
+    });
+    it('should resolve after userLoaded event is raised', async () => {
+      setSession({
+        validUser: false,
+        validApiToken: false,
+      });
+      const tracker = jest.fn();
+      authService.waitForAuthentication().then(tracker);
+
+      await userManager.events._userLoaded.raise({});
+      // triggering twice as event can be triggered multiple times
+      // and errors should not occur
+      await userManager.events._userLoaded.raise({});
+
+      await waitFor(() => {
+        expect(tracker).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   describe('Session polling ', () => {
     const mockHttpPoller = getHttpPollerMockData();
     afterEach(() => {

--- a/src/auth/__tests__/useManualTokenRenewal.test.tsx
+++ b/src/auth/__tests__/useManualTokenRenewal.test.tsx
@@ -1,0 +1,371 @@
+import React, { useState } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { noop } from 'lodash';
+
+import authService from '../authService';
+import useManualTokenRenewal from '../useManualTokenRenewal';
+
+type ReturnType = {
+  getWarning: () => boolean;
+  getRenderCount: () => number;
+  getCancelButton: () => HTMLButtonElement;
+  getHideButton: () => HTMLButtonElement;
+  getReRenderButton: () => HTMLButtonElement;
+  getEmptyButton: () => HTMLButtonElement;
+  getHookElement: () => HTMLDivElement;
+  getHideIndicatorElement: () => HTMLDivElement;
+};
+
+const mockSpies = {
+  renewToken: jest.fn(),
+  addAccessTokenExpiring: jest.fn(),
+  removeAccessTokenExpiring: jest.fn(),
+  isAuthenticated: jest.fn(),
+  logout: jest.fn(),
+  waitForAuthentication: jest.fn(),
+};
+
+let mockIsAuthenticated = false;
+let mockWaitForAuthenticationResolver = noop;
+
+jest.mock('../authService', () => ({
+  renewToken: () => {
+    mockSpies.renewToken();
+    return new Promise(resolve => {
+      setTimeout(() => resolve({}), 50);
+    });
+  },
+  isAuthenticated: () => {
+    mockSpies.isAuthenticated();
+    return mockIsAuthenticated;
+  },
+  logout: () => {
+    mockSpies.logout();
+  },
+  userManager: {
+    events: {
+      addAccessTokenExpiring: (cb: jest.Mock) => {
+        mockSpies.addAccessTokenExpiring(cb);
+      },
+      removeAccessTokenExpiring: (cb: jest.Mock) => {
+        mockSpies.removeAccessTokenExpiring(cb);
+      },
+    },
+  },
+  waitForAuthentication: (callback: unknown) => {
+    mockSpies.waitForAuthentication(callback);
+    if (mockIsAuthenticated) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      mockWaitForAuthenticationResolver = resolve;
+    });
+  },
+}));
+
+describe('useManualTokenRenewal', () => {
+  const warnIndicatorElementId = 'warn-indicator';
+  const cancelButtonElementId = 'cancel-button';
+  const hideButtonElementId = 'hide-button';
+  const reRenderButtonElementId = 're-render-button';
+  const renderCountIndicatorElementId = 'render-count-indicator';
+  const hookElementId = 'hook-element';
+  const hiddenElementId = 'hidden';
+  const emptyButtonElementId = 'hidden';
+
+  const logoutThreshold = 1000 * 60 * 10;
+  const warningThreshold = 1000 * 60 * 8;
+  const checkInterval = 1000 * 60;
+
+  const HookComponent = () => {
+    const { warn, cancelTimeout } = useManualTokenRenewal({ authService });
+    return (
+      <div id={hookElementId}>
+        <span id={warnIndicatorElementId}>{String(warn)}</span>
+        <button id={cancelButtonElementId} onClick={cancelTimeout}>
+          cancelTimeout
+        </button>
+        <button id={emptyButtonElementId} onClick={jest.fn()}>
+          Just a click target
+        </button>
+      </div>
+    );
+  };
+
+  const TestComponent = () => {
+    const [isHidden, updateIsHidden] = useState(false);
+    const [renderCount, forceRender] = useState(0);
+    return (
+      <div>
+        {!isHidden && <HookComponent />}
+        {isHidden && <div id={hiddenElementId}>hidden</div>}
+        <button
+          id={hideButtonElementId}
+          onClick={() => updateIsHidden(!isHidden)}
+        >
+          cancelTimeout
+        </button>
+        <button
+          id={reRenderButtonElementId}
+          onClick={() => forceRender(count => count + 1)}
+        >
+          re-render
+        </button>
+        <span id={renderCountIndicatorElementId}>{String(renderCount)}</span>
+      </div>
+    );
+  };
+
+  const renderTestComponent = (data?: {
+    isAuthenticated: boolean;
+  }): ReturnType => {
+    mockIsAuthenticated = data?.isAuthenticated === true;
+    const result = render(<TestComponent />);
+    const { container } = result;
+    const getElementById = (id: string) =>
+      container.querySelector(`#${id}`) as HTMLElement;
+    return {
+      getWarning: () =>
+        getElementById(warnIndicatorElementId).innerHTML === 'true',
+      getCancelButton: () =>
+        getElementById(cancelButtonElementId) as HTMLButtonElement,
+      getHideButton: () =>
+        getElementById(hideButtonElementId) as HTMLButtonElement,
+      getHookElement: () => getElementById(hookElementId) as HTMLDivElement,
+      getHideIndicatorElement: () =>
+        getElementById(hiddenElementId) as HTMLDivElement,
+      getReRenderButton: () =>
+        getElementById(reRenderButtonElementId) as HTMLButtonElement,
+      getRenderCount: () =>
+        parseInt(getElementById(renderCountIndicatorElementId).innerHTML, 10),
+      getEmptyButton: () =>
+        getElementById(emptyButtonElementId) as HTMLButtonElement,
+    };
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setInterval');
+    jest.spyOn(global, 'clearInterval');
+    jest.spyOn(global.document, 'addEventListener');
+    jest.spyOn(global.document, 'removeEventListener');
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    mockIsAuthenticated = false;
+    mockWaitForAuthenticationResolver = noop;
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  // jest might add its own listeners, so filter those out
+  const getExpectedListenerMockCalls = (fn: unknown) =>
+    (fn as jest.Mock).mock.calls.filter(call => {
+      const [type, func] = call;
+      return (
+        ['pointerup', 'keyup'].includes(type) && typeof func === 'function'
+      );
+    });
+
+  const getAddEventListenerCalls = () =>
+    getExpectedListenerMockCalls(global.document.addEventListener);
+
+  const getRemoveEventListenerCalls = () =>
+    getExpectedListenerMockCalls(global.document.removeEventListener);
+
+  const getAccessTokenExpiringCallback = () => {
+    const calls = mockSpies.addAccessTokenExpiring.mock.calls;
+    if (calls.length !== 1) {
+      throw new Error('addAccessTokenExpiring not called correct times!');
+    }
+    return calls[0][0];
+  };
+
+  const advanceTimersToBeyondWarningThreshold = () =>
+    jest.advanceTimersByTime(warningThreshold + 100);
+
+  const advanceTimersOneCheckInterval = () =>
+    jest.advanceTimersByTime(checkInterval + 100);
+
+  const advanceTimersToBeyondLogoutThreshold = () =>
+    jest.advanceTimersByTime(logoutThreshold + 100);
+
+  const advanceTimersToNearWarningThreshold = () =>
+    jest.advanceTimersByTime(warningThreshold - 100);
+
+  const removeComponent = async (result: ReturnType) => {
+    await act(async () => {
+      const { getHideButton, getHideIndicatorElement, getHookElement } = result;
+      expect(!!getHookElement()).toBeTruthy();
+      getHideButton().click();
+      await waitFor(() => {
+        expect(!!getHideIndicatorElement()).toBeTruthy();
+        expect(!!getHookElement()).toBeFalsy();
+      });
+    });
+  };
+  const rerender = async (result: ReturnType) =>
+    act(async () => {
+      const { getReRenderButton, getRenderCount } = result;
+      const initialCount = getRenderCount();
+      getReRenderButton().click();
+      await waitFor(() => {
+        expect(getRenderCount()).toBe(initialCount + 1);
+      });
+    });
+
+  it('When user is not authenticated, no timers are started or listeners added.', async () => {
+    const result = renderTestComponent();
+    const { getWarning } = result;
+    expect(getWarning()).toBeFalsy();
+    expect(mockSpies.waitForAuthentication).toHaveBeenCalledTimes(1);
+    await rerender(result);
+    expect(global.setInterval).toHaveBeenCalledTimes(0);
+    expect(getAddEventListenerCalls()).toHaveLength(0);
+    expect(mockSpies.addAccessTokenExpiring).toHaveBeenCalledTimes(0);
+    expect(mockSpies.renewToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('When user is authenticated, timers are started and listeners added. Only once!', async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    expect(mockSpies.waitForAuthentication).toHaveBeenCalledTimes(1);
+    await rerender(result);
+    await rerender(result);
+    expect(global.setInterval).toHaveBeenCalledTimes(1);
+    // one pointer and one key event on each initialization
+    expect(getAddEventListenerCalls()).toHaveLength(2);
+    expect(mockSpies.addAccessTokenExpiring).toHaveBeenCalledTimes(1);
+    expect(mockSpies.renewToken).toHaveBeenCalledTimes(0);
+  });
+  it('User might not be authenticated immediately - for example when returning from login', async () => {
+    const result = renderTestComponent({ isAuthenticated: false });
+    expect(mockSpies.waitForAuthentication).toHaveBeenCalledTimes(1);
+    await rerender(result);
+    expect(global.setInterval).toHaveBeenCalledTimes(0);
+    expect(getAddEventListenerCalls()).toHaveLength(0);
+    mockWaitForAuthenticationResolver();
+    await rerender(result);
+    await waitFor(() => {
+      expect(global.setInterval).toHaveBeenCalledTimes(1);
+      expect(getAddEventListenerCalls()).toHaveLength(2);
+    });
+  });
+
+  it('Timers and listeners are removed when component is removed.', async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    await rerender(result);
+    await rerender(result);
+    await rerender(result);
+    // event listeners are deleted when new ones are added
+    expect(getRemoveEventListenerCalls()).toHaveLength(2);
+    expect(getAddEventListenerCalls()).toHaveLength(2);
+    await removeComponent(result);
+    expect(global.setInterval).toHaveBeenCalledTimes(1);
+    expect(global.clearInterval).toHaveBeenCalledTimes(1);
+    expect(mockSpies.addAccessTokenExpiring).toHaveBeenCalledTimes(1);
+    expect(mockSpies.removeAccessTokenExpiring).toHaveBeenCalledTimes(1);
+    // event listeners are deleted also when component is unloaded
+    expect(getRemoveEventListenerCalls()).toHaveLength(4);
+    expect(mockSpies.renewToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('Warning is triggered when user is idle long enough. Calling cancelTimeout() resets the warning ', async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    const { getWarning, getCancelButton } = result;
+    expect(getWarning()).toBeFalsy();
+    advanceTimersToBeyondWarningThreshold();
+    await waitFor(
+      async () => {
+        await rerender(result);
+        expect(getWarning()).toBeTruthy();
+      },
+      { timeout: warningThreshold * 2 }
+    );
+    getCancelButton().click();
+    await waitFor(() => {
+      expect(getWarning()).toBeFalsy();
+    });
+    await rerender(result);
+    await waitFor(
+      () => {
+        advanceTimersOneCheckInterval();
+        expect(getWarning()).toBeTruthy();
+      },
+      { timeout: warningThreshold * 2 }
+    );
+    // warning does not end timers
+    expect(global.clearInterval).toHaveBeenCalledTimes(0);
+  });
+  it('Warning is not triggered while user is active and event listener is triggered.', async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    const { getWarning } = result;
+
+    await act(async () => {
+      advanceTimersToNearWarningThreshold();
+      const event = new KeyboardEvent('keyup', {
+        keyCode: 37,
+        bubbles: true,
+      });
+      global.document.dispatchEvent(event);
+      advanceTimersOneCheckInterval();
+      await rerender(result);
+      expect(getWarning()).toBeFalsy();
+    });
+  });
+  it(`Token is not renewed if it is expiring but user has been idle. 
+      It is renewed when user is active again`, async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    const { getWarning, getCancelButton } = result;
+    advanceTimersToBeyondWarningThreshold();
+    await waitFor(
+      () => {
+        expect(getWarning()).toBeTruthy();
+      },
+      { timeout: warningThreshold * 2 }
+    );
+    const accessTokenExpiringCallback = getAccessTokenExpiringCallback();
+    accessTokenExpiringCallback();
+    expect(mockSpies.renewToken).toHaveBeenCalledTimes(0);
+    getCancelButton().click();
+    advanceTimersOneCheckInterval();
+    await waitFor(() => {
+      expect(getWarning()).toBeFalsy();
+      expect(mockSpies.renewToken).toHaveBeenCalledTimes(1);
+    });
+  });
+  it('When user is idle long enough, the user is logged out.', async () => {
+    const result = renderTestComponent({ isAuthenticated: true });
+    const { getWarning } = result;
+    advanceTimersToBeyondWarningThreshold();
+    await waitFor(
+      async () => {
+        await rerender(result);
+        expect(getWarning()).toBeTruthy();
+      },
+      { timeout: warningThreshold * 2 }
+    );
+
+    await rerender(result);
+    advanceTimersToBeyondLogoutThreshold();
+    // logut is called
+    await waitFor(
+      async () => {
+        expect(mockSpies.logout).toHaveBeenCalledTimes(1);
+      },
+      { timeout: logoutThreshold * 2 }
+    );
+
+    // all timers are stopped
+    expect(global.clearInterval).toHaveBeenCalledTimes(1);
+    expect(mockSpies.removeAccessTokenExpiring).toHaveBeenCalledTimes(1);
+    // event listeners are deleted before new ones are added
+    // event listeners are removed before user is logged out
+    expect(getRemoveEventListenerCalls()).toHaveLength(4);
+  });
+});

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -38,7 +38,7 @@ export class AuthService {
   private _isProcessingLogin = false;
   constructor() {
     const settings: UserManagerSettings = {
-      automaticSilentRenew: true,
+      automaticSilentRenew: false,
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       authority: window._env_.REACT_APP_OIDC_AUTHORITY,
       client_id: window._env_.REACT_APP_OIDC_CLIENT_ID,
@@ -47,10 +47,9 @@ export class AuthService {
       response_type: window._env_.REACT_APP_OIDC_RESPONSE_TYPE,
       scope: window._env_.REACT_APP_OIDC_SCOPE,
       post_logout_redirect_uri: `${origin}/`,
-      // This calculates to 1 minute, good for debugging:
-      // eslint-disable-next-line max-len
-      // https://github.com/City-of-Helsinki/kukkuu-ui/blob/8029ed64c3d0496fa87fa57837c73520e8cbe37f/src/domain/auth/userManager.ts#L18
-      // accessTokenExpiringNotificationTime: 59.65 * 60,
+      // Currently expiration time is 1 hour, 3600 seconds
+      // set following value to 3600 - <seconds until renewal starts>, to debug the renewal process
+      //accessTokenExpiringNotificationTime: 3600 - 10,
     };
 
     // Show oidc debugging info in the console only while developing

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -251,6 +251,24 @@ export class AuthService {
     sessionStorage.removeItem(API_TOKEN);
     this.userSessionValidityPoller.stop();
   }
+
+  async waitForAuthentication(): Promise<void> {
+    return new Promise(resolve => {
+      if (this.isAuthenticated()) {
+        resolve();
+        return;
+      }
+      let isResolved = false;
+      // addUserLoaded can be called multiple times - for example when token is renewed
+      // isResolved prevents calling resolve() twice
+      this.userManager.events.addUserLoaded(() => {
+        if (!isResolved) {
+          isResolved = true;
+          resolve();
+        }
+      });
+    });
+  }
 }
 
 export default new AuthService();

--- a/src/auth/components/activityTracker/ActivityTracker.tsx
+++ b/src/auth/components/activityTracker/ActivityTracker.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ConfirmationModal from '../../../profile/components/modals/confirmationModal/ConfirmationModal';
+import authService from '../../authService';
+import useManualTokenRenewal from '../../useManualTokenRenewal';
+
+function ActivityTracker(): React.ReactElement | null {
+  const { t } = useTranslation();
+  const { warn, cancelTimeout } = useManualTokenRenewal({ authService });
+  if (warn) {
+    return (
+      <ConfirmationModal
+        isOpen
+        onClose={() => cancelTimeout()}
+        onConfirm={() => cancelTimeout()}
+        actionButtonText={t('confirmationModal.continue')}
+        closeButtonText=""
+        title={t('confirmationModal.idleWarningTitle')}
+        content={() => <p>{t('confirmationModal.idleWarning')}</p>}
+      />
+    );
+  }
+
+  return null;
+}
+
+export default ActivityTracker;

--- a/src/auth/useManualTokenRenewal.ts
+++ b/src/auth/useManualTokenRenewal.ts
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { AuthService } from './authService';
+
+export type ManualTokenRenewalProps = {
+  authService: AuthService;
+};
+
+export type ManualTokenRenewalReturnType = {
+  warn: boolean;
+  cancelTimeout: () => void;
+};
+
+export type TrackingData = {
+  checkIntervalId?: ReturnType<typeof setTimeout>;
+  lastUpdate: number;
+  idleUserLogoutThresholdInMs: number;
+  logoutWarningThresholdInMs: number;
+  checkIntervalInMs: number;
+  warn: boolean;
+  tokenIsExpiring: boolean;
+};
+
+export default function useManualTokenRenewal({
+  authService,
+}: ManualTokenRenewalProps): ManualTokenRenewalReturnType {
+  const [, updateState] = useState(0);
+  const trackerRef = useRef<TrackingData>({
+    lastUpdate: -1,
+    checkIntervalId: undefined,
+    idleUserLogoutThresholdInMs: 1000 * 60 * 10,
+    logoutWarningThresholdInMs: 1000 * 60 * 8,
+    checkIntervalInMs: 1000 * 30,
+    warn: false,
+    tokenIsExpiring: false,
+  });
+
+  // single useMemo() is better than wrapping all functions inside it with useCallback(<function>,[dependency array])
+  const trackingFunctions = useMemo(() => {
+    const forceUpdate = () => {
+      updateState(count => count + 1);
+    };
+
+    const refreshActivityTime = () => {
+      trackerRef.current.lastUpdate = Date.now();
+    };
+
+    // change warn value and update state to re-render parent component
+    const updateWarnValue = (value: boolean) => {
+      if (trackerRef.current.warn === value) {
+        return;
+      }
+      trackerRef.current.warn = value;
+      forceUpdate();
+    };
+
+    const isTracking = () =>
+      !!trackerRef.current.checkIntervalId && !!trackerRef.current.lastUpdate;
+
+    const getActivityStatus = () => {
+      if (!isTracking()) {
+        return 'stopped';
+      }
+      const currentRef = trackerRef.current;
+      const now = Date.now();
+      const timeSinceLastRefresh = now - trackerRef.current.lastUpdate;
+      if (timeSinceLastRefresh > currentRef.idleUserLogoutThresholdInMs) {
+        return 'expired';
+      } else if (timeSinceLastRefresh > currentRef.logoutWarningThresholdInMs) {
+        return 'warn';
+      }
+      return 'ok';
+    };
+
+    const renewToken = () => {
+      authService.renewToken();
+      trackerRef.current.tokenIsExpiring = false;
+    };
+
+    const checkActivity = () => {
+      const activityLevel = getActivityStatus();
+      if (activityLevel === 'expired') {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        stopActivityChecker();
+        authService.logout();
+      } else if (activityLevel === 'warn') {
+        updateWarnValue(true);
+      } else if (activityLevel === 'ok' && trackerRef.current.tokenIsExpiring) {
+        renewToken();
+      }
+    };
+
+    const stopTimer = () => {
+      if (trackerRef.current.checkIntervalId) {
+        clearInterval(trackerRef.current.checkIntervalId);
+        trackerRef.current.checkIntervalId = undefined;
+      }
+      trackerRef.current.lastUpdate = -1;
+    };
+
+    const startTimer = () => {
+      stopTimer();
+      trackerRef.current.checkIntervalId = setInterval(
+        checkActivity,
+        trackerRef.current.checkIntervalInMs
+      );
+      refreshActivityTime();
+    };
+
+    const cancelTimeout = () => {
+      refreshActivityTime();
+      updateWarnValue(false);
+    };
+
+    const handleUserEvents = (addListener: boolean) => {
+      document.removeEventListener('pointerup', refreshActivityTime);
+      document.removeEventListener('keyup', refreshActivityTime);
+      if (addListener) {
+        document.addEventListener('pointerup', refreshActivityTime, {
+          passive: true,
+        });
+        document.addEventListener('keyup', refreshActivityTime);
+      }
+    };
+
+    const handleAccessTokenExpiring = () => {
+      const status = getActivityStatus();
+      if (status === 'stopped') {
+        return;
+      } else if (status === 'ok') {
+        renewToken();
+      } else {
+        trackerRef.current.tokenIsExpiring = true;
+      }
+    };
+
+    const startActivityChecker = () => {
+      startTimer();
+      handleUserEvents(true);
+      authService.userManager.events.addAccessTokenExpiring(
+        handleAccessTokenExpiring
+      );
+    };
+
+    const stopActivityChecker = () => {
+      stopTimer();
+      handleUserEvents(false);
+      authService.userManager.events.removeAccessTokenExpiring(
+        handleAccessTokenExpiring
+      );
+    };
+
+    return {
+      refreshActivityTime,
+      updateWarnValue,
+      getActivityStatus,
+      renewToken,
+      startActivityChecker,
+      stopActivityChecker,
+      handleUserEvents,
+      cancelTimeout,
+      startTimer,
+      stopTimer,
+      isTracking,
+    };
+  }, [updateState, authService]);
+
+  useEffect(() => {
+    const { startActivityChecker, stopActivityChecker } = trackingFunctions;
+    authService.waitForAuthentication().then(() => {
+      startActivityChecker();
+    });
+    return () => {
+      stopActivityChecker();
+    };
+  }, [trackingFunctions, authService]);
+
+  return {
+    warn: trackerRef.current.warn,
+    cancelTimeout: trackingFunctions.cancelTimeout,
+  };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,7 +25,10 @@
     "removePhone": "Remove phone number?",
     "removeAddress": "Remove address?",
     "saveMessage": "The information you have changed is immediately available to the following City of Helsinki services:",
-    "saveTitle": "Do you want to save your changes?"
+    "saveTitle": "Do you want to save your changes?",
+    "idleWarning": "The session is about to expire. To prevent an automatic logout, select Continue",
+    "idleWarningTitle": "You will be logged out soon",
+    "continue": "Continue"
   },
   "createProfile": {
     "heading": "Fill in your details to create a profile",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -25,7 +25,10 @@
     "removePhone": "Poistetaanko puhelinnumero?",
     "removeAddress": "Poistetaanko osoite?",
     "saveMessage": "Muuttamasi tiedot ovat heti käytössä seuraavissa Helsingin kaupungin palveluissa:",
-    "saveTitle": "Haluatko tallentaa tekemäsi muutokset?"
+    "saveTitle": "Haluatko tallentaa tekemäsi muutokset?",
+    "idleWarning": "Sessio on vanhentumassa, jos haluat jatkaa niin klikkaa jatka, muuten sinut kirjataan ulos",
+    "idleWarningTitle": "Sinut kirjataan pian ulos",
+    "continue": "Jatka"
   },
   "createProfile": {
     "heading": "Täydennä tietosi luodaksesi profiili",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -25,7 +25,10 @@
     "removePhone": "Ta bort telefonnummer?",
     "removeAddress": "Ta bort adress?",
     "saveMessage": "Informationen som du har ändrat är omedelbart tillgänglig för följande Helsingfors stads tjänster:",
-    "saveTitle": "Vill du spara dina ändringar?"
+    "saveTitle": "Vill du spara dina ändringar?",
+    "idleWarning": "Sessionen är på väg att gå ut. Om du vill fortsätta ska du klicka på Fortsätt. Annars loggas du ut.",
+    "idleWarningTitle": "Du loggas ut inom kort",
+    "continue": "Fortsätt"
   },
   "createProfile": {
     "heading": "Fyll i detaljerna för att skapa en profil",


### PR DESCRIPTION
Tokens are not auto-renewed anymore. They are renewed when they are expiring and user has been active.

If expiring and user is not active, tokens are renewed when user is active again.

If user is idle for 10 minutes, user is logged out. A warning is shown after 8 minutes of inactivity.

To test faster:
- authService.ts: uncomment line 52 with "accessTokenExpiringNotificationTime"
- useManualTokenRenewal.ts: divide all intervals by 60 on lines 31-33
