### PR TITLE
HP-2174 frontpage updates

### DIFF
--- a/src/auth/components/login/Login.module.css
+++ b/src/auth/components/login/Login.module.css
@@ -16,14 +16,17 @@
   padding-bottom: var(--spacing-layout-l);
 }
 
-button.button {
-  margin-top: var(--spacing-layout-m);
-}
-
 .content h1 {
   margin-top: var(--spacing-layout-m);
   margin-bottom: 0;
-  line-height: var(--lineheight-s);;
+  line-height: var(--lineheight-s);
+}
+
+@media (max-width: 767.98px) {
+  .content h1 {
+    margin-top: var(--spacing-layout-xs);
+    font-size: 2rem;
+  }
 }
 
 .ingress {
@@ -31,4 +34,12 @@ button.button {
   margin-bottom: var(--spacing-layout-m);
   line-height: var(--lineheight-l);
   font-size: var(--fontsize-body-l);
+}
+
+@media (max-width: 767.98px) {
+  .ingress {
+    margin-top: var(--spacing-layout-xs);
+    margin-bottom: var(--spacing-layout-s);
+    font-size: var(--fontsize-body-s);
+  }
 }

--- a/src/common/footer/Footer.tsx
+++ b/src/common/footer/Footer.tsx
@@ -19,6 +19,7 @@ const Footer = () => {
     });
   };
 
+  const logoHref = `https://hel.fi/${lang}`;
   const whiteColor = 'var(--color-white)';
 
   return (
@@ -58,7 +59,7 @@ const Footer = () => {
             alt="Helsingin kaupunki"
           />
         }
-        logoHref="https://hel.fi"
+        logoHref={logoHref}
       >
         <HDSFooter.Link
           aria-label={createAriaLabel(t('footer.privacy'))}

--- a/src/common/header/Header.tsx
+++ b/src/common/header/Header.tsx
@@ -7,6 +7,7 @@ import {
   Logo,
   logoFi,
   logoSv,
+  LanguageSelectorProps,
 } from 'hds-react';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
@@ -71,6 +72,13 @@ function Header(): React.ReactElement {
     }
   };
 
+  // List all languages as primary languages
+  const sortLanguageOptions: LanguageSelectorProps['sortLanguageOptions'] = (
+    options: LanguageOption[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _activeLanguage
+  ) => [options, []];
+
   return (
     <HDSHeader
       onDidChangeLanguage={changeLanguageAction}
@@ -88,7 +96,8 @@ function Header(): React.ReactElement {
         logo={<Logo src={logoSrcFromLanguage} alt={t('helsinkiLogo')} />}
         frontPageLabel={t('nav.goToHomePage')}
       >
-        <HDSHeader.SimpleLanguageOptions languages={languageOptions} />
+        <HDSHeader.LanguageSelector sortLanguageOptions={sortLanguageOptions} />
+
         <hr aria-hidden="true" />
         <UserDropdown />
       </HDSHeader.ActionBar>

--- a/src/common/header/Header.tsx
+++ b/src/common/header/Header.tsx
@@ -74,9 +74,7 @@ function Header(): React.ReactElement {
 
   // List all languages as primary languages
   const sortLanguageOptions: LanguageSelectorProps['sortLanguageOptions'] = (
-    options: LanguageOption[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _activeLanguage
+    options: LanguageOption[]
   ) => [options, []];
 
   return (

--- a/src/common/helsinkiLogo/HelsinkiLogo.module.css
+++ b/src/common/helsinkiLogo/HelsinkiLogo.module.css
@@ -1,17 +1,29 @@
 .logo {
   background-color: var(--color-black);
   background-size: contain;
-  height: 60px;
+  height: 80px;
 }
 
 .logo-fi {
-  width: 130px;
+  width: 174.21px;
   -webkit-mask: url('../svg/HelsinkiLogoFi.svg') no-repeat;
   mask: url('../svg/HelsinkiLogoFi.svg') no-repeat;
 }
 
 .logo-sv {
-  width: 175px;
+  width: 230px;
   -webkit-mask: url('../svg/HelsinkiLogoSv.svg') no-repeat;
   mask: url('../svg/HelsinkiLogoSv.svg') no-repeat;
+}
+
+.logoWrapper {
+  margin-top: var(--spacing-layout-l);
+  height: 80px;
+}
+
+@media (max-width: 767.98px) {
+  .logoWrapper {
+    margin-top: var(--spacing-layout-s);
+    height: 65px;
+  }
 }

--- a/src/common/helsinkiLogo/HelsinkiLogo.tsx
+++ b/src/common/helsinkiLogo/HelsinkiLogo.tsx
@@ -1,32 +1,26 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
-import classNames from 'classnames';
+import { Logo, logoFi, logoSv } from 'hds-react';
 
 import styles from './HelsinkiLogo.module.css';
 import getLanguageCode from '../helpers/getLanguageCode';
 
-type Props = {
-  className?: string;
-  isLinkToFrontPage?: boolean;
-};
-function HelsinkiLogo({
-  className,
-  isLinkToFrontPage,
-}: Props): React.ReactElement {
+function HelsinkiLogo(): React.ReactElement {
   const { t, i18n } = useTranslation();
-
   const lang = getLanguageCode(i18n.languages[0]);
-  const logoStyle = lang === 'sv' ? styles['logo-sv'] : styles['logo-fi'];
+  const logoSrc = lang === 'sv' ? logoSv : logoFi;
+  const altText = t('helsinkiLogo');
 
-  const logoClassName = classNames(styles['logo'], logoStyle, className);
-  const titleAndAriaLabel = t('nav.titleAriaLabel');
-
-  if (isLinkToFrontPage) {
-    return <Link to="/" className={logoClassName} title={titleAndAriaLabel} />;
-  }
-
-  return <span className={logoClassName} aria-label={titleAndAriaLabel} />;
+  return (
+    <div className={styles.logoWrapper}>
+      <Logo
+        src={logoSrc}
+        size="full"
+        alt={altText}
+        data-testid={'helsinki-logo'}
+      />
+    </div>
+  );
 }
 
 export default HelsinkiLogo;

--- a/src/common/helsinkiLogo/__tests__/HelsinkiLogo.test.tsx
+++ b/src/common/helsinkiLogo/__tests__/HelsinkiLogo.test.tsx
@@ -1,34 +1,18 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, act } from '@testing-library/react';
 
 import i18n from '../../test/testi18nInit';
 import HelsinkiLogo from '../HelsinkiLogo';
 
-type Props = {
-  isLinkToFrontPage?: boolean;
-};
+it('language switch changes helsinki logo', async () => {
+  const { getByTestId } = render(<HelsinkiLogo />);
+  const fiSvg = getByTestId('helsinki-logo').getAttribute('src');
 
-const getWrapper = (props?: Props) => shallow(<HelsinkiLogo {...props} />);
-
-describe('renders correct logo based on language', () => {
-  it('finnish logo', () => {
-    const wrapper = getWrapper();
-    expect(wrapper.find('.logo-fi').length).toEqual(1);
-  });
-
-  it('swedish logo', () => {
+  act(() => {
+    // Change the language to swedish
     i18n.changeLanguage('sv');
-    const wrapper = getWrapper();
-    expect(wrapper.find('.logo-sv').length).toEqual(1);
   });
-});
 
-it('renders link', () => {
-  const wrapper = getWrapper({ isLinkToFrontPage: true });
-  expect(wrapper.props().to).toEqual('/');
-});
-
-it('renders span', () => {
-  const wrapper = getWrapper();
-  expect(wrapper.props().to).toBeFalsy();
+  // Check that the logo image source has changed (Helsinki to Helsingfors)
+  expect(getByTestId('helsinki-logo').getAttribute('src')).not.toBe(fiSvg);
 });


### PR DESCRIPTION

- Update the front page to look more like in the figma design
- Use HDS helsinki logo
- Switch header language menu from simple to normal (better mobile mode)

https://helsinkisolutionoffice.atlassian.net/browse/HP-2174

- Footer helsinki logo links now to sv/fi/en version depending on the selected language

https://helsinkisolutionoffice.atlassian.net/browse/HP-2060