### PR TITLE
HP-2126: no service connections fix with auth codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
     ]
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^8.1.0",
+    "@types/sinonjs__fake-timers": "^8.1.0",
     "apollo": "^2.33.9",
     "cross-env": "^7.0.3",
     "helsinki-utils": "City-of-Helsinki/helsinki-utils-js#0.1.0",

--- a/src/common/actionQueue/actionQueueRunner.ts
+++ b/src/common/actionQueue/actionQueueRunner.ts
@@ -116,6 +116,13 @@ export function createActionQueueRunner(
     }
     const next = queueController.getNext();
     if (next) {
+      if (
+        action.active &&
+        getOption(action, 'idleWhenActive') &&
+        pendingPromise
+      ) {
+        return 'pending';
+      }
       return next.type === action.type ? 'next' : 'not-next';
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,7 +2940,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^8.0.1":
+"@sinonjs/fake-timers@^8.0.1", "@sinonjs/fake-timers@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7"
   integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
@@ -3509,6 +3509,11 @@
   dependencies:
     "@types/mime" "^1"
     "@types/node" "*"
+
+"@types/sinonjs__fake-timers@^8.1.0":
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz#5fd3592ff10c1e9695d377020c033116cc2889f2"
+  integrity sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==
 
 "@types/sockjs@^0.3.33":
   version "0.3.33"


### PR DESCRIPTION
If user has no service connections and no auth codes to get, then the browser redirection action is executed twice and will throw an error.

Added a check so an action with active state **and** options.idleWhenActive **and** a pending promise will return status 'pending'. Previously it returned 'next'.

Also added a timeout to the redirection catcher, if the url does not match the expected url. If the browser is not actually redirected and the url is set in an useEffect, then the catcher checks the url before it is set.