### PR TITLE
fix: e2e tests navigation

### DIFF
--- a/e2e/tests/create-profile.spec.ts
+++ b/e2e/tests/create-profile.spec.ts
@@ -26,7 +26,9 @@ test('Same email address cannot be used for multiple accounts', async ({
   await newPage.goto(PROFILE_URL);
   await clickLoginButton(newPage);
   await newPage.locator('.login-method-helsinki_tunnus a').click();
-  await newPage.locator('a:text("Luo Helsinki-profiili")').click();
+  await newPage
+    .locator('a.hds-button:has-text("Luo Helsinki-profiili")')
+    .click();
   await newPage
     .getByPlaceholder('sähköpostiosoite@email.com')
     .fill(mailbox.emailAddress);

--- a/e2e/utils/utils.ts
+++ b/e2e/utils/utils.ts
@@ -23,7 +23,8 @@ export const clickLoginButton = async (page: Page) => {
 
 export const clickServiceConnectionsLink = async (page: Page) => {
   await page
-    .getByRole('link', { name: 'Käyttämäsi palvelut', exact: true })
+    .getByRole('navigation')
+    .getByRole('link', { name: 'Käyttämäsi palvelut' })
     .click();
 };
 
@@ -92,7 +93,7 @@ export const createProfile = async (page: Page, mailbox: Mailbox) => {
   await page.goto(PROFILE_URL);
   await clickLoginButton(page);
   await page.locator('.login-method-helsinki_tunnus a').click();
-  await page.locator('a:text("Luo Helsinki-profiili")').click();
+  await page.locator('a.hds-button:has-text("Luo Helsinki-profiili")').click();
   await page
     .getByPlaceholder('sähköpostiosoite@email.com')
     .fill(mailbox.emailAddress);


### PR DESCRIPTION
Fix two issues in playwright tests
- Keycloak ui was changed so that there are two links in login page with text "Luo helsinki-profiili" and playwright gets confused
- Similar error in profile page with two "Käyttämäsi palvelut" links. It's a bit mystery how this has worked before.