### PR TITLE
HP-2277 Update email change notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-city-profile-ui",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -182,13 +182,13 @@ function EmailEditor(): React.ReactElement | null {
           )}
         </div>
       </div>
-      {!showVerifyEmailInfo && (
-        <EditingNotifications content={content} dataType={dataType} />
-      )}
+
+      <EditingNotifications content={content} dataType={dataType} />
+
       {showVerifyEmailInfo && (
         <div className={styles['notification-wrapper']}>
           <Notification
-            type={'info'}
+            type={'alert'}
             label={t('profileInformation.verifyEmailTitle')}
             dataTestId={'verify-email-notification'}
           >


### PR DESCRIPTION

- Show both notifications (success & verify) when changing  suomifi or helsinki account email.
- Change the type of verify email to "alert" 
- Increased version number to keep track

https://helsinkisolutionoffice.atlassian.net/browse/HP-2277