### PR TITLE
HP-2254 Show verify email info for helsinki account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -24,7 +24,10 @@ import FocusKeeper from '../../../common/focusKeeper/FocusKeeper';
 import AccessibleFormikErrors from '../accessibleFormikErrors/AccessibleFormikErrors';
 import AccessibilityFieldHelpers from '../../../common/accessibilityFieldHelpers/AccessibilityFieldHelpers';
 import useProfile from '../../../auth/useProfile';
-import { hasTunnistusSuomiFiAmr } from '../profileInformation/authenticationProviderUtil';
+import {
+  hasHelsinkiAccountAMR,
+  hasTunnistusSuomiFiAmr,
+} from '../profileInformation/authenticationProviderUtil';
 import { useCommonEditHandling } from '../../hooks/useCommonEditHandling';
 import AddButton from '../addButton/AddButton';
 
@@ -55,7 +58,8 @@ function EmailEditor(): React.ReactElement | null {
   const formFields = getFormFields(dataType);
   const ariaLabels = createActionAriaLabels(dataType, email, t);
   const { profile } = useProfile();
-  const willSendEmailVerificationCode = hasTunnistusSuomiFiAmr(profile);
+  const willSendEmailVerificationCode =
+    hasTunnistusSuomiFiAmr(profile) || hasHelsinkiAccountAMR(profile);
   const { hasFieldError, getFieldErrorMessage } = createFormFieldHelpers<
     EmailValue
   >(t, true);

--- a/src/profile/components/profileInformation/authenticationProviderUtil.ts
+++ b/src/profile/components/profileInformation/authenticationProviderUtil.ts
@@ -39,3 +39,7 @@ export function getAmrStatic(profile: Profile | null): AMRStatic | null {
 export function hasTunnistusSuomiFiAmr(profile: Profile | null): boolean {
   return getAmrFromProfileData(profile) === tunnistusSuomifiAMR;
 }
+
+export function hasHelsinkiAccountAMR(profile: Profile | null): boolean {
+  return getAmrFromProfileData(profile) === config.helsinkiAccountAMR;
+}


### PR DESCRIPTION
When changing the email address using helsinki account there should be an info to verify the email. Similar as for suomi.fi account.

https://helsinkisolutionoffice.atlassian.net/browse/HP-2252

Also updated package.json version number. (that has been forgotten a few times now)