### PR TITLE
fix: parseGraphQLError default HP-2435

### DIFF
--- a/src/gdprApi/actions/__tests__/deleteProfile.test.ts
+++ b/src/gdprApi/actions/__tests__/deleteProfile.test.ts
@@ -12,12 +12,9 @@ import {
   createDeleteProfileAction,
   deleteProfileType,
   getDeleteProfileResultOrError,
-  isInsufficientLoaResult,
 } from '../deleteProfile';
 import { getDeleteMyProfileMutationResult } from '../../../common/test/getDeleteMyProfileMutationResult';
 import { DeleteResultLists } from '../../../profile/helpers/parseDeleteProfileResult';
-
-type ActionResults = ReturnType<typeof getDeleteProfileResultOrError>;
 
 describe('deleteProfile.ts', () => {
   const queryTracker = vi.fn();
@@ -29,14 +26,12 @@ describe('deleteProfile.ts', () => {
     returnFailed,
     returnError,
     returnNoData,
-    returnInsufficientLoa,
   }: {
     noKeycloadAuthCode?: boolean;
     noTunnistamoAuthCode?: boolean;
     returnFailed?: boolean;
     returnError?: boolean;
     returnNoData?: boolean;
-    returnInsufficientLoa?: boolean;
   } = {}) => {
     fetchMock.mockIf(/.*\/graphql\/.*$/, async (req: Request) => {
       const payload = await req.json();
@@ -51,13 +46,6 @@ describe('deleteProfile.ts', () => {
         return Promise.reject({
           body: JSON.stringify({
             message: 'Error',
-          }),
-        });
-      }
-      if (returnInsufficientLoa === true) {
-        return Promise.reject({
-          body: JSON.stringify({
-            message: 'insufficientLoa',
           }),
         });
       }
@@ -163,19 +151,6 @@ describe('deleteProfile.ts', () => {
       );
       expect(result).toBeUndefined();
       expect(!!error).toBeTruthy();
-    });
-    it('Insufficient loa returns error', async () => {
-      const { runner, getAction } = initTests({
-        returnInsufficientLoa: true,
-        returnNoData: true,
-      });
-      const [errorMessage] = await to(
-        getAction().executor(getAction(), runner)
-      );
-
-      expect(
-        isInsufficientLoaResult(({ errorMessage } as unknown) as ActionResults)
-      ).toBeTruthy();
     });
     it('Result should not be stored to sessionStorage', async () => {
       const { getAction } = initTests();

--- a/src/gdprApi/actions/__tests__/deleteServiceConnection.test.ts
+++ b/src/gdprApi/actions/__tests__/deleteServiceConnection.test.ts
@@ -14,7 +14,6 @@ import {
   deleteServiceConnectionType,
   getDeleteServiceConnectionResultOrError,
   isForbiddenResult,
-  isInsufficientLoaResult,
   isSuccessResult,
 } from '../deleteServiceConnection';
 
@@ -30,14 +29,12 @@ describe('deleteServiceConnection.ts', () => {
     returnForbidden,
     returnError,
     returnNoData,
-    returnInsufficientLoa,
   }: {
     noKeycloadAuthCode?: boolean;
     noTunnistamoAuthCode?: boolean;
     returnForbidden?: boolean;
     returnError?: boolean;
     returnNoData?: boolean;
-    returnInsufficientLoa?: boolean;
   } = {}) => {
     fetchMock.mockIf(/.*\/graphql\/.*$/, async (req: Request) => {
       const payload = await req.json();
@@ -56,13 +53,6 @@ describe('deleteServiceConnection.ts', () => {
         return Promise.reject({
           body: JSON.stringify({
             message: 'Error',
-          }),
-        });
-      }
-      if (returnInsufficientLoa === true) {
-        return Promise.reject({
-          body: JSON.stringify({
-            message: 'insufficientLoa',
           }),
         });
       }
@@ -172,19 +162,6 @@ describe('deleteServiceConnection.ts', () => {
         isForbiddenResult(({ errorMessage } as unknown) as ActionResults)
       ).toBeFalsy();
       expect(isSuccessResult({ result } as ActionResults)).toBeFalsy();
-    });
-    it('Insufficient loa returns error', async () => {
-      const { runner, getAction } = initTests({
-        returnInsufficientLoa: true,
-        returnNoData: true,
-      });
-      const [errorMessage] = await to(
-        getAction().executor(getAction(), runner)
-      );
-
-      expect(
-        isInsufficientLoaResult(({ errorMessage } as unknown) as ActionResults)
-      ).toBeTruthy();
     });
     it('Result should not be stored to sessionStorage', async () => {
       const { getAction } = initTests();

--- a/src/gdprApi/actions/__tests__/getDownloadData.test.ts
+++ b/src/gdprApi/actions/__tests__/getDownloadData.test.ts
@@ -4,7 +4,6 @@ import { waitFor } from '@testing-library/react';
 import {
   getDownloadDataAction,
   getDownloadDataResultOrError,
-  isInsufficientLoaResult,
 } from '../getDownloadData';
 import { createActionQueueRunner } from '../../../common/actionQueue/actionQueueRunner';
 import { Action, getOption } from '../../../common/actionQueue/actionQueue';
@@ -13,8 +12,6 @@ import {
   keycloakAuthCodeParserAction,
 } from '../authCodeParser';
 import { getMockCalls } from '../../../common/test/mockHelper';
-
-type ActionResults = ReturnType<typeof getDownloadDataResultOrError>;
 
 describe('getDownloadData.ts', () => {
   const queryTracker = vi.fn();
@@ -25,13 +22,11 @@ describe('getDownloadData.ts', () => {
     noKeycloadAuthCode,
     returnNoData,
     returnError,
-    returnInsufficientLoa,
   }: {
     noKeycloadAuthCode?: boolean;
     noTunnistamoAuthCode?: boolean;
     returnNoData?: boolean;
     returnError?: boolean;
-    returnInsufficientLoa?: boolean;
   } = {}) => {
     fetchMock.mockIf(/.*\/graphql\/.*$/, async (req: Request) => {
       const payload = await req.json();
@@ -46,13 +41,6 @@ describe('getDownloadData.ts', () => {
         return Promise.reject({
           body: JSON.stringify({
             message: 'Error',
-          }),
-        });
-      }
-      if (returnInsufficientLoa === true) {
-        return Promise.reject({
-          body: JSON.stringify({
-            message: 'insufficientLoa',
           }),
         });
       }
@@ -127,21 +115,6 @@ describe('getDownloadData.ts', () => {
       const { runner, getAction } = initTests({ returnError: true });
       const [error] = await to(getAction().executor(getAction(), runner));
       expect(error).toBeDefined();
-    });
-    it('Insufficient loa returns error', async () => {
-      const { runner, getAction } = initTests({
-        returnInsufficientLoa: true,
-        returnNoData: true,
-      });
-      const [errorMessage] = await to(
-        getAction().executor(getAction(), runner)
-      );
-
-      expect(
-        isInsufficientLoaResult(({
-          errorMessage,
-        } as unknown) as ActionResults)
-      ).toBeTruthy();
     });
     it('Result should not be stored to sessionStorage', async () => {
       const { getAction } = initTests();

--- a/src/profile/helpers/__tests__/parseGraphQLError.test.ts
+++ b/src/profile/helpers/__tests__/parseGraphQLError.test.ts
@@ -1,0 +1,66 @@
+import { ApolloError } from '@apollo/client';
+
+import parseGraphQLError from '../parseGraphQLError';
+
+describe('parseGraphQLError', () => {
+  it('should return isAllowedError true and isInsufficientLoaError false when error is permission denied', () => {
+    const error: ApolloError = new ApolloError({
+      graphQLErrors: [
+        {
+          extensions: {
+            code: 'PERMISSION_DENIED_ERROR',
+          },
+          path: ['myProfile', 'verifiedPersonalInformation'],
+          locations: undefined,
+          nodes: undefined,
+          source: undefined,
+          positions: undefined,
+          originalError: undefined,
+          name: '',
+          message: '',
+        },
+      ],
+    });
+
+    const result = parseGraphQLError(error);
+
+    expect(result.isAllowedError).toBe(true);
+    expect(result.isInsufficientLoaError).toBe(false);
+  });
+
+  it('should return isAllowedError false and isInsufficientLoaError true when error is insufficient loa', () => {
+    const error: ApolloError = new ApolloError({
+      graphQLErrors: [
+        {
+          extensions: {
+            code: 'INSUFFICIENT_LOA_ERROR',
+          },
+          locations: undefined,
+          path: undefined,
+          nodes: undefined,
+          source: undefined,
+          positions: undefined,
+          originalError: undefined,
+          name: '',
+          message: '',
+        },
+      ],
+    });
+
+    const result = parseGraphQLError(error);
+
+    expect(result.isAllowedError).toBe(false);
+    expect(result.isInsufficientLoaError).toBe(true);
+  });
+
+  it('should return isAllowedError false and isInsufficientLoaError false as a default', () => {
+    const error: ApolloError = new ApolloError({
+      graphQLErrors: [],
+    });
+
+    const result = parseGraphQLError(error);
+
+    expect(result.isAllowedError).toBe(false);
+    expect(result.isInsufficientLoaError).toBe(false);
+  });
+});

--- a/src/profile/helpers/parseGraphQLError.ts
+++ b/src/profile/helpers/parseGraphQLError.ts
@@ -24,7 +24,7 @@ function parseGraphQLError(error: ApolloError | Error): ParsingResult {
     return { isAllowedError: false, isInsufficientLoaError: true };
   }
 
-  return { isAllowedError: false, isInsufficientLoaError: true };
+  return { isAllowedError: false, isInsufficientLoaError: false };
 }
 
 export default parseGraphQLError;


### PR DESCRIPTION
- `parseGraphQLError` should return `isAllowedError` and `isInsufficientLoaError` as false by default.
- Removed loa tests from actions and instead created tests for `parseGraphQLError`