### PR TITLE
fix: a11y service connections fix element focus on closing accordion HP-2307

### DIFF
--- a/src/common/test/testingLibraryTools.ts
+++ b/src/common/test/testingLibraryTools.ts
@@ -52,6 +52,9 @@ export type TestTools = RenderResult & {
   ) => Promise<string | undefined>;
   fetch: () => Promise<void>;
   clickElement: (selector: ElementSelector) => Promise<HTMLElement | null>;
+  keydownEnterElement: (
+    selector: ElementSelector
+  ) => Promise<HTMLElement | null>;
   submit: (props?: {
     waitForOnSaveNotification?: WaitForElementAndValueProps;
     waitForAfterSaveNotification?: WaitForElementAndValueProps;
@@ -241,6 +244,18 @@ export const renderComponentWithMocksAndContexts = async (
     return Promise.resolve(button);
   };
 
+  const keydownEnterElement: TestTools['keydownEnterElement'] = async selector => {
+    const button = getElement(selector);
+
+    await waitFor(() => {
+      fireEvent.keyDown(button as Element, {
+        key: 'Enter',
+        charCode: 13,
+      });
+    });
+    return Promise.resolve(button);
+  };
+
   const isDisabled: TestTools['isDisabled'] = element =>
     !!element && element.getAttribute('disabled') !== null;
 
@@ -349,6 +364,7 @@ export const renderComponentWithMocksAndContexts = async (
     getTextOrInputValue,
     fetch,
     clickElement,
+    keydownEnterElement,
     submit,
     isDisabled,
     setInputValue,

--- a/src/profile/components/serviceConnections/ServiceConnection.tsx
+++ b/src/profile/components/serviceConnections/ServiceConnection.tsx
@@ -35,6 +35,7 @@ function ServiceConnection({
         title={service.title || ''}
         showInformationText
         initiallyOpen={isActive}
+        dataTestId={encodedServiceName}
       >
         <p>{service.description}</p>
         <div

--- a/src/profile/components/serviceConnections/__tests__/ServiceConnection.test.tsx
+++ b/src/profile/components/serviceConnections/__tests__/ServiceConnection.test.tsx
@@ -47,6 +47,12 @@ describe('<ServiceConnection /> ', () => {
     querySelector: `button[title="${service.title}"]`,
   });
 
+  const getSecondaryExpandableSelector = (
+    service: ServiceConnectionData
+  ): ElementSelector => ({
+    testId: `${encodeServiceName(service)}-secondary-toggle-button`,
+  });
+
   const TestingComponent = ({
     service,
     isActive,
@@ -132,6 +138,58 @@ describe('<ServiceConnection /> ', () => {
       await waitForElement(
         getServiceInformationSelector(defaultServiceConnectionData)
       );
+    });
+  });
+  it(`Clicking secondary close button should close accordion and focus on primary button`, async () => {
+    await act(async () => {
+      const { clickElement, waitForElement, getElement } = await initTests(
+        defaultServiceConnectionData,
+        true
+      );
+
+      await waitForElement(
+        getServiceInformationSelector(defaultServiceConnectionData)
+      );
+      await waitForElement(
+        getSecondaryExpandableSelector(defaultServiceConnectionData)
+      );
+
+      await clickElement(
+        getSecondaryExpandableSelector(defaultServiceConnectionData)
+      );
+
+      await waitFor(async () => {
+        expect(
+          getElement(getExpandableSelector(defaultServiceConnectionData))
+        ).toHaveFocus();
+      });
+    });
+  });
+
+  it(`Keydown on secondary close button should close accordion and focus on primary button`, async () => {
+    await act(async () => {
+      const {
+        keydownEnterElement,
+        waitForElement,
+        getElement,
+      } = await initTests(defaultServiceConnectionData, true);
+
+      await waitForElement(
+        getServiceInformationSelector(defaultServiceConnectionData)
+      );
+      await waitForElement(
+        getSecondaryExpandableSelector(defaultServiceConnectionData)
+      );
+
+      await keydownEnterElement(
+        getSecondaryExpandableSelector(defaultServiceConnectionData)
+      );
+
+      await waitFor(async () => {
+        expect(
+          getElement(getExpandableSelector(defaultServiceConnectionData))
+        ).toHaveFocus();
+      });
     });
   });
   it(`Clicking the remove button calls the onDeletion() with service data`, async () => {


### PR DESCRIPTION
Closing service connection accordion from inside the accordion button loses focus upon closing. Fixing by moving focus to primary toggle button upon closing.

https://helsinkisolutionoffice.atlassian.net/browse/HP-2307

![hp-2307](https://github.com/City-of-Helsinki/open-city-profile-ui/assets/66477579/5b13895f-e6d4-4d94-8f85-6c34ef34cdee)