### PR TITLE
HP-2344 | feat: update max length of name fields

### DIFF
--- a/src/profile/helpers/formProperties.ts
+++ b/src/profile/helpers/formProperties.ts
@@ -41,17 +41,17 @@ export const formFieldsByDataType: FormFieldsByDataType = {
   'basic-data': {
     firstName: {
       required: true,
-      max: 255,
+      max: 150,
       translationKey: 'profileForm.firstName',
     },
     nickname: {
       required: false,
-      max: 64,
+      max: 32,
       translationKey: 'profileForm.nickname',
     },
     lastName: {
       required: true,
-      max: 255,
+      max: 150,
       translationKey: 'profileForm.lastName',
     },
   },


### PR DESCRIPTION
First and last name need to be limited to 150. Name information is also updated to keycloak by the backend. Updating longer values will work, but unfortunately backend will only support tokens with name fields limited to 150. So upon the next login the API token will not be accepted by the backend anymore since the `User` object will be updated based on the information in the token.

Nickname only allows 32 characters.

Refs: HP-2344