### PR TITLE
HP-2220 | Change default value for Helsinki tunnus amr claim

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
 REACT_APP_PROFILE_GRAPHQL="https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
-REACT_APP_HELSINKI_ACCOUNT_AMR="helusername"
+REACT_APP_HELSINKI_ACCOUNT_AMR="helsinki_tunnus"
 REACT_APP_KEYCLOAK_AUTHORITY="https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/"

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ Since this app uses react-scripts (Create React App) the env-files work a bit di
 
 The following envs are used:
 
-| Name                                  | Description                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------- |
-| `REACT_APP_HELSINKI_ACCOUNT_AMR`      | Authentication method reference for Helsinki account. </br> **default:** `helusername` |
-| `REACT_APP_OIDC_AUTHORITY`            | This is the URL to tunnistamo.                                                         |
-| `REACT_APP_OIDC_CLIENT_ID`            | ID of the client that has to be configured in tunnistamo.                              |
-| `REACT_APP_OIDC_SCOPE`                | Which scopes the app requires.                                                         |
-| `REACT_APP_PROFILE_AUDIENCE`          | Name of the api-token that client uses profile-api with.                               |
-| `REACT_APP_PROFILE_BE_GDPR_CLIENT_ID` | Client id used when getting gdpr authentication token for connected services           |
-| `REACT_APP_PROFILE_GRAPHQL`           | URL to the profile graphql.                                                            |
-| `REACT_APP_SENTRY_DSN`                | Sentry public dns-key.                                                                 |
-| `REACT_APP_OIDC_RESPONSE_TYPE`        | Which response type to require.                                                        |
-| `REACT_APP_KEYCLOAK_GDPR_CLIENT_ID`   | Client id for getting auth codes from keycloak                                         |
-| `REACT_APP_KEYCLOAK_AUTHORITY`        | Url to Keycloak. The openid config is fetched from this url                            |
+| Name                                  | Description                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `REACT_APP_HELSINKI_ACCOUNT_AMR`      | Authentication method reference for Helsinki account. </br> **default:** `helsinki_tunnus` |
+| `REACT_APP_OIDC_AUTHORITY`            | This is the URL to tunnistamo.                                                             |
+| `REACT_APP_OIDC_CLIENT_ID`            | ID of the client that has to be configured in tunnistamo.                                  |
+| `REACT_APP_OIDC_SCOPE`                | Which scopes the app requires.                                                             |
+| `REACT_APP_PROFILE_AUDIENCE`          | Name of the api-token that client uses profile-api with.                                   |
+| `REACT_APP_PROFILE_BE_GDPR_CLIENT_ID` | Client id used when getting gdpr authentication token for connected services               |
+| `REACT_APP_PROFILE_GRAPHQL`           | URL to the profile graphql.                                                                |
+| `REACT_APP_SENTRY_DSN`                | Sentry public dns-key.                                                                     |
+| `REACT_APP_OIDC_RESPONSE_TYPE`        | Which response type to require.                                                            |
+| `REACT_APP_KEYCLOAK_GDPR_CLIENT_ID`   | Client id for getting auth codes from keycloak                                             |
+| `REACT_APP_KEYCLOAK_AUTHORITY`        | Url to Keycloak. The openid config is fetched from this url                                |
 
 ## Setting up local development environment with Docker
 

--- a/src/common/test/userMocking.ts
+++ b/src/common/test/userMocking.ts
@@ -13,7 +13,7 @@ export function mockProfileCreator(
   overrides?: MockedUserOverrides['profileOverrides']
 ): Profile {
   return {
-    amr: ['helusername-test'],
+    amr: ['helsinki_tunnus-test'],
     auth_time: 1593431180,
     email: 'email@email.com',
     email_verified: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const config = {
   environment: window._env_.REACT_APP_ENVIRONMENT,
   helsinkiAccountAMR: defaultTo(
     window._env_.REACT_APP_HELSINKI_ACCOUNT_AMR,
-    'helusername'
+    'helsinki_tunnus'
   ),
   oidcAuthority: window._env_.REACT_APP_OIDC_AUTHORITY,
   tunnistamoGdprClientId: window._env_.REACT_APP_PROFILE_BE_GDPR_CLIENT_ID,

--- a/src/profile/components/profileInformation/__tests__/AuthenticationProviderInformation.test.jsx
+++ b/src/profile/components/profileInformation/__tests__/AuthenticationProviderInformation.test.jsx
@@ -6,7 +6,7 @@ import AuthenticationProviderInformation from '../AuthenticationProviderInformat
 import { mockUserCreator } from '../../../../common/test/userMocking';
 
 let mockCurrentAmr;
-const helsinkiAccountAMR = 'helusername-test';
+const helsinkiAccountAMR = 'helsinki_tunnus-test';
 
 jest.mock('../../../../config', () => ({
   helsinkiAccountAMR,
@@ -29,7 +29,7 @@ describe('<AuthenticationProviderInformation /> ', () => {
     });
 
     afterAll(() => {
-      window._env_.REACT_APP_HELSINKI_ACCOUNT_AMR = 'helusername';
+      window._env_.REACT_APP_HELSINKI_ACCOUNT_AMR = 'helsinki_tunnus';
     });
 
     it('should render helsinki account information as expected based on config', () => {


### PR DESCRIPTION
`helusername` is deprecated and the new keycloak authentication uses `helsinki_tunnus` in tunnistamo (which Helsinki profile uses).

Refs: HP-2220