### PR TITLE
feat: profile data hide empty values from screenreaders HP-2309

### DIFF
--- a/src/common/labeledValue/LabeledValue.tsx
+++ b/src/common/labeledValue/LabeledValue.tsx
@@ -12,8 +12,9 @@ type Props = {
 function LabeledValue({ label, value, testId }: Props): React.ReactElement {
   const labelTestId = testId ? { 'data-testid': `${testId}-label` } : null;
   const valueTestId = testId ? { 'data-testid': `${testId}-value` } : null;
+
   return (
-    <div className={styles['wrapper']}>
+    <div className={styles['wrapper']} {...(!value && { 'aria-hidden': true })}>
       <strong className={styles['label']} {...labelTestId}>
         {label}
       </strong>

--- a/src/profile/components/basicData/__tests__/BasicData.test.tsx
+++ b/src/profile/components/basicData/__tests__/BasicData.test.tsx
@@ -103,8 +103,10 @@ describe('<BasicData /> ', () => {
     });
   };
 
-  const initTests = async (): Promise<TestTools> => {
-    responses.push({ profileData: initialProfile });
+  const initTests = async (
+    profileData = initialProfile
+  ): Promise<TestTools> => {
+    responses.push({ profileData });
     const testTools = await renderTestSuite();
     await testTools.fetch();
     return Promise.resolve(testTools);
@@ -204,6 +206,19 @@ describe('<BasicData /> ', () => {
         },
         testRuns
       );
+    });
+  });
+
+  it('empty value should have aria-hidden true in parent', async () => {
+    await act(async () => {
+      const testTools = await initTests({ ...initialProfile, nickname: '' });
+      const { findByTestId } = testTools;
+
+      expect(
+        (
+          await findByTestId(`${basicDataType}-nickname-label`)
+        ).parentElement?.getAttribute('aria-hidden')
+      ).toEqual('true');
     });
   });
 });


### PR DESCRIPTION
Hide columns from screen readers in occasion where optional input value can be empty.