### PR TITLE
feat: remove all adresses/phonenumbers when one is removed HP-2338

### DIFF
--- a/src/profile/helpers/editData.ts
+++ b/src/profile/helpers/editData.ts
@@ -324,12 +324,10 @@ function setAllItemsToRemoveAndCloneList(
     throw new Error('Item not found in updateAllItemsAndCloneList() ');
   }
 
-  const newList = _.cloneDeep(allItems).map(element => ({
+  return _.cloneDeep(allItems).map(element => ({
     ...element,
     saving: 'remove' as SaveType,
   }));
-
-  return newList;
 }
 
 function createFormValues(

--- a/src/profile/helpers/editData.ts
+++ b/src/profile/helpers/editData.ts
@@ -315,6 +315,23 @@ function updateItemAndCloneList(
   return newList;
 }
 
+function setAllItemsToRemoveAndCloneList(
+  allItems: EditData[],
+  item: EditData
+): EditData[] {
+  const index = findItemIndex(allItems, item.id);
+  if (index < 0) {
+    throw new Error('Item not found in updateAllItemsAndCloneList() ');
+  }
+
+  const newList = _.cloneDeep(allItems).map(element => ({
+    ...element,
+    saving: 'remove' as SaveType,
+  }));
+
+  return newList;
+}
+
 function createFormValues(
   allItems: EditData[],
   dataType: EditDataType,
@@ -674,12 +691,8 @@ export function createEditorForDataType(
         allItems = clone;
         return null;
       }
-      allItems = updateItemAndCloneList(
-        allItems,
-        targetItem,
-        targetItem.value,
-        'remove'
-      );
+      // Remove all items from list because there can be only one address or phone number
+      allItems = setAllItemsToRemoveAndCloneList(allItems, targetItem);
       return createFormValues(allItems, dataType);
     },
     setPrimary: targetRef => {


### PR DESCRIPTION

Remove all addresses if one is removed. This is to clean up situations where user has multiple addresses (legacy).  
Same for phone numbers. Would also affect email, but it's not possible to remove email from ui.

Before this change if user has multiple addresses removing the address would just change it to the next one in line.

Can be tested by adding multiple addresses and phone numbers in django admin view.

https://helsinkisolutionoffice.atlassian.net/browse/HP-2338