### PR TITLE
fix: remove incorrect html tags from user guide HP-2656

### DIFF
--- a/src/userGuide/UserGuideEn.tsx
+++ b/src/userGuide/UserGuideEn.tsx
@@ -104,19 +104,15 @@ function UserGuideEn(): ReactElement {
           another.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image001}
-            alt="In the authentication window, select Suomi.fi identification."
-          />
-        </p>
+        <UserGuideImage
+          src={image001}
+          alt="In the authentication window, select Suomi.fi identification."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image002}
-            alt="In the authentication window, select Suomi.fi identification."
-          />
-        </p>
+        <UserGuideImage
+          src={image002}
+          alt="In the authentication window, select Suomi.fi identification."
+        />
 
         <h4>Identification in the Suomi.fi service</h4>
 
@@ -137,12 +133,10 @@ function UserGuideEn(): ReactElement {
           alt="Choose your bank or mobile account as your Suomi.fi authentication option."
         />
 
-        <p>
-          <UserGuideImage
-            src={image004}
-            alt="Check that your details are correct when you switch back to the City of Helsinki service."
-          />
-        </p>
+        <UserGuideImage
+          src={image004}
+          alt="Check that your details are correct when you switch back to the City of Helsinki service."
+        />
 
         <h4>Email address verification</h4>
 
@@ -178,14 +172,12 @@ function UserGuideEn(): ReactElement {
           </b>
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image005}
-            alt={`Your email address will serve as your login to City of Helsinki services.
+        <UserGuideImage
+          src={image005}
+          alt={`Your email address will serve as your login to City of Helsinki services.
             By using the same email address for both the Suomi.fi login and the Helsinki ID,
             you will have one Helsinki profile. The merge cannot be unmerged later.`}
-          />
-        </p>
+        />
 
         <UserGuideImage
           src={image006}
@@ -243,12 +235,10 @@ function UserGuideEn(): ReactElement {
           another.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image009}
-            alt={`The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button.`}
-          />
-        </p>
+        <UserGuideImage
+          src={image009}
+          alt={`The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button.`}
+        />
 
         <h4>Email address verification</h4>
         <p>
@@ -288,14 +278,12 @@ function UserGuideEn(): ReactElement {
           </b>
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image005}
-            alt={`Your email address will serve as your login to City of Helsinki services.
+        <UserGuideImage
+          src={image005}
+          alt={`Your email address will serve as your login to City of Helsinki services.
             By using the same email address for both the Suomi.fi login and the Helsinki ID,
             you will have one Helsinki profile. The merge cannot be unmerged later.`}
-          />
-        </p>
+        />
 
         <UserGuideImage
           src={image006}
@@ -324,14 +312,12 @@ function UserGuideEn(): ReactElement {
           password combination.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image010}
-            alt={`When you create a Helsinki profile, you still have to fill in
+        <UserGuideImage
+          src={image010}
+          alt={`When you create a Helsinki profile, you still have to fill in
             your name and password. You will also need to give your consent
             for your data to be used in order to create Helsinki profile.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         id="_Combining_identification_methods"
@@ -376,7 +362,7 @@ function UserGuideEn(): ReactElement {
       >
         <p>
           If you can&apos;t remember your password, you can create a new one in
-          the login window using the <i>I forgot my password</i>
+          the login window using the <i>I forgot my password </i>
           link. You may also have &quot;forgotten&quot; your password because
           you have previously logged in to the service using Suomi.fi, in which
           case you didn&apos;t have to create a password.
@@ -396,33 +382,29 @@ function UserGuideEn(): ReactElement {
           src={image011}
           alt="In the login window, click on the I forgot my password link."
         />
-        <p>
-          <UserGuideImage
-            src={image012}
-            alt="Enter your email address in the box that appears to receive a password renewal link in your email."
-          />
-        </p>
+
+        <UserGuideImage
+          src={image012}
+          alt="Enter your email address in the box that appears to receive a password renewal link in your email."
+        />
+
         <UserGuideImage
           src={image013}
           alt="You will be informed that an email will be sent to you to renew your password."
         />
 
-        <p>
-          <UserGuideImage
-            src={image014}
-            alt={`In the email you receive, there will be a link to enter a new password.
+        <UserGuideImage
+          src={image014}
+          alt={`In the email you receive, there will be a link to enter a new password.
             The link will be valid for 30 minutes.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image015}
-            alt={`In the update password window, you must enter the same password twice.
+        <UserGuideImage
+          src={image015}
+          alt={`In the update password window, you must enter the same password twice.
             The password must be at least 12 characters long. The password must contain
             both upper and lower case letters, numbers and special characters.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -440,22 +422,18 @@ function UserGuideEn(): ReactElement {
           different authentication methods cannot be open at the same time.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image016}
-            alt={`An incompatible login method means, for example, that you have logged
+        <UserGuideImage
+          src={image016}
+          alt={`An incompatible login method means, for example, that you have logged
             in to one service with an email/password combination and you have moved on to
             the next service, which requires a Suomi.fi authentication. In this case,
             you need to log out of the first service in order to authenticate to the new service.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image017}
-            alt="Confirm the logout from a previous service."
-          />
-        </p>
+        <UserGuideImage
+          src={image017}
+          alt="Confirm the logout from a previous service."
+        />
       </UserGuideAccordion>
 
       <h2 id="_viewing_and_editing">Viewing and editing your own data</h2>
@@ -495,30 +473,24 @@ function UserGuideEn(): ReactElement {
           Helsinki profile.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image018}
-            alt={`In the My Information section of the Helsinki profile, official information
+        <UserGuideImage
+          src={image018}
+          alt={`In the My Information section of the Helsinki profile, official information
             comes directly from the Population Register Centre and is updated there as well.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image019}
-            alt="In the My information section of your Helsinki profile, you can update the basic data yourself."
-          />
-        </p>
+        <UserGuideImage
+          src={image019}
+          alt="In the My information section of your Helsinki profile, you can update the basic data yourself."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image023}
-            alt={`You can add and edit your other address details, your phone number and your email address. The
+        <UserGuideImage
+          src={image023}
+          alt={`You can add and edit your other address details, your phone number and your email address. The
             language of communication determines the language in which you receive messages from the service.
             The authentication method tells you how you are logged in to the service, i.e. Suomi.fi authentication
             or an email/password combination, i.e. the Helsinki ID.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -542,22 +514,18 @@ function UserGuideEn(): ReactElement {
           before deleting it.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image024}
-            alt={`When you authenticate to the new service, you will be asked to
+        <UserGuideImage
+          src={image024}
+          alt={`When you authenticate to the new service, you will be asked to
             consent to the use of your data required by the service. You can return to this information later on the Your services section of your Helsinki profile.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image025}
-            alt={`In the Your services used section of your Helsinki profile, you can
+        <UserGuideImage
+          src={image025}
+          alt={`In the Your services used section of your Helsinki profile, you can
             see all the services you are authenticated to and what data they use.
             You can also delete your data from individual services.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -578,13 +546,12 @@ function UserGuideEn(): ReactElement {
           / password login in the same Helsinki profile, the data download must
           be done with the Suomi.fi authentication.
         </p>
-        <p>
-          <UserGuideImage
-            src={image026}
-            alt={`In the My information section of your Helsinki profile,
+
+        <UserGuideImage
+          src={image026}
+          alt={`In the My information section of your Helsinki profile,
             you can download your data for all services as a JSON file.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
 
       <h2 id="_Deleting_your_information">Deleting your information</h2>
@@ -611,20 +578,18 @@ function UserGuideEn(): ReactElement {
           When you select the service, you want to delete on the Your services
           tab, you will receive a pop-up message confirming the deletion.
         </p>
-        <p>
-          <UserGuideImage
-            src={image027}
-            alt={`You can delete your data in your Helsinki profile for an individual
+
+        <UserGuideImage
+          src={image027}
+          alt={`You can delete your data in your Helsinki profile for an individual
             service in the Your services section.`}
-          />
-        </p>
-        <p>
-          <UserGuideImage
-            src={image028}
-            alt={`After clicking on the "Delete your data from this service" button, you will
+        />
+
+        <UserGuideImage
+          src={image028}
+          alt={`After clicking on the "Delete your data from this service" button, you will
             receive a pop-up confirmation message on the screen to prevent accidental deletion.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
 
       <UserGuideAccordion
@@ -663,13 +628,12 @@ function UserGuideEn(): ReactElement {
             information button that allows you to delete your entire Helsinki profile
              and your information used in different services.`}
         />
-        <p>
-          <UserGuideImage
-            src={image030}
-            alt={`A confirmation message is also displayed in a pop-up window
+
+        <UserGuideImage
+          src={image030}
+          alt={`A confirmation message is also displayed in a pop-up window
             to prevent accidental deletion of the data.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
     </Fragment>
   );

--- a/src/userGuide/UserGuideFi.tsx
+++ b/src/userGuide/UserGuideFi.tsx
@@ -103,19 +103,15 @@ function UserGuideFi(): ReactElement {
           Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image001}
-            alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
-          />
-        </p>
+        <UserGuideImage
+          src={image001}
+          alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image002}
-            alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
-          />
-        </p>
+        <UserGuideImage
+          src={image002}
+          alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
+        />
 
         <h4>Tunnistautuminen Suomi.fi-palvelussa</h4>
 
@@ -131,19 +127,15 @@ function UserGuideFi(): ReactElement {
           väestörekisterikeskuksen palvelussa.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image003}
-            alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
-          />
-        </p>
+        <UserGuideImage
+          src={image003}
+          alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image004}
-            alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
-          />
-        </p>
+        <UserGuideImage
+          src={image004}
+          alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
+        />
 
         <h4>Sähköpostiosoitteen vahvistus</h4>
         <p>
@@ -175,23 +167,17 @@ function UserGuideFi(): ReactElement {
           </b>
         </p>
 
-        <p>
-          <UserGuideImage src={image005} alt={altText05} />
-        </p>
+        <UserGuideImage src={image005} alt={altText05} />
 
-        <p>
-          <UserGuideImage
-            src={image006}
-            alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
-          />
-        </p>
+        <UserGuideImage
+          src={image006}
+          alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image007}
-            alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
-          />
-        </p>
+        <UserGuideImage
+          src={image007}
+          alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+        />
 
         <h4>Helsinki-profiilin luonti</h4>
 
@@ -221,12 +207,11 @@ function UserGuideFi(): ReactElement {
           Kun kirjaudut seuraavan kerran samaan palveluun, valitse
           tunnistautumisvaihtoehdoksi Suomi.fi.
         </p>
-        <p>
-          <UserGuideImage
-            src={image008}
-            alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
-          />
-        </p>
+
+        <UserGuideImage
+          src={image008}
+          alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -240,12 +225,11 @@ function UserGuideFi(): ReactElement {
           Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image009}
-            alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
-          />
-        </p>
+        <UserGuideImage
+          src={image009}
+          alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
+        />
+
         <h4>Sähköpostiosoitteen vahvistus</h4>
         <p>
           Profiilin luomisen yhteydessä sinulta pyydetään sähköpostiosoite, joka
@@ -274,22 +258,19 @@ function UserGuideFi(): ReactElement {
             keskeyttäneen tunnistautumisprosessin.
           </b>
         </p>
-        <p>
-          <UserGuideImage src={image005} alt={altText05} />
-        </p>
-        <p>
-          <UserGuideImage
-            src={image006}
-            alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
-          />
-        </p>
 
-        <p>
-          <UserGuideImage
-            src={image007}
-            alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
-          />
-        </p>
+        <UserGuideImage src={image005} alt={altText05} />
+
+        <UserGuideImage
+          src={image006}
+          alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+        />
+
+        <UserGuideImage
+          src={image007}
+          alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+        />
+
         <h4>Helsinki-profiilin luonti</h4>
         <p>
           Sähköpostin vahvistamisen jälkeen täytä nimitietosi ja anna salasana.
@@ -306,13 +287,12 @@ function UserGuideFi(): ReactElement {
           tarvitsemasi Helsinki-tunnus on tämä
           sähköpostiosoite-salasana-yhdistelmä.
         </p>
-        <p>
-          <UserGuideImage
-            src={image010}
-            alt={`Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+
+        <UserGuideImage
+          src={image010}
+          alt={`Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
             salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -365,40 +345,31 @@ function UserGuideFi(): ReactElement {
           sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image011}
-            alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
-          />
-        </p>
-        <p>
-          <UserGuideImage
-            src={image012}
-            alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
-          />
-        </p>
+        <UserGuideImage
+          src={image011}
+          alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image013}
-            alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
-          />
-        </p>
+        <UserGuideImage
+          src={image012}
+          alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image014}
-            alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
-          />
-        </p>
+        <UserGuideImage
+          src={image013}
+          alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image015}
-            alt={`Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+        <UserGuideImage
+          src={image014}
+          alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
+        />
+
+        <UserGuideImage
+          src={image015}
+          alt={`Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
             vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -416,19 +387,15 @@ function UserGuideFi(): ReactElement {
           avoinna.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image016}
-            alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
-          />
-        </p>
+        <UserGuideImage
+          src={image016}
+          alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image017}
-            alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
-          />
-        </p>
+        <UserGuideImage
+          src={image017}
+          alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
+        />
       </UserGuideAccordion>
       <h2 id="_Omien_tietojen_katselu">
         Omien tietojen katselu ja muokkaaminen
@@ -471,19 +438,16 @@ function UserGuideFi(): ReactElement {
           src={image018}
           alt="Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä."
         />
-        <p>
-          <UserGuideImage
-            src={image019}
-            alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
-          />
-        </p>
 
-        <p>
-          <UserGuideImage
-            src={image023}
-            alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
-          />
-        </p>
+        <UserGuideImage
+          src={image019}
+          alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
+        />
+
+        <UserGuideImage
+          src={image023}
+          alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -504,21 +468,17 @@ function UserGuideFi(): ReactElement {
           poistoa.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image024}
-            alt={`Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+        <UserGuideImage
+          src={image024}
+          alt={`Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
             Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image025}
-            alt={`Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+        <UserGuideImage
+          src={image025}
+          alt={`Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
             tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -534,13 +494,11 @@ function UserGuideFi(): ReactElement {
           . Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja
           sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin,
           tietojen lataus pitää tehdä Suomi.fi-tunnistautuneena.
-          <p>
-            <UserGuideImage
-              src={image026}
-              alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
-            />
-          </p>
         </p>
+        <UserGuideImage
+          src={image026}
+          alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
+        />
       </UserGuideAccordion>
       <h2 id="_Tietojen_poisto">Tietojen poisto</h2>
       <p>
@@ -566,19 +524,15 @@ function UserGuideFi(): ReactElement {
           saat ponnahdusikkunaan vahvistusviestin poistosta.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image027}
-            alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
-          />
-        </p>
+        <UserGuideImage
+          src={image027}
+          alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image028}
-            alt='Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.'
-          />
-        </p>
+        <UserGuideImage
+          src={image028}
+          alt='Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.'
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -613,19 +567,15 @@ function UserGuideFi(): ReactElement {
           uuden profiilin, mutta kaikki aiemmat tiedot on menetetty.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image029}
-            alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
-          />
-        </p>
+        <UserGuideImage
+          src={image029}
+          alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image030}
-            alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
-          />
-        </p>
+        <UserGuideImage
+          src={image030}
+          alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
+        />
       </UserGuideAccordion>
     </Fragment>
   );

--- a/src/userGuide/UserGuideImage.tsx
+++ b/src/userGuide/UserGuideImage.tsx
@@ -9,10 +9,10 @@ interface ImageProps {
 
 function UserGuideImage({ src, alt }: ImageProps): React.ReactElement {
   return (
-    <p>
+    <div>
       <img src={src} alt={alt} loading="lazy" />
       <p className={styles['image-text']}>{alt}</p>
-    </p>
+    </div>
   );
 }
 

--- a/src/userGuide/UserGuideSv.tsx
+++ b/src/userGuide/UserGuideSv.tsx
@@ -108,18 +108,16 @@ function UserGuideSv(): ReactElement {
           med olika inloggningsalternativ, där inloggningen till Suomi.fi väljs.
           Visningen av inloggningsalternativen varierar från en tjänst till en
           annan.
-          <UserGuideImage
-            src={image001}
-            alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
-          />
         </p>
+        <UserGuideImage
+          src={image001}
+          alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image002}
-            alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
-          />
-        </p>
+        <UserGuideImage
+          src={image002}
+          alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+        />
 
         <h4>Identifiering i tjänsten Suomi.fi</h4>
 
@@ -135,19 +133,15 @@ function UserGuideSv(): ReactElement {
           Befolkningsregistercentralens tjänst.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image003}
-            alt="Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi."
-          />
-        </p>
+        <UserGuideImage
+          src={image003}
+          alt="Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image004}
-            alt="När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta."
-          />
-        </p>
+        <UserGuideImage
+          src={image004}
+          alt="När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta."
+        />
 
         <h4>Verifiering av e-postadress</h4>
 
@@ -181,28 +175,22 @@ function UserGuideSv(): ReactElement {
           </b>
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image005}
-            alt={`Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+        <UserGuideImage
+          src={image005}
+          alt={`Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
             använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
             Helsingfors-profil. Sammanslagningen kan inte tas bort senare.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image006}
-            alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
-          />
-        </p>
+        <UserGuideImage
+          src={image006}
+          alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image007}
-            alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
-          />
-        </p>
+        <UserGuideImage
+          src={image007}
+          alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+        />
 
         <h4>Skapa en Helsingforsprofilen</h4>
 
@@ -252,12 +240,11 @@ function UserGuideSv(): ReactElement {
           Visningen av inloggningsalternativen varierar från en tjänst till en
           annan.
         </p>
-        <p>
-          <UserGuideImage
-            src={image009}
-            alt="Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen."
-          />
-        </p>
+
+        <UserGuideImage
+          src={image009}
+          alt="Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen."
+        />
 
         <h4>Verifiering av e-postadress</h4>
 
@@ -298,28 +285,22 @@ function UserGuideSv(): ReactElement {
           </b>
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image005}
-            alt={`Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+        <UserGuideImage
+          src={image005}
+          alt={`Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
             använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
             Helsingfors-profil. Sammanslagningen kan inte tas bort senare.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image006}
-            alt={`E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.`}
-          />
-        </p>
+        <UserGuideImage
+          src={image006}
+          alt={`E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.`}
+        />
 
-        <p>
-          <UserGuideImage
-            src={image007}
-            alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
-          />
-        </p>
+        <UserGuideImage
+          src={image007}
+          alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+        />
 
         <h4>Skapa en Helsingforsprofilen</h4>
 
@@ -341,13 +322,11 @@ function UserGuideSv(): ReactElement {
           och lösenord.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image010}
-            alt={`När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
+        <UserGuideImage
+          src={image010}
+          alt={`När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
             också ge ditt samtycke till att dina uppgifter används för att skapa Helsingforsprofilen.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -370,7 +349,7 @@ function UserGuideSv(): ReactElement {
 
         <p>
           Om din Helsingforsprofil skapades med en Suomi.fi-autentisering kan du
-          klicka på länken <i>Jag har glömt mitt lösenord</i>
+          klicka på länken <i>Jag har glömt mitt lösenord </i>
           på inloggningsskärmen. För instruktioner om hur du gör detta, se
           avsnittet <a href="#_Glömt_lösenord">Glömt lösenord</a> nedan.
         </p>
@@ -411,35 +390,27 @@ function UserGuideSv(): ReactElement {
           alt="I inloggningsfönstret klickar du på länken Jag har glömt mitt lösenord."
         />
 
-        <p>
-          <UserGuideImage
-            src={image012}
-            alt="Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post."
-          />
-        </p>
+        <UserGuideImage
+          src={image012}
+          alt="Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image013}
-            alt="Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord."
-          />
-        </p>
+        <UserGuideImage
+          src={image013}
+          alt="Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image014}
-            alt={`I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
+        <UserGuideImage
+          src={image014}
+          alt={`I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
             kommer att vara giltig i 30 minuter.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image015}
-            alt={`I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
+        <UserGuideImage
+          src={image015}
+          alt={`I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
             12 tecken långt. Lösenordet måste innehålla både stora och små bokstäver, nummer och specialtecken.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -457,21 +428,17 @@ function UserGuideSv(): ReactElement {
           autentiseringsmetoder kan inte vara öppna samtidigt.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image016}
-            alt={`En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
+        <UserGuideImage
+          src={image016}
+          alt={`En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
             kombination av e-post och lösenord och går vidare till nästa tjänst, som kräver en Suomi.fi-autentisering. 
             I detta fall måste du logga ut från den första tjänsten för att kunna autentisera dig till den nya tjänsten.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image017}
-            alt="Bekräfta din utloggning från en tidigare tjänst."
-          />
-        </p>
+        <UserGuideImage
+          src={image017}
+          alt="Bekräfta din utloggning från en tidigare tjänst."
+        />
       </UserGuideAccordion>
 
       <h2 id="_viewing_and_editing">Visa och redigera dina egna uppgifter</h2>
@@ -513,30 +480,24 @@ function UserGuideSv(): ReactElement {
           hur du är autentiserad dig på din Helsingforsprofil.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image018}
-            alt={`I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
+        <UserGuideImage
+          src={image018}
+          alt={`I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
             Befolkningsregistercentralen och uppdateras också där.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image019}
-            alt="I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information."
-          />
-        </p>
+        <UserGuideImage
+          src={image019}
+          alt="I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image023}
-            alt={`Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
+        <UserGuideImage
+          src={image023}
+          alt={`Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
             Tjänstens kontaktspråk avgör på vilket språk du tar emot meddelanden från tjänsten. Den 
             autentiseringsmetoden hur du är inloggad i tjänsten, dvs. Suomi.fi-autentisering eller en kombination 
             av e-post och lösenord, dvs. Helsingfors-ID.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
       <UserGuideAccordion
         language={lang}
@@ -559,14 +520,12 @@ function UserGuideSv(): ReactElement {
           raderar dem.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image024}
-            alt={`När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
+        <UserGuideImage
+          src={image024}
+          alt={`När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
             dina uppgifter som tjänsten kräver. Du kan senare återvända till denna information på avsnittet Dina 
             tjänster i din Helsingforsprofil.`}
-          />
-        </p>
+        />
 
         <UserGuideImage
           src={image025}
@@ -595,12 +554,10 @@ function UserGuideSv(): ReactElement {
           datanerladdningen göras med Suomi.fi-autentiseringen.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image026}
-            alt="I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil."
-          />
-        </p>
+        <UserGuideImage
+          src={image026}
+          alt="I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil."
+        />
       </UserGuideAccordion>
 
       <h2 id="_Deleting_your_information">Radering av uppgifter</h2>
@@ -629,20 +586,16 @@ function UserGuideSv(): ReactElement {
           får du ett popup-meddelande som bekräftar borttagningen.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image027}
-            alt="Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster."
-          />
-        </p>
+        <UserGuideImage
+          src={image027}
+          alt="Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster."
+        />
 
-        <p>
-          <UserGuideImage
-            src={image028}
-            alt={`När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
+        <UserGuideImage
+          src={image028}
+          alt={`När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
             popup-bekräftelsemeddelande på skärmen för att förhindra oavsiktlig radering av dina uppgifter.`}
-          />
-        </p>
+        />
       </UserGuideAccordion>
 
       <UserGuideAccordion
@@ -677,20 +630,16 @@ function UserGuideSv(): ReactElement {
           ny profil vid behov, men alla tidigare uppgifter försvinner.
         </p>
 
-        <p>
-          <UserGuideImage
-            src={image029}
-            alt={`I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
+        <UserGuideImage
+          src={image029}
+          alt={`I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
             du kan radera hela din Helsingforsprofil och den information som du har använt i olika tjänster.`}
-          />
-        </p>
+        />
 
-        <p>
-          <UserGuideImage
-            src={image030}
-            alt={`Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data.`}
-          />
-        </p>
+        <UserGuideImage
+          src={image030}
+          alt={`Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data.`}
+        />
       </UserGuideAccordion>
     </Fragment>
   );

--- a/src/userGuide/__tests__/UserGuide.test.tsx
+++ b/src/userGuide/__tests__/UserGuide.test.tsx
@@ -19,7 +19,7 @@ vi.mock('react-router-dom', async () => {
 describe('User guide', () => {
   const renderLang = (language: string) => {
     i18n.changeLanguage(language);
-    render(
+    return render(
       <TestLoginProvider>
         <I18nextProvider i18n={i18n}>
           <UserGuide />
@@ -37,17 +37,20 @@ describe('User guide', () => {
     expect(container).toMatchSnapshot();
   });
   test('renders UserGuide component in Finnish', () => {
-    renderLang('fi');
+    const container = renderLang('fi');
     expect(screen.getByText('Helsinki-profiilin ohje')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
   });
 
   test('renders UserGuide component in Swedish', () => {
-    renderLang('sv');
+    const container = renderLang('sv');
     expect(screen.getByText('Helsingforsprofilens hjälp')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
   });
 
   test('renders UserGuide component in English', () => {
-    renderLang('en');
+    const container = renderLang('en');
     expect(screen.getByText('Helsinki profile guide')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/userGuide/__tests__/__snapshots__/UserGuide.test.tsx.snap
+++ b/src/userGuide/__tests__/__snapshots__/UserGuide.test.tsx.snap
@@ -1,5 +1,12558 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`User guide > renders UserGuide component in English 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wrapper"
+      >
+        <header
+          class="hds-header Header-module_header__291GF"
+        >
+          <div
+            class="Header-module_headerBackgroundWrapper__KsFy2"
+          >
+            <a
+              class="SkipLink-module_skipLink__1knzF"
+              href="#main-content"
+            >
+              <span
+                class="SkipLink-module_skipLinkLabel__21n5B"
+              >
+                skipToContent
+              </span>
+            </a>
+            <div
+              class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+            >
+              <div
+                class="HeaderActionBar-module_headerActionBar__lPeGE"
+              >
+                <span
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                  role="link"
+                >
+                  <span
+                    class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                  >
+                    <img
+                      alt="helsinkiLogo"
+                      class="Logo-module_logo__Y2mwP"
+                      src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                    />
+                  </span>
+                </span>
+                <a
+                  aria-label="nav.titleAriaLabel"
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                  href="/"
+                >
+                  <span
+                    class="HeaderActionBar-module_title__opzt9"
+                  >
+                    appName
+                  </span>
+                </a>
+                <div
+                  class="HeaderActionBar-module_headerActions__3lNnM"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                  >
+                    <div
+                      class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                    >
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="fi"
+                        type="button"
+                      >
+                        <span>
+                          Suomi
+                        </span>
+                      </button>
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="sv"
+                        type="button"
+                      >
+                        <span>
+                          Svenska
+                        </span>
+                      </button>
+                      <button
+                        aria-current="true"
+                        class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                        lang="en"
+                        type="button"
+                      >
+                        <span>
+                          English
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <hr
+                    aria-hidden="true"
+                  />
+                  <button
+                    aria-label="nav.signin"
+                    class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                    data-hds-header-error-usage="login"
+                    id="action-bar-login-action"
+                    type="button"
+                  >
+                    <div
+                      class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                    >
+                      <span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="signin"
+                            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                        >
+                          nav.signin
+                        </span>
+                      </span>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <main
+          class="content"
+          id="main-content"
+        >
+          <div
+            class="wrapper"
+          >
+            <div
+              class="common-content-area common-bottom-padding content"
+            >
+              <div
+                class="inner-content"
+              >
+                <h1
+                  class="page-load-focus-element hide-focus-borders"
+                  tabindex="-1"
+                >
+                  Helsinki profile guide
+                </h1>
+                <p
+                  class="summary"
+                >
+                  The Helsinki profile is the customer profile of a citizen using the city's digital services. It is the primary means of identification for the City's digital services. The Helsinki profile brings together the customer's personal information and contact information, as well as links to different city services, in one place. The profile allows users to manage their own data and its visibility across different services.
+                </p>
+                <a
+                  class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                  download="Helsinki-profile-userguide.pdf"
+                  href="/Helsinki-profile-userguide.pdf"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="download"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                  >
+                    Helsinki profile guide (.pdf)
+                  </span>
+                </a>
+                <div
+                  class="table-of-contents"
+                >
+                  <div
+                    class="table-of-contents__container"
+                  >
+                    <h2
+                      class="table-of-contents__title"
+                    >
+                      On this site
+                    </h2>
+                    <nav
+                      class="table-of-contents__content"
+                      id="helfi-toc-table-of-contents-list"
+                    >
+                      <ul
+                        class="table-of-contents__list"
+                      >
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Create_a_Helsinki_profile"
+                          >
+                            Create a Helsinki profile
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Login"
+                          >
+                            Login
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_viewing_and_editing"
+                          >
+                            Viewing and editing your own data
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Deleting_your_information"
+                          >
+                            Deleting your information
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+                <h2
+                  id="_Create_a_Helsinki_profile"
+                >
+                  Create a Helsinki profile
+                </h2>
+                <p>
+                  The Helsinki profile is used by logging in to the City of Helsinki's customer services. The first time you log in, you will be asked to create a Helsinki profile and give your consent to the use of the data required by the service.
+                </p>
+                <p>
+                  You can also create a Helsinki profile at
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                </p>
+                <p>
+                  You can create a Helsinki profile using your Suomi.fi e-Identification or your email and password. You can also log in to the City of Helsinki's digital services using Google or Yle IDs, which will be phased out in 2024.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-67"
+                  id="_Suomi.fi_identification"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Suomi.fi_identification-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Suomi.fi_identification-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Suomi.fi identification
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Suomi.fi_identification-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Suomi.fi_identification-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Choice of authentication
+                    </h4>
+                    <p>
+                      After pressing the Login link in the service, the user is presented with a screen offering various login options, where the Suomi.fi login is selected. The view of the login options varies from one service to another.
+                    </p>
+                    <div>
+                      <img
+                        alt="In the authentication window, select Suomi.fi identification."
+                        loading="lazy"
+                        src="/src/userGuide/assets/01-sisaankirjautuminen-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the authentication window, select Suomi.fi identification.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="In the authentication window, select Suomi.fi identification."
+                        loading="lazy"
+                        src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the authentication window, select Suomi.fi identification.
+                      </p>
+                    </div>
+                    <h4>
+                      Identification in the Suomi.fi service
+                    </h4>
+                    <p>
+                      After selecting the Suomi.fi login, the user will be presented with different login options. The options are the same as for other government services offering strong authentication.
+                    </p>
+                    <p>
+                      After authentication, check that the information you are using is correct. If you find any errors in the data, they must be corrected in the Population Register Centre's service.
+                    </p>
+                    <div>
+                      <img
+                        alt="Choose your bank or mobile account as your Suomi.fi authentication option."
+                        loading="lazy"
+                        src="/src/userGuide/assets/03-vahvan-valinta-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Choose your bank or mobile account as your Suomi.fi authentication option.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Check that your details are correct when you switch back to the City of Helsinki service."
+                        loading="lazy"
+                        src="/src/userGuide/assets/04-vahvat-tiedot-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Check that your details are correct when you switch back to the City of Helsinki service.
+                      </p>
+                    </div>
+                    <h4>
+                      Email address verification
+                    </h4>
+                    <p>
+                      After authentication, you will be asked for your email address. A confirmation message will be sent to the email address to verify the authenticity of the address.
+                    </p>
+                    <p>
+                      If you have already created Helsinki profile with an email address and password, you can use the same email address. In this case, the different authentication methods will be combined, and you will be able to see all the services you use at once.
+                       
+                      <b>
+                        Please note, however, that you will not be able to unlink them later.
+                      </b>
+                    </p>
+                    <p>
+                      To confirm your email, you will receive a 6-digit code to the email address you provided. If the message does not arrive in your inbox almost immediately, check your spam folder.
+                    </p>
+                    <p>
+                      <b>
+                        Do not close the browser window of your Helsinki profile when you retrieve the confirmation message from your email. Otherwise, the system will assume that you have interrupted the authentication process.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="The email contains a 6-digit verification code to confirm that the email address is genuine."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        The email contains a 6-digit verification code to confirm that the email address is genuine.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="The 6-digit number of the email must be entered in the verification code field in the browser window."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        The 6-digit number of the email must be entered in the verification code field in the browser window.
+                      </p>
+                    </div>
+                    <h4>
+                      Create a Helsinki profile
+                    </h4>
+                    <p>
+                      After confirming the email, you will still need to give your consent to the use of your data. Without your consent, a Helsinki profile cannot be created, and the services cannot use your data.
+                    </p>
+                    <p>
+                      You will then have a Helsinki profile, and your Suomi.fi login details will be saved in your profile. Different services use your data in different ways, but they will always tell you how they use it when you first log in. The information is also always available in your Helsinki profile.
+                    </p>
+                    <p>
+                      After creating your Helsinki profile, you will be logged in to the service where you started the sign-up process. You can access your Helsinki profile at
+                       
+                      <a
+                        href="https://profiili.hel.fi"
+                      >
+                        https://profiili.hel.fi
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      The next time you log in to the same service, you simply select Suomi.fi, the authentication option of your choice, and you are inside the service.
+                    </p>
+                    <div>
+                      <img
+                        alt="Before you can use the service you want or before you can create your Helsinki profile, you must give your consent to the use of your data. Without consent, your data cannot be used and therefore no profile can be created."
+                        loading="lazy"
+                        src="/src/userGuide/assets/08-profiilin-luominen-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Before you can use the service you want or before you can create your Helsinki profile, you must give your consent to the use of your data. Without consent, your data cannot be used and therefore no profile can be created.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Suomi.fi identification"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Suomi.fi_identification-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-68"
+                  id="_Email_identification"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Email_identification-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Email_identification-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Email identification
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Email_identification-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Email_identification-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Choice of authentication
+                    </h4>
+                    <p>
+                      After pressing the log in link on the digital service site, you will see different login options, from which you can choose Create Helsinki profile. The view of the login options varies from one service to another.
+                    </p>
+                    <div>
+                      <img
+                        alt="The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button."
+                        loading="lazy"
+                        src="/src/userGuide/assets/09-helsinki-tunnus-luonti-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button.
+                      </p>
+                    </div>
+                    <h4>
+                      Email address verification
+                    </h4>
+                    <p>
+                      When you create your profile, you will be asked for your email address, which will also serve as your username. A confirmation message will be sent to the email address to verify the authenticity of the address.
+                    </p>
+                    <p>
+                      If you have already created Helsinki profile using Suomi.fi authentication, you can create a password for your profile by clicking on the 
+                      <i>
+                        I have forgotten my password
+                      </i>
+                       link. For more information on creating a password, see
+                       
+                      <a
+                        href="#_Forgotten_password"
+                      >
+                        Forgotten password
+                      </a>
+                      . In this case, both the services requiring Suomi.fi authentication and email password authentication can be found in the same Helsinki profile, and you can manage all your information in one view.
+                       
+                      <b>
+                        Please note, however, that you will not be able to cancel the merge later.
+                      </b>
+                    </p>
+                    <p>
+                      To confirm your email, you will receive a 6-digit code to the email address you provided. If the message does not arrive in your inbox almost immediately, check your spam folder.
+                    </p>
+                    <p>
+                      <b>
+                        Do not close the browser window of your Helsinki profile when you retrieve the confirmation message from your email. Otherwise, the system will assume that you have interrupted the authentication process.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="The email contains a 6-digit verification code to confirm that the email address is genuine."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        The email contains a 6-digit verification code to confirm that the email address is genuine.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="The 6-digit number of the email must be entered in the verification code field in the browser window."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        The 6-digit number of the email must be entered in the verification code field in the browser window.
+                      </p>
+                    </div>
+                    <h4>
+                      Create a Helsinki profile
+                    </h4>
+                    <p>
+                      After confirming the email, please fill in your name and password. Your password must be at least 12 characters long, and include upper and lowercase letters, numbers and special characters.
+                    </p>
+                    <p>
+                      Confirm that you agree to the use of your data. Without your consent, your Helsinki profile cannot be created, and your data cannot be used by the services.
+                    </p>
+                    <p>
+                      A Helsinki profile has now been created for you. The Helsinki profile you need to authenticate with the services is this email address and password combination.
+                    </p>
+                    <div>
+                      <img
+                        alt="When you create a Helsinki profile, you still have to fill in
+            your name and password. You will also need to give your consent
+            for your data to be used in order to create Helsinki profile."
+                        loading="lazy"
+                        src="/src/userGuide/assets/13-helsinki-tunnus-teko-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        When you create a Helsinki profile, you still have to fill in
+            your name and password. You will also need to give your consent
+            for your data to be used in order to create Helsinki profile.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Email identification"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Email_identification-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-69"
+                  id="_Combining_identification_methods"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Combining_identification_methods-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Combining_identification_methods-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Combining identification methods
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Combining_identification_methods-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Combining_identification_methods-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      If you wish, you can combine different authentication methods into a single Helsinki profile, allowing you to view and manage all your data and services at once. This can be done by first creating a Helsinki ID with an email address/password combination and then using the same email address for the first Suomi.fi authentication.
+                    </p>
+                    <p>
+                      <b>
+                        Please note, however, that you will not be able to unlink them later.
+                      </b>
+                    </p>
+                    <p>
+                      If your Helsinki profile was created with Suomi.fi authentication, you can click on the 
+                      <i>
+                        I forgot my password
+                      </i>
+                       link in the login screen. See the 
+                      <a
+                        href="#_Forgotten_password"
+                      >
+                        Forgotten password
+                      </a>
+                       section below for instructions on how to do this.
+                    </p>
+                    <button
+                      aria-label="Close Combining identification methods"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Combining_identification_methods-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Login"
+                >
+                  Login
+                </h2>
+                <p>
+                  With your Helsinki profile, you can log in to the digital services of the City of Helsinki. You can log in using the Suomi.fi e-Identification or the email address and password you provided when creating your profile.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-70"
+                  id="_Forgotten_password"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Forgotten_password-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Forgotten_password-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Forgotten password
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Forgotten_password-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Forgotten_password-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      If you can't remember your password, you can create a new one in the login window using the 
+                      <i>
+                        I forgot my password 
+                      </i>
+                      link. You may also have "forgotten" your password because you have previously logged in to the service using Suomi.fi, in which case you didn't have to create a password.
+                    </p>
+                    <p>
+                      Once you have entered your email, you will receive a link to enter a new password in your email. The link will be valid for 30 minutes.
+                    </p>
+                    <p>
+                      The password must be at least 12 characters long. It must use both upper and lower case letters, numbers and special characters.
+                    </p>
+                    <div>
+                      <img
+                        alt="In the login window, click on the I forgot my password link."
+                        loading="lazy"
+                        src="/src/userGuide/assets/14-salasanan-unohdus-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the login window, click on the I forgot my password link.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Enter your email address in the box that appears to receive a password renewal link in your email."
+                        loading="lazy"
+                        src="/src/userGuide/assets/15-sahkoposti-salasanalle-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Enter your email address in the box that appears to receive a password renewal link in your email.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="You will be informed that an email will be sent to you to renew your password."
+                        loading="lazy"
+                        src="/src/userGuide/assets/16-salasanan-vaihtopyynto-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        You will be informed that an email will be sent to you to renew your password.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="In the email you receive, there will be a link to enter a new password.
+            The link will be valid for 30 minutes."
+                        loading="lazy"
+                        src="/src/userGuide/assets/17-salasanan-vaihtoviesti-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the email you receive, there will be a link to enter a new password.
+            The link will be valid for 30 minutes.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="In the update password window, you must enter the same password twice.
+            The password must be at least 12 characters long. The password must contain
+            both upper and lower case letters, numbers and special characters."
+                        loading="lazy"
+                        src="/src/userGuide/assets/18-uusi-salasana-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the update password window, you must enter the same password twice.
+            The password must be at least 12 characters long. The password must contain
+            both upper and lower case letters, numbers and special characters.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Forgotten password"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Forgotten_password-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-71"
+                  id="_Problem_with_identification"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Problem_with_identification-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Problem_with_identification-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Problem with identification
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Problem_with_identification-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Problem_with_identification-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      When you move from one service to another, the way you authenticate may be different for each service. For example, you were logged in to the first service with your Helsinki ID, i.e. a combination of email and password, but the second service requires you to authenticate with Suomi.fi. In this case, you will receive a message saying that the authentication method is not compatible. You will need to log out from the previous service in order to log in to the new service. Two different authentication methods cannot be open at the same time.
+                    </p>
+                    <div>
+                      <img
+                        alt="An incompatible login method means, for example, that you have logged
+            in to one service with an email/password combination and you have moved on to
+            the next service, which requires a Suomi.fi authentication. In this case,
+            you need to log out of the first service in order to authenticate to the new service."
+                        loading="lazy"
+                        src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        An incompatible login method means, for example, that you have logged
+            in to one service with an email/password combination and you have moved on to
+            the next service, which requires a Suomi.fi authentication. In this case,
+            you need to log out of the first service in order to authenticate to the new service.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Confirm the logout from a previous service."
+                        loading="lazy"
+                        src="/src/userGuide/assets/20-kirjautumislogout-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Confirm the logout from a previous service.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Problem with identification"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Problem_with_identification-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_viewing_and_editing"
+                >
+                  Viewing and editing your own data
+                </h2>
+                <p>
+                  By logging in to your Helsinki profile at
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                  , you can view and edit your data and how it is used by the services.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-72"
+                  id="_Editing_profile_information"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Editing_profile_information-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Editing_profile_information-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Editing profile information
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Editing_profile_information-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Editing_profile_information-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      The official information will be added to your profile and will only be visible when you authenticate with Suomi.fi. Updating this information is done in the Population Register Centre service.
+                    </p>
+                    <p>
+                      In the 
+                      <i>
+                        My information
+                      </i>
+                       -section of your Helsinki profile, you can add a phone number, change your email address, and add address information. If you change your name information in your Helsinki profile, the next time you log in using Suomi.fi, your information will be updated according to the information available in the Population Register Centre.
+                    </p>
+                    <p>
+                      You can add or change the information you have entered yourself by clicking on the 
+                      <i>
+                        Add
+                      </i>
+                       button, or the 
+                      <i>
+                        Edit
+                      </i>
+                       button if the information already exists. Press the 
+                      <i>
+                        Save
+                      </i>
+                       button to save the data in the database.
+                    </p>
+                    <p>
+                      In the Helsinki profile, the language of communication section determines the language in which, for example, emails from the service will be sent. You can also see how you are authenticated to your Helsinki profile.
+                    </p>
+                    <div>
+                      <img
+                        alt="In the My Information section of the Helsinki profile, official information
+            comes directly from the Population Register Centre and is updated there as well."
+                        loading="lazy"
+                        src="/src/userGuide/assets/21-omat-tiedot-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the My Information section of the Helsinki profile, official information
+            comes directly from the Population Register Centre and is updated there as well.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="In the My information section of your Helsinki profile, you can update the basic data yourself."
+                        loading="lazy"
+                        src="/src/userGuide/assets/22-omat-nimitiedot-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the My information section of your Helsinki profile, you can update the basic data yourself.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="You can add and edit your other address details, your phone number and your email address. The
+            language of communication determines the language in which you receive messages from the service.
+            The authentication method tells you how you are logged in to the service, i.e. Suomi.fi authentication
+            or an email/password combination, i.e. the Helsinki ID."
+                        loading="lazy"
+                        src="/src/userGuide/assets/23-omat-yhteystiedot-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        You can add and edit your other address details, your phone number and your email address. The
+            language of communication determines the language in which you receive messages from the service.
+            The authentication method tells you how you are logged in to the service, i.e. Suomi.fi authentication
+            or an email/password combination, i.e. the Helsinki ID.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Editing profile information"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Editing_profile_information-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-73"
+                  id="_Processing_of_your"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Processing_of_your-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Processing_of_your-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Processing of your data by different services
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Processing_of_your-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Processing_of_your-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      The services will use the data managed by the Helsinki profile as indicated. The first time you authenticate to a service, you can see what information the service uses.
+                    </p>
+                    <p>
+                      In your Helsinki profile, you can check this information later and, if you wish, delete your data from the service. It is not possible to delete your data if your service process has not been completed. It is also advisable to
+                       
+                      <a
+                        href="#_Download_your_information"
+                      >
+                        download your own information
+                      </a>
+                       
+                      before deleting it.
+                    </p>
+                    <div>
+                      <img
+                        alt="When you authenticate to the new service, you will be asked to
+            consent to the use of your data required by the service. You can return to this information later on the Your services section of your Helsinki profile."
+                        loading="lazy"
+                        src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        When you authenticate to the new service, you will be asked to
+            consent to the use of your data required by the service. You can return to this information later on the Your services section of your Helsinki profile.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="In the Your services used section of your Helsinki profile, you can
+            see all the services you are authenticated to and what data they use.
+            You can also delete your data from individual services."
+                        loading="lazy"
+                        src="/src/userGuide/assets/25-kayttamasi-palvelut-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the Your services used section of your Helsinki profile, you can
+            see all the services you are authenticated to and what data they use.
+            You can also delete your data from individual services.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Processing of your data by different services"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Processing_of_your-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-74"
+                  id="_Download_your_information"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Download_your_information-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Download_your_information-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Download your information
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Download_your_information-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Download_your_information-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      You can also download the data you have stored in different services as a single JSON file. For more information on
+                       
+                      <a
+                        href="https://fi.wikipedia.org/wiki/JSON"
+                      >
+                        the
+                         
+                        <u>
+                          JSON file format, see Wikipedia (link opens in a new window)
+                        </u>
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      If you have combined the Suomi.fi authentication and the email address / password login in the same Helsinki profile, the data download must be done with the Suomi.fi authentication.
+                    </p>
+                    <div>
+                      <img
+                        alt="In the My information section of your Helsinki profile,
+            you can download your data for all services as a JSON file."
+                        loading="lazy"
+                        src="/src/userGuide/assets/26-tietojen-lataus-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        In the My information section of your Helsinki profile,
+            you can download your data for all services as a JSON file.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Download your information"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Download_your_information-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Deleting_your_information"
+                >
+                  Deleting your information
+                </h2>
+                <p>
+                  You can delete your data either for individual services or for your entire profile. Upon deletion, all your data from the service will be deleted or anonymised if, for example, the service is required by law to retain it. However, you will not have access to the data after deletion nor will it be linked to you.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-75"
+                  id="_Deleting_your_information"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Deleting_your_information-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Deleting_your_information-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Deleting your information from a single service
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Deleting_your_information-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Deleting_your_information-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      If you have combined your Suomi.fi authentication and email address / password login in the same Helsinki profile, you must delete the service while authenticated with Suomi.fi.
+                    </p>
+                    <p>
+                      When you select the service, you want to delete on the Your services tab, you will receive a pop-up message confirming the deletion.
+                    </p>
+                    <div>
+                      <img
+                        alt="You can delete your data in your Helsinki profile for an individual
+            service in the Your services section."
+                        loading="lazy"
+                        src="/src/userGuide/assets/27-tietojen-poisto-palvelusta-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        You can delete your data in your Helsinki profile for an individual
+            service in the Your services section.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="After clicking on the "Delete your data from this service" button, you will
+            receive a pop-up confirmation message on the screen to prevent accidental deletion."
+                        loading="lazy"
+                        src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        After clicking on the "Delete your data from this service" button, you will
+            receive a pop-up confirmation message on the screen to prevent accidental deletion.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Deleting your information from a single service"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Deleting_your_information-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-76"
+                  id="_Deleting_your_Helsinki_profile"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Deleting_your_Helsinki_profile-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Deleting_your_Helsinki_profile-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Deleting your Helsinki profile
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Deleting_your_Helsinki_profile-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Deleting_your_Helsinki_profile-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      If you want to delete your entire Helsinki profile, you can do so by pressing the 
+                      <i>
+                        Delete my information
+                      </i>
+                       button. You will then see a pop-up window where you will be asked to confirm that you want to delete your information. After confirming the request, all data will be deleted from the profile and from all services, if no service is pending.
+                    </p>
+                    <p>
+                      Some statutory services may require data to be retained for a limited or permanent period. Depending on the transaction and the service, data may be anonymized in some cases. If a statutory service is required to retain data, the profile or the data used by that service cannot be deleted.
+                    </p>
+                    <p>
+                      If you have combined the Suomi.fi authentication and the email address / password login in the same Helsinki profile, you must delete the profile while authenticated with Suomi.fi.
+                    </p>
+                    <p>
+                      After deleting your Helsinki profile, you can always create a new profile, if necessary, but all previous data will be lost.
+                    </p>
+                    <div>
+                      <img
+                        alt="
+            In the My information section of your Helsinki profile, there is a Delete my
+            information button that allows you to delete your entire Helsinki profile
+             and your information used in different services."
+                        loading="lazy"
+                        src="/src/userGuide/assets/29-tietojen-poisto-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        
+            In the My information section of your Helsinki profile, there is a Delete my
+            information button that allows you to delete your entire Helsinki profile
+             and your information used in different services.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="A confirmation message is also displayed in a pop-up window
+            to prevent accidental deletion of the data."
+                        loading="lazy"
+                        src="/src/userGuide/assets/30-tietojen-poisto-popup-en.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        A confirmation message is also displayed in a pop-up window
+            to prevent accidental deletion of the data.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Close Deleting your Helsinki profile"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Deleting_your_Helsinki_profile-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Close
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <footer
+          class="Footer-module_footer__1aD3T custom-theme-77"
+        >
+          <div
+            class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+            style="height: 15px;"
+          >
+            <svg
+              aria-hidden="true"
+              height="85"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <pattern
+                  height="85"
+                  id="koros_basic-78"
+                  patternUnits="userSpaceOnUse"
+                  width="96"
+                  x="0"
+                  y="0"
+                >
+                  <path
+                    d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                    transform="scale(3)"
+                  />
+                </pattern>
+              </defs>
+              <rect
+                fill="url(#koros_basic-78)"
+                height="85"
+                style="shape-rendering: crispEdges;"
+                width="100%"
+              />
+            </svg>
+          </div>
+          <div
+            class="Footer-module_footerContent__3MC14"
+          >
+            <div
+              class="Footer-module_footerSections__2nrr8"
+            >
+              <h2
+                class="Footer-module_title__269y7"
+              >
+                appName
+              </h2>
+              <div
+                class="FooterUtilities-module_utilities__10PzW"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterUtilities-module_divider__2VjbX"
+                />
+                <div
+                  class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.needHelp
+                      </h3>
+                      <a
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="/guide"
+                      >
+                        <span>
+                          footer.userGuide
+                        </span>
+                      </a>
+                      <div
+                        variant="utility"
+                      >
+                        <span>
+                          footer.helsinkiProfileSupport
+                        </span>
+                        <ul
+                          class="contacts-list"
+                        >
+                          <li>
+                            footer.openingHours
+                          </li>
+                          <li>
+                            <a
+                              class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                              href="tel:0931088800"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-label="phone"
+                                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                              <span>
+                                09 310 88800
+                              </span>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.otherContactInformation
+                      </h3>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.contactUsLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.contactUs
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.feedbackLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.feedback
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="FooterBase-module_base__2f0eu"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterBase-module_divider__3sz3q"
+                />
+                <div
+                  class="FooterBase-module_logoWrapper__3BI7d"
+                >
+                  <a
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                    href="https://hel.fi/en"
+                    tabindex="0"
+                  >
+                    <img
+                      alt="cityOfHelsinki"
+                      class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgY2xhc3M9IkxvZ28tbW9kdWxlX2xvZ29fX1kybXdQIExvZ28tbW9kdWxlX21lZGl1bV9fMXp5V20iIGFyaWEtaGlkZGVuPSJ0cnVlIiBzdHlsZT0iCiAgICBjb2xvcjogd2hpdGU7CiI+CiAgICA8cGF0aAogICAgICAgIGQ9Ik03NS43NTMgMi4yNTF2MjAuN2MwIDMuOTUtMy4yNzUgNy4xNzgtNy4zMSA3LjE3OGgtMjIuMjZjLTIuNjc0IDAtNS4yMDUuOTYtNy4xODMgMi43MzlhMTAuNzQ5IDEwLjc0OSAwIDAwLTcuMTgzLTIuNzRIOS41MDljLTQuMDAzIDAtNy4yNDctMy4yMS03LjI0Ny03LjE3N1YyLjI1aDczLjQ5MXpNNDAuMTg3IDM0LjgzNWE4LjQ3IDguNDcgMCAwMTYuMDEyLTIuNDcxaDIyLjI0NWM1LjI2OCAwIDkuNTU2LTQuMjE5IDkuNTU2LTkuNDEzVjBIMHYyMi45MzVjMCA1LjE5NCA0LjI1NiA5LjQxMyA5LjUwOSA5LjQxM2gyMi4zMDhjMi4yNjMgMCA0LjM5OC44ODIgNi4wMTIgMi40NzFMMzkuMDE2IDM2bDEuMTctMS4xNjV6IgogICAgICAgIGZpbGw9ImN1cnJlbnRDb2xvciI+PC9wYXRoPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiPjwvcGF0aD4KPC9zdmc+"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="FooterBase-module_copyright__2iiev"
+                >
+                  <span>
+                    © 
+                    cityOfHelsinki
+                     
+                    2024
+                  </span>
+                  <span
+                    class="FooterBase-module_copyrightDot__2AfS6"
+                  >
+                    •
+                  </span>
+                  <span>
+                    footer.reserveRights
+                  </span>
+                </div>
+                <div
+                  class="FooterBase-module_baseActions__1hCiR"
+                >
+                  <div
+                    class="FooterBase-module_links__3lfLo"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                      href="profileForm.termsFileDescriptionLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.privacy
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                  </div>
+                  <button
+                    class="FooterBase-module_backToTopButton__hXTHm"
+                    role="link"
+                    type="button"
+                  >
+                    footer.backToTop
+                    <svg
+                      aria-hidden="true"
+                      aria-label="arrow-up"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wrapper"
+    >
+      <header
+        class="hds-header Header-module_header__291GF"
+      >
+        <div
+          class="Header-module_headerBackgroundWrapper__KsFy2"
+        >
+          <a
+            class="SkipLink-module_skipLink__1knzF"
+            href="#main-content"
+          >
+            <span
+              class="SkipLink-module_skipLinkLabel__21n5B"
+            >
+              skipToContent
+            </span>
+          </a>
+          <div
+            class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+          >
+            <div
+              class="HeaderActionBar-module_headerActionBar__lPeGE"
+            >
+              <span
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                role="link"
+              >
+                <span
+                  class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                >
+                  <img
+                    alt="helsinkiLogo"
+                    class="Logo-module_logo__Y2mwP"
+                    src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                  />
+                </span>
+              </span>
+              <a
+                aria-label="nav.titleAriaLabel"
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                href="/"
+              >
+                <span
+                  class="HeaderActionBar-module_title__opzt9"
+                >
+                  appName
+                </span>
+              </a>
+              <div
+                class="HeaderActionBar-module_headerActions__3lNnM"
+              >
+                <div
+                  class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                  >
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="fi"
+                      type="button"
+                    >
+                      <span>
+                        Suomi
+                      </span>
+                    </button>
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="sv"
+                      type="button"
+                    >
+                      <span>
+                        Svenska
+                      </span>
+                    </button>
+                    <button
+                      aria-current="true"
+                      class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                      lang="en"
+                      type="button"
+                    >
+                      <span>
+                        English
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <hr
+                  aria-hidden="true"
+                />
+                <button
+                  aria-label="nav.signin"
+                  class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                  data-hds-header-error-usage="login"
+                  id="action-bar-login-action"
+                  type="button"
+                >
+                  <div
+                    class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                  >
+                    <span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="signin"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                      >
+                        nav.signin
+                      </span>
+                    </span>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main
+        class="content"
+        id="main-content"
+      >
+        <div
+          class="wrapper"
+        >
+          <div
+            class="common-content-area common-bottom-padding content"
+          >
+            <div
+              class="inner-content"
+            >
+              <h1
+                class="page-load-focus-element hide-focus-borders"
+                tabindex="-1"
+              >
+                Helsinki profile guide
+              </h1>
+              <p
+                class="summary"
+              >
+                The Helsinki profile is the customer profile of a citizen using the city's digital services. It is the primary means of identification for the City's digital services. The Helsinki profile brings together the customer's personal information and contact information, as well as links to different city services, in one place. The profile allows users to manage their own data and its visibility across different services.
+              </p>
+              <a
+                class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                download="Helsinki-profile-userguide.pdf"
+                href="/Helsinki-profile-userguide.pdf"
+              >
+                <span
+                  aria-hidden="true"
+                  class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="download"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                >
+                  Helsinki profile guide (.pdf)
+                </span>
+              </a>
+              <div
+                class="table-of-contents"
+              >
+                <div
+                  class="table-of-contents__container"
+                >
+                  <h2
+                    class="table-of-contents__title"
+                  >
+                    On this site
+                  </h2>
+                  <nav
+                    class="table-of-contents__content"
+                    id="helfi-toc-table-of-contents-list"
+                  >
+                    <ul
+                      class="table-of-contents__list"
+                    >
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Create_a_Helsinki_profile"
+                        >
+                          Create a Helsinki profile
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Login"
+                        >
+                          Login
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_viewing_and_editing"
+                        >
+                          Viewing and editing your own data
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Deleting_your_information"
+                        >
+                          Deleting your information
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+              </div>
+              <h2
+                id="_Create_a_Helsinki_profile"
+              >
+                Create a Helsinki profile
+              </h2>
+              <p>
+                The Helsinki profile is used by logging in to the City of Helsinki's customer services. The first time you log in, you will be asked to create a Helsinki profile and give your consent to the use of the data required by the service.
+              </p>
+              <p>
+                You can also create a Helsinki profile at
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+              </p>
+              <p>
+                You can create a Helsinki profile using your Suomi.fi e-Identification or your email and password. You can also log in to the City of Helsinki's digital services using Google or Yle IDs, which will be phased out in 2024.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-67"
+                id="_Suomi.fi_identification"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Suomi.fi_identification-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Suomi.fi_identification-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Suomi.fi identification
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Suomi.fi_identification-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Suomi.fi_identification-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Choice of authentication
+                  </h4>
+                  <p>
+                    After pressing the Login link in the service, the user is presented with a screen offering various login options, where the Suomi.fi login is selected. The view of the login options varies from one service to another.
+                  </p>
+                  <div>
+                    <img
+                      alt="In the authentication window, select Suomi.fi identification."
+                      loading="lazy"
+                      src="/src/userGuide/assets/01-sisaankirjautuminen-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the authentication window, select Suomi.fi identification.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="In the authentication window, select Suomi.fi identification."
+                      loading="lazy"
+                      src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the authentication window, select Suomi.fi identification.
+                    </p>
+                  </div>
+                  <h4>
+                    Identification in the Suomi.fi service
+                  </h4>
+                  <p>
+                    After selecting the Suomi.fi login, the user will be presented with different login options. The options are the same as for other government services offering strong authentication.
+                  </p>
+                  <p>
+                    After authentication, check that the information you are using is correct. If you find any errors in the data, they must be corrected in the Population Register Centre's service.
+                  </p>
+                  <div>
+                    <img
+                      alt="Choose your bank or mobile account as your Suomi.fi authentication option."
+                      loading="lazy"
+                      src="/src/userGuide/assets/03-vahvan-valinta-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Choose your bank or mobile account as your Suomi.fi authentication option.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Check that your details are correct when you switch back to the City of Helsinki service."
+                      loading="lazy"
+                      src="/src/userGuide/assets/04-vahvat-tiedot-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Check that your details are correct when you switch back to the City of Helsinki service.
+                    </p>
+                  </div>
+                  <h4>
+                    Email address verification
+                  </h4>
+                  <p>
+                    After authentication, you will be asked for your email address. A confirmation message will be sent to the email address to verify the authenticity of the address.
+                  </p>
+                  <p>
+                    If you have already created Helsinki profile with an email address and password, you can use the same email address. In this case, the different authentication methods will be combined, and you will be able to see all the services you use at once.
+                     
+                    <b>
+                      Please note, however, that you will not be able to unlink them later.
+                    </b>
+                  </p>
+                  <p>
+                    To confirm your email, you will receive a 6-digit code to the email address you provided. If the message does not arrive in your inbox almost immediately, check your spam folder.
+                  </p>
+                  <p>
+                    <b>
+                      Do not close the browser window of your Helsinki profile when you retrieve the confirmation message from your email. Otherwise, the system will assume that you have interrupted the authentication process.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="The email contains a 6-digit verification code to confirm that the email address is genuine."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      The email contains a 6-digit verification code to confirm that the email address is genuine.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="The 6-digit number of the email must be entered in the verification code field in the browser window."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      The 6-digit number of the email must be entered in the verification code field in the browser window.
+                    </p>
+                  </div>
+                  <h4>
+                    Create a Helsinki profile
+                  </h4>
+                  <p>
+                    After confirming the email, you will still need to give your consent to the use of your data. Without your consent, a Helsinki profile cannot be created, and the services cannot use your data.
+                  </p>
+                  <p>
+                    You will then have a Helsinki profile, and your Suomi.fi login details will be saved in your profile. Different services use your data in different ways, but they will always tell you how they use it when you first log in. The information is also always available in your Helsinki profile.
+                  </p>
+                  <p>
+                    After creating your Helsinki profile, you will be logged in to the service where you started the sign-up process. You can access your Helsinki profile at
+                     
+                    <a
+                      href="https://profiili.hel.fi"
+                    >
+                      https://profiili.hel.fi
+                    </a>
+                    .
+                  </p>
+                  <p>
+                    The next time you log in to the same service, you simply select Suomi.fi, the authentication option of your choice, and you are inside the service.
+                  </p>
+                  <div>
+                    <img
+                      alt="Before you can use the service you want or before you can create your Helsinki profile, you must give your consent to the use of your data. Without consent, your data cannot be used and therefore no profile can be created."
+                      loading="lazy"
+                      src="/src/userGuide/assets/08-profiilin-luominen-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Before you can use the service you want or before you can create your Helsinki profile, you must give your consent to the use of your data. Without consent, your data cannot be used and therefore no profile can be created.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Suomi.fi identification"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Suomi.fi_identification-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-68"
+                id="_Email_identification"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Email_identification-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Email_identification-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Email identification
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Email_identification-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Email_identification-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Choice of authentication
+                  </h4>
+                  <p>
+                    After pressing the log in link on the digital service site, you will see different login options, from which you can choose Create Helsinki profile. The view of the login options varies from one service to another.
+                  </p>
+                  <div>
+                    <img
+                      alt="The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button."
+                      loading="lazy"
+                      src="/src/userGuide/assets/09-helsinki-tunnus-luonti-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      The Helsinki ID consists of an email and password combination, which will be created by clicking on the Create a new Helsinki profile button.
+                    </p>
+                  </div>
+                  <h4>
+                    Email address verification
+                  </h4>
+                  <p>
+                    When you create your profile, you will be asked for your email address, which will also serve as your username. A confirmation message will be sent to the email address to verify the authenticity of the address.
+                  </p>
+                  <p>
+                    If you have already created Helsinki profile using Suomi.fi authentication, you can create a password for your profile by clicking on the 
+                    <i>
+                      I have forgotten my password
+                    </i>
+                     link. For more information on creating a password, see
+                     
+                    <a
+                      href="#_Forgotten_password"
+                    >
+                      Forgotten password
+                    </a>
+                    . In this case, both the services requiring Suomi.fi authentication and email password authentication can be found in the same Helsinki profile, and you can manage all your information in one view.
+                     
+                    <b>
+                      Please note, however, that you will not be able to cancel the merge later.
+                    </b>
+                  </p>
+                  <p>
+                    To confirm your email, you will receive a 6-digit code to the email address you provided. If the message does not arrive in your inbox almost immediately, check your spam folder.
+                  </p>
+                  <p>
+                    <b>
+                      Do not close the browser window of your Helsinki profile when you retrieve the confirmation message from your email. Otherwise, the system will assume that you have interrupted the authentication process.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Your email address will serve as your login to City of Helsinki services.
+            By using the same email address for both the Suomi.fi login and the Helsinki ID,
+            you will have one Helsinki profile. The merge cannot be unmerged later.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="The email contains a 6-digit verification code to confirm that the email address is genuine."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      The email contains a 6-digit verification code to confirm that the email address is genuine.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="The 6-digit number of the email must be entered in the verification code field in the browser window."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      The 6-digit number of the email must be entered in the verification code field in the browser window.
+                    </p>
+                  </div>
+                  <h4>
+                    Create a Helsinki profile
+                  </h4>
+                  <p>
+                    After confirming the email, please fill in your name and password. Your password must be at least 12 characters long, and include upper and lowercase letters, numbers and special characters.
+                  </p>
+                  <p>
+                    Confirm that you agree to the use of your data. Without your consent, your Helsinki profile cannot be created, and your data cannot be used by the services.
+                  </p>
+                  <p>
+                    A Helsinki profile has now been created for you. The Helsinki profile you need to authenticate with the services is this email address and password combination.
+                  </p>
+                  <div>
+                    <img
+                      alt="When you create a Helsinki profile, you still have to fill in
+            your name and password. You will also need to give your consent
+            for your data to be used in order to create Helsinki profile."
+                      loading="lazy"
+                      src="/src/userGuide/assets/13-helsinki-tunnus-teko-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      When you create a Helsinki profile, you still have to fill in
+            your name and password. You will also need to give your consent
+            for your data to be used in order to create Helsinki profile.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Email identification"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Email_identification-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-69"
+                id="_Combining_identification_methods"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Combining_identification_methods-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Combining_identification_methods-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Combining identification methods
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Combining_identification_methods-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Combining_identification_methods-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    If you wish, you can combine different authentication methods into a single Helsinki profile, allowing you to view and manage all your data and services at once. This can be done by first creating a Helsinki ID with an email address/password combination and then using the same email address for the first Suomi.fi authentication.
+                  </p>
+                  <p>
+                    <b>
+                      Please note, however, that you will not be able to unlink them later.
+                    </b>
+                  </p>
+                  <p>
+                    If your Helsinki profile was created with Suomi.fi authentication, you can click on the 
+                    <i>
+                      I forgot my password
+                    </i>
+                     link in the login screen. See the 
+                    <a
+                      href="#_Forgotten_password"
+                    >
+                      Forgotten password
+                    </a>
+                     section below for instructions on how to do this.
+                  </p>
+                  <button
+                    aria-label="Close Combining identification methods"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Combining_identification_methods-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Login"
+              >
+                Login
+              </h2>
+              <p>
+                With your Helsinki profile, you can log in to the digital services of the City of Helsinki. You can log in using the Suomi.fi e-Identification or the email address and password you provided when creating your profile.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-70"
+                id="_Forgotten_password"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Forgotten_password-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Forgotten_password-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Forgotten password
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Forgotten_password-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Forgotten_password-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    If you can't remember your password, you can create a new one in the login window using the 
+                    <i>
+                      I forgot my password 
+                    </i>
+                    link. You may also have "forgotten" your password because you have previously logged in to the service using Suomi.fi, in which case you didn't have to create a password.
+                  </p>
+                  <p>
+                    Once you have entered your email, you will receive a link to enter a new password in your email. The link will be valid for 30 minutes.
+                  </p>
+                  <p>
+                    The password must be at least 12 characters long. It must use both upper and lower case letters, numbers and special characters.
+                  </p>
+                  <div>
+                    <img
+                      alt="In the login window, click on the I forgot my password link."
+                      loading="lazy"
+                      src="/src/userGuide/assets/14-salasanan-unohdus-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the login window, click on the I forgot my password link.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Enter your email address in the box that appears to receive a password renewal link in your email."
+                      loading="lazy"
+                      src="/src/userGuide/assets/15-sahkoposti-salasanalle-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Enter your email address in the box that appears to receive a password renewal link in your email.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="You will be informed that an email will be sent to you to renew your password."
+                      loading="lazy"
+                      src="/src/userGuide/assets/16-salasanan-vaihtopyynto-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      You will be informed that an email will be sent to you to renew your password.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="In the email you receive, there will be a link to enter a new password.
+            The link will be valid for 30 minutes."
+                      loading="lazy"
+                      src="/src/userGuide/assets/17-salasanan-vaihtoviesti-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the email you receive, there will be a link to enter a new password.
+            The link will be valid for 30 minutes.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="In the update password window, you must enter the same password twice.
+            The password must be at least 12 characters long. The password must contain
+            both upper and lower case letters, numbers and special characters."
+                      loading="lazy"
+                      src="/src/userGuide/assets/18-uusi-salasana-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the update password window, you must enter the same password twice.
+            The password must be at least 12 characters long. The password must contain
+            both upper and lower case letters, numbers and special characters.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Forgotten password"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Forgotten_password-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-71"
+                id="_Problem_with_identification"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Problem_with_identification-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Problem_with_identification-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Problem with identification
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Problem_with_identification-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Problem_with_identification-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    When you move from one service to another, the way you authenticate may be different for each service. For example, you were logged in to the first service with your Helsinki ID, i.e. a combination of email and password, but the second service requires you to authenticate with Suomi.fi. In this case, you will receive a message saying that the authentication method is not compatible. You will need to log out from the previous service in order to log in to the new service. Two different authentication methods cannot be open at the same time.
+                  </p>
+                  <div>
+                    <img
+                      alt="An incompatible login method means, for example, that you have logged
+            in to one service with an email/password combination and you have moved on to
+            the next service, which requires a Suomi.fi authentication. In this case,
+            you need to log out of the first service in order to authenticate to the new service."
+                      loading="lazy"
+                      src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      An incompatible login method means, for example, that you have logged
+            in to one service with an email/password combination and you have moved on to
+            the next service, which requires a Suomi.fi authentication. In this case,
+            you need to log out of the first service in order to authenticate to the new service.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Confirm the logout from a previous service."
+                      loading="lazy"
+                      src="/src/userGuide/assets/20-kirjautumislogout-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Confirm the logout from a previous service.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Problem with identification"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Problem_with_identification-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_viewing_and_editing"
+              >
+                Viewing and editing your own data
+              </h2>
+              <p>
+                By logging in to your Helsinki profile at
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+                , you can view and edit your data and how it is used by the services.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-72"
+                id="_Editing_profile_information"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Editing_profile_information-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Editing_profile_information-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Editing profile information
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Editing_profile_information-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Editing_profile_information-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    The official information will be added to your profile and will only be visible when you authenticate with Suomi.fi. Updating this information is done in the Population Register Centre service.
+                  </p>
+                  <p>
+                    In the 
+                    <i>
+                      My information
+                    </i>
+                     -section of your Helsinki profile, you can add a phone number, change your email address, and add address information. If you change your name information in your Helsinki profile, the next time you log in using Suomi.fi, your information will be updated according to the information available in the Population Register Centre.
+                  </p>
+                  <p>
+                    You can add or change the information you have entered yourself by clicking on the 
+                    <i>
+                      Add
+                    </i>
+                     button, or the 
+                    <i>
+                      Edit
+                    </i>
+                     button if the information already exists. Press the 
+                    <i>
+                      Save
+                    </i>
+                     button to save the data in the database.
+                  </p>
+                  <p>
+                    In the Helsinki profile, the language of communication section determines the language in which, for example, emails from the service will be sent. You can also see how you are authenticated to your Helsinki profile.
+                  </p>
+                  <div>
+                    <img
+                      alt="In the My Information section of the Helsinki profile, official information
+            comes directly from the Population Register Centre and is updated there as well."
+                      loading="lazy"
+                      src="/src/userGuide/assets/21-omat-tiedot-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the My Information section of the Helsinki profile, official information
+            comes directly from the Population Register Centre and is updated there as well.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="In the My information section of your Helsinki profile, you can update the basic data yourself."
+                      loading="lazy"
+                      src="/src/userGuide/assets/22-omat-nimitiedot-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the My information section of your Helsinki profile, you can update the basic data yourself.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="You can add and edit your other address details, your phone number and your email address. The
+            language of communication determines the language in which you receive messages from the service.
+            The authentication method tells you how you are logged in to the service, i.e. Suomi.fi authentication
+            or an email/password combination, i.e. the Helsinki ID."
+                      loading="lazy"
+                      src="/src/userGuide/assets/23-omat-yhteystiedot-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      You can add and edit your other address details, your phone number and your email address. The
+            language of communication determines the language in which you receive messages from the service.
+            The authentication method tells you how you are logged in to the service, i.e. Suomi.fi authentication
+            or an email/password combination, i.e. the Helsinki ID.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Editing profile information"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Editing_profile_information-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-73"
+                id="_Processing_of_your"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Processing_of_your-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Processing_of_your-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Processing of your data by different services
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Processing_of_your-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Processing_of_your-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    The services will use the data managed by the Helsinki profile as indicated. The first time you authenticate to a service, you can see what information the service uses.
+                  </p>
+                  <p>
+                    In your Helsinki profile, you can check this information later and, if you wish, delete your data from the service. It is not possible to delete your data if your service process has not been completed. It is also advisable to
+                     
+                    <a
+                      href="#_Download_your_information"
+                    >
+                      download your own information
+                    </a>
+                     
+                    before deleting it.
+                  </p>
+                  <div>
+                    <img
+                      alt="When you authenticate to the new service, you will be asked to
+            consent to the use of your data required by the service. You can return to this information later on the Your services section of your Helsinki profile."
+                      loading="lazy"
+                      src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      When you authenticate to the new service, you will be asked to
+            consent to the use of your data required by the service. You can return to this information later on the Your services section of your Helsinki profile.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="In the Your services used section of your Helsinki profile, you can
+            see all the services you are authenticated to and what data they use.
+            You can also delete your data from individual services."
+                      loading="lazy"
+                      src="/src/userGuide/assets/25-kayttamasi-palvelut-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the Your services used section of your Helsinki profile, you can
+            see all the services you are authenticated to and what data they use.
+            You can also delete your data from individual services.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Processing of your data by different services"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Processing_of_your-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-74"
+                id="_Download_your_information"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Download_your_information-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Download_your_information-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Download your information
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Download_your_information-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Download_your_information-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    You can also download the data you have stored in different services as a single JSON file. For more information on
+                     
+                    <a
+                      href="https://fi.wikipedia.org/wiki/JSON"
+                    >
+                      the
+                       
+                      <u>
+                        JSON file format, see Wikipedia (link opens in a new window)
+                      </u>
+                    </a>
+                    .
+                  </p>
+                  <p>
+                    If you have combined the Suomi.fi authentication and the email address / password login in the same Helsinki profile, the data download must be done with the Suomi.fi authentication.
+                  </p>
+                  <div>
+                    <img
+                      alt="In the My information section of your Helsinki profile,
+            you can download your data for all services as a JSON file."
+                      loading="lazy"
+                      src="/src/userGuide/assets/26-tietojen-lataus-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      In the My information section of your Helsinki profile,
+            you can download your data for all services as a JSON file.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Download your information"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Download_your_information-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Deleting_your_information"
+              >
+                Deleting your information
+              </h2>
+              <p>
+                You can delete your data either for individual services or for your entire profile. Upon deletion, all your data from the service will be deleted or anonymised if, for example, the service is required by law to retain it. However, you will not have access to the data after deletion nor will it be linked to you.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-75"
+                id="_Deleting_your_information"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Deleting_your_information-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Deleting_your_information-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Deleting your information from a single service
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Deleting_your_information-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Deleting_your_information-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    If you have combined your Suomi.fi authentication and email address / password login in the same Helsinki profile, you must delete the service while authenticated with Suomi.fi.
+                  </p>
+                  <p>
+                    When you select the service, you want to delete on the Your services tab, you will receive a pop-up message confirming the deletion.
+                  </p>
+                  <div>
+                    <img
+                      alt="You can delete your data in your Helsinki profile for an individual
+            service in the Your services section."
+                      loading="lazy"
+                      src="/src/userGuide/assets/27-tietojen-poisto-palvelusta-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      You can delete your data in your Helsinki profile for an individual
+            service in the Your services section.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="After clicking on the "Delete your data from this service" button, you will
+            receive a pop-up confirmation message on the screen to prevent accidental deletion."
+                      loading="lazy"
+                      src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      After clicking on the "Delete your data from this service" button, you will
+            receive a pop-up confirmation message on the screen to prevent accidental deletion.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Deleting your information from a single service"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Deleting_your_information-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-76"
+                id="_Deleting_your_Helsinki_profile"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Deleting_your_Helsinki_profile-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Deleting_your_Helsinki_profile-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Deleting your Helsinki profile
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Deleting_your_Helsinki_profile-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Deleting_your_Helsinki_profile-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    If you want to delete your entire Helsinki profile, you can do so by pressing the 
+                    <i>
+                      Delete my information
+                    </i>
+                     button. You will then see a pop-up window where you will be asked to confirm that you want to delete your information. After confirming the request, all data will be deleted from the profile and from all services, if no service is pending.
+                  </p>
+                  <p>
+                    Some statutory services may require data to be retained for a limited or permanent period. Depending on the transaction and the service, data may be anonymized in some cases. If a statutory service is required to retain data, the profile or the data used by that service cannot be deleted.
+                  </p>
+                  <p>
+                    If you have combined the Suomi.fi authentication and the email address / password login in the same Helsinki profile, you must delete the profile while authenticated with Suomi.fi.
+                  </p>
+                  <p>
+                    After deleting your Helsinki profile, you can always create a new profile, if necessary, but all previous data will be lost.
+                  </p>
+                  <div>
+                    <img
+                      alt="
+            In the My information section of your Helsinki profile, there is a Delete my
+            information button that allows you to delete your entire Helsinki profile
+             and your information used in different services."
+                      loading="lazy"
+                      src="/src/userGuide/assets/29-tietojen-poisto-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      
+            In the My information section of your Helsinki profile, there is a Delete my
+            information button that allows you to delete your entire Helsinki profile
+             and your information used in different services.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="A confirmation message is also displayed in a pop-up window
+            to prevent accidental deletion of the data."
+                      loading="lazy"
+                      src="/src/userGuide/assets/30-tietojen-poisto-popup-en.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      A confirmation message is also displayed in a pop-up window
+            to prevent accidental deletion of the data.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Close Deleting your Helsinki profile"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Deleting_your_Helsinki_profile-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Close
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <footer
+        class="Footer-module_footer__1aD3T custom-theme-77"
+      >
+        <div
+          class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+          style="height: 15px;"
+        >
+          <svg
+            aria-hidden="true"
+            height="85"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <defs>
+              <pattern
+                height="85"
+                id="koros_basic-78"
+                patternUnits="userSpaceOnUse"
+                width="96"
+                x="0"
+                y="0"
+              >
+                <path
+                  d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                  transform="scale(3)"
+                />
+              </pattern>
+            </defs>
+            <rect
+              fill="url(#koros_basic-78)"
+              height="85"
+              style="shape-rendering: crispEdges;"
+              width="100%"
+            />
+          </svg>
+        </div>
+        <div
+          class="Footer-module_footerContent__3MC14"
+        >
+          <div
+            class="Footer-module_footerSections__2nrr8"
+          >
+            <h2
+              class="Footer-module_title__269y7"
+            >
+              appName
+            </h2>
+            <div
+              class="FooterUtilities-module_utilities__10PzW"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterUtilities-module_divider__2VjbX"
+              />
+              <div
+                class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+              >
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.needHelp
+                    </h3>
+                    <a
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="/guide"
+                    >
+                      <span>
+                        footer.userGuide
+                      </span>
+                    </a>
+                    <div
+                      variant="utility"
+                    >
+                      <span>
+                        footer.helsinkiProfileSupport
+                      </span>
+                      <ul
+                        class="contacts-list"
+                      >
+                        <li>
+                          footer.openingHours
+                        </li>
+                        <li>
+                          <a
+                            class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                            href="tel:0931088800"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label="phone"
+                              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                            <span>
+                              09 310 88800
+                            </span>
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.otherContactInformation
+                    </h3>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.contactUsLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.contactUs
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.feedbackLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.feedback
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="FooterBase-module_base__2f0eu"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterBase-module_divider__3sz3q"
+              />
+              <div
+                class="FooterBase-module_logoWrapper__3BI7d"
+              >
+                <a
+                  class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                  href="https://hel.fi/en"
+                  tabindex="0"
+                >
+                  <img
+                    alt="cityOfHelsinki"
+                    class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                    src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgY2xhc3M9IkxvZ28tbW9kdWxlX2xvZ29fX1kybXdQIExvZ28tbW9kdWxlX21lZGl1bV9fMXp5V20iIGFyaWEtaGlkZGVuPSJ0cnVlIiBzdHlsZT0iCiAgICBjb2xvcjogd2hpdGU7CiI+CiAgICA8cGF0aAogICAgICAgIGQ9Ik03NS43NTMgMi4yNTF2MjAuN2MwIDMuOTUtMy4yNzUgNy4xNzgtNy4zMSA3LjE3OGgtMjIuMjZjLTIuNjc0IDAtNS4yMDUuOTYtNy4xODMgMi43MzlhMTAuNzQ5IDEwLjc0OSAwIDAwLTcuMTgzLTIuNzRIOS41MDljLTQuMDAzIDAtNy4yNDctMy4yMS03LjI0Ny03LjE3N1YyLjI1aDczLjQ5MXpNNDAuMTg3IDM0LjgzNWE4LjQ3IDguNDcgMCAwMTYuMDEyLTIuNDcxaDIyLjI0NWM1LjI2OCAwIDkuNTU2LTQuMjE5IDkuNTU2LTkuNDEzVjBIMHYyMi45MzVjMCA1LjE5NCA0LjI1NiA5LjQxMyA5LjUwOSA5LjQxM2gyMi4zMDhjMi4yNjMgMCA0LjM5OC44ODIgNi4wMTIgMi40NzFMMzkuMDE2IDM2bDEuMTctMS4xNjV6IgogICAgICAgIGZpbGw9ImN1cnJlbnRDb2xvciI+PC9wYXRoPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiPjwvcGF0aD4KPC9zdmc+"
+                  />
+                </a>
+              </div>
+              <div
+                class="FooterBase-module_copyright__2iiev"
+              >
+                <span>
+                  © 
+                  cityOfHelsinki
+                   
+                  2024
+                </span>
+                <span
+                  class="FooterBase-module_copyrightDot__2AfS6"
+                >
+                  •
+                </span>
+                <span>
+                  footer.reserveRights
+                </span>
+              </div>
+              <div
+                class="FooterBase-module_baseActions__1hCiR"
+              >
+                <div
+                  class="FooterBase-module_links__3lfLo"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <a
+                    aria-label="opensInNewWindow"
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                    href="profileForm.termsFileDescriptionLink"
+                    target="_blank"
+                  >
+                    <span>
+                      footer.privacy
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="link-external"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                </div>
+                <button
+                  class="FooterBase-module_backToTopButton__hXTHm"
+                  role="link"
+                  type="button"
+                >
+                  footer.backToTop
+                  <svg
+                    aria-hidden="true"
+                    aria-label="arrow-up"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`User guide > renders UserGuide component in Finnish 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wrapper"
+      >
+        <header
+          class="hds-header Header-module_header__291GF"
+        >
+          <div
+            class="Header-module_headerBackgroundWrapper__KsFy2"
+          >
+            <a
+              class="SkipLink-module_skipLink__1knzF"
+              href="#main-content"
+            >
+              <span
+                class="SkipLink-module_skipLinkLabel__21n5B"
+              >
+                skipToContent
+              </span>
+            </a>
+            <div
+              class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+            >
+              <div
+                class="HeaderActionBar-module_headerActionBar__lPeGE"
+              >
+                <span
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                  role="link"
+                >
+                  <span
+                    class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                  >
+                    <img
+                      alt="helsinkiLogo"
+                      class="Logo-module_logo__Y2mwP"
+                      src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                    />
+                  </span>
+                </span>
+                <a
+                  aria-label="nav.titleAriaLabel"
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                  href="/"
+                >
+                  <span
+                    class="HeaderActionBar-module_title__opzt9"
+                  >
+                    appName
+                  </span>
+                </a>
+                <div
+                  class="HeaderActionBar-module_headerActions__3lNnM"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                  >
+                    <div
+                      class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                    >
+                      <button
+                        aria-current="true"
+                        class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                        lang="fi"
+                        type="button"
+                      >
+                        <span>
+                          Suomi
+                        </span>
+                      </button>
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="sv"
+                        type="button"
+                      >
+                        <span>
+                          Svenska
+                        </span>
+                      </button>
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="en"
+                        type="button"
+                      >
+                        <span>
+                          English
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <hr
+                    aria-hidden="true"
+                  />
+                  <button
+                    aria-label="nav.signin"
+                    class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                    data-hds-header-error-usage="login"
+                    id="action-bar-login-action"
+                    type="button"
+                  >
+                    <div
+                      class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                    >
+                      <span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="signin"
+                            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                        >
+                          nav.signin
+                        </span>
+                      </span>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <main
+          class="content"
+          id="main-content"
+        >
+          <div
+            class="wrapper"
+          >
+            <div
+              class="common-content-area common-bottom-padding content"
+            >
+              <div
+                class="inner-content"
+              >
+                <h1
+                  class="page-load-focus-element hide-focus-borders"
+                  tabindex="-1"
+                >
+                  Helsinki-profiilin ohje
+                </h1>
+                <p>
+                  Helsinki-profiili on kaupungin digitaalisten asiointipalvelujen käyttäjän asiakasprofiili, joka toimii ensisijaisena tunnistautumistapana kaupungin palveluihin. Profiili kokoaa yhteen paikkaan käyttäjän henkilö- ja yhteystiedot sekä yhteydet eri kaupungin palveluihin. Profiilissa voit hallinnoida omia tietojasi ja niiden näkyvyyttä eri palveluissa.
+                </p>
+                <a
+                  class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                  download="Helsinki-profiili-ohjeet.pdf"
+                  href="/Helsinki-profiili-ohjeet.pdf"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="download"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                  >
+                    Helsinki-profiilin ohje (.pdf)
+                  </span>
+                </a>
+                <div
+                  class="table-of-contents"
+                >
+                  <div
+                    class="table-of-contents__container"
+                  >
+                    <h2
+                      class="table-of-contents__title"
+                    >
+                      Tällä sivulla
+                    </h2>
+                    <nav
+                      class="table-of-contents__content"
+                      id="helfi-toc-table-of-contents-list"
+                    >
+                      <ul
+                        class="table-of-contents__list"
+                      >
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Helsinki_profiilin_luonti"
+                          >
+                            Helsinki-profiilin luonti
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Kirjautuminen"
+                          >
+                            Kirjautuminen
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Omien_tietojen_katselu"
+                          >
+                            Omien tietojen katselu ja muokkaaminen
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Tietojen_poisto"
+                          >
+                            Tietojen poisto
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+                <h2
+                  id="_Helsinki_profiilin_luonti"
+                >
+                  Helsinki-profiilin luonti
+                </h2>
+                <p>
+                  Helsinki-profiilia käytetään kirjautumalla Helsingin kaupungin asiointipalveluihin. Ensimmäisellä kirjautumiskerralla sinua pyydetään luomaan Helsinki-profiili ja antamaan suostumus palvelun tarvitsemien tietojen käyttöön.
+                </p>
+                <p>
+                  Voit myös luoda Helsinki-profiilin osoitteessa
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                  .
+                </p>
+                <p>
+                  Helsinki-profiilin voit luoda käyttäen Suomi.fi-tunnistautumista tai sähköpostia ja salasanaa. Helsingin kaupungin digitaalisiin palveluihin voi myös kirjautua Google- tai Yle-tunnuksilla, jotka poistuvat käytöstä vuoden 2024 aikana.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-23"
+                  id="_Suomi.fi-tunnistautuminen"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Suomi.fi-tunnistautuminen-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Suomi.fi-tunnistautuminen-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Suomi.fi-tunnistautuminen
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Suomi.fi-tunnistautuminen-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Suomi.fi-tunnistautuminen-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Tunnistautumisen valinta
+                    </h4>
+                    <p>
+                      Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Suomi.fi-tunnistautuminen. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
+                    </p>
+                    <div>
+                      <img
+                        alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
+                        loading="lazy"
+                        src="/src/userGuide/assets/01-sisaankirjautuminen.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
+                        loading="lazy"
+                        src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen.
+                      </p>
+                    </div>
+                    <h4>
+                      Tunnistautuminen Suomi.fi-palvelussa
+                    </h4>
+                    <p>
+                      Suomi.fi-tunnistautumisen valinnan jälkeen käyttäjä saa ruudulleen erilaisia tunnistautumistapoja. Vaihtoehdot ovat samat kuin muissakin julkishallinnon vahvaa tunnistautumista tarjoavissa palveluissa.
+                    </p>
+                    <p>
+                      Tunnistautumisen jälkeen tarkista, että käytettävät tiedot ovat oikein. Mikäli havaitset tiedoissa virheitä, ne tulee korjata väestörekisterikeskuksen palvelussa.
+                    </p>
+                    <div>
+                      <img
+                        alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
+                        loading="lazy"
+                        src="/src/userGuide/assets/03-vahvan-valinta.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
+                        loading="lazy"
+                        src="/src/userGuide/assets/04-vahvat-tiedot.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun.
+                      </p>
+                    </div>
+                    <h4>
+                      Sähköpostiosoitteen vahvistus
+                    </h4>
+                    <p>
+                      Tunnistautumisen jälkeen sinulta kysytään sähköpostiosoite. Sähköpostiosoitteeseen lähetetään vahvistusviesti osoitteen aitouden varmistamiseksi.
+                    </p>
+                    <p>
+                      Jos olet jo aiemmin luonut Helsinki-profiilin sähköpostiosoitteella ja salasanalla, voit käyttää samaa sähköpostiosoitetta. Tällöin eri tunnistautumistavat yhdistyvät, ja näet jatkossa kaikkien käyttämiesi palvelujen tiedot kerralla.
+                       
+                      <b>
+                        Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                      </b>
+                    </p>
+                    <p>
+                      Sähköpostin vahvistamiseksi saat antamaasi sähköpostiosoitteeseen 6-numeroisen koodin. Syötä koodi ruudulla näkyvään kenttään. Jos viesti ei tule sähköpostiisi lähes välittömästi, tarkista roskapostikansiosi.
+                    </p>
+                    <p>
+                      <b>
+                        Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
+                      </p>
+                    </div>
+                    <h4>
+                      Helsinki-profiilin luonti
+                    </h4>
+                    <p>
+                      Sähköpostin vahvistamisen jälkeen sinun pitää vielä tarkistaa tietosi ja antaa suostumus tietojesi käyttöön. Ilman suostumusta Helsinki-profiilia ei voida luoda, eivätkä palvelut voi käyttää tietojasi.
+                    </p>
+                    <p>
+                      Tämän jälkeen sinulle syntyy Helsinki-profiili ja Suomi.fi-tunnistautumisen tiedot tallentuvat profiiliin. Eri asiointipalvelut hyödyntävät tietojasi eri tavoin, mutta nämä tiedot kerrotaan aina ensimmäisellä kirjautumiskerralla. Tiedot löytyvät myös aina Helsinki-profiilista.
+                    </p>
+                    <p>
+                      Helsinki-profiilin luomisen jälkeen olet tunnistautuneena siinä palvelussa, josta aloitit kirjautumisprosessin. Helsinki-profiiliin pääset osoitteessa
+                       
+                      <a
+                        href="https://profiili.hel.fi"
+                      >
+                        https://profiili.hel.fi
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      Kun kirjaudut seuraavan kerran samaan palveluun, valitse tunnistautumisvaihtoehdoksi Suomi.fi.
+                    </p>
+                    <div>
+                      <img
+                        alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
+                        loading="lazy"
+                        src="/src/userGuide/assets/08-profiilin-luominen.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Suomi.fi-tunnistautuminen"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Suomi.fi-tunnistautuminen-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-24"
+                  id="_Helsinki-tunnuksen_käyttö"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Helsinki-tunnuksen_käyttö-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Helsinki-tunnuksen_käyttö-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Sähköposti-tunnistautuminen
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Helsinki-tunnuksen_käyttö-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Helsinki-tunnuksen_käyttö-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Tunnistautumisen valinta
+                    </h4>
+                    <p>
+                      Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Luo Helsinki-profiili. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
+                        loading="lazy"
+                        src="/src/userGuide/assets/09-helsinki-tunnus-luonti.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta.
+                      </p>
+                    </div>
+                    <h4>
+                      Sähköpostiosoitteen vahvistus
+                    </h4>
+                    <p>
+                      Profiilin luomisen yhteydessä sinulta pyydetään sähköpostiosoite, joka toimii myös käyttäjätunnuksenasi. Sähköpostiosoitteeseen lähetetään vahvistusviesti osoitteen aitouden varmistamiseksi.
+                    </p>
+                    <p>
+                      Jos olet jo aiemmin luonut Helsinki-profiilin Suomi.fi-tunnistautuen, voit luoda profiilille salasanan klikkaamalla Olen unohtanut salasanani -linkkiä. Salasanan luomisesta on enemmän
+                       
+                      <a
+                        href="#_Unohtunut_salasana"
+                      >
+                         Unohtunut salasana
+                      </a>
+                       -kohdassa. Tällöin eri tunnistautumistavat yhdistyvät, ja näet jatkossa kaikkien käyttämiesi palvelujen tiedot kerralla.
+                       
+                      <b>
+                        Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                      </b>
+                    </p>
+                    <p>
+                      Sähköpostin vahvistamiseksi saat antamaasi sähköpostiosoitteeseen 6-numeroisen koodin. Syötä koodi ruudulla näkyvään kenttään. Jos viesti ei tule sähköpostiisi lähes välittömästi, tarkista roskapostikansiosi.
+                    </p>
+                    <p>
+                      <b>
+                        Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
+                      </p>
+                    </div>
+                    <h4>
+                      Helsinki-profiilin luonti
+                    </h4>
+                    <p>
+                      Sähköpostin vahvistamisen jälkeen täytä nimitietosi ja anna salasana. Salasanassa pitää olla vähintään 12 merkkiä, pieniä ja isoja kirjaimia, numeroita sekä erikoismerkkejä.
+                    </p>
+                    <p>
+                      Vahvista vielä suostumus tietojesi käyttöön. Ilman suostumusta Helsinki-profiilia ei voida luoda, eivätkä palvelut voi käyttää tietojasi.
+                    </p>
+                    <p>
+                      Nyt sinulle on luotu Helsinki-profiili. Palveluihin tunnistautumiseen tarvitsemasi Helsinki-tunnus on tämä sähköpostiosoite-salasana-yhdistelmä.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+            salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda."
+                        loading="lazy"
+                        src="/src/userGuide/assets/13-helsinki-tunnus-teko.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+            salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Sähköposti-tunnistautuminen"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Helsinki-tunnuksen_käyttö-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-25"
+                  id="_Tunnistautumistapojen_yhdistäminen"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Tunnistautumistapojen_yhdistäminen-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Tunnistautumistapojen_yhdistäminen-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Tunnistautumistapojen yhdistäminen
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Tunnistautumistapojen_yhdistäminen-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Tunnistautumistapojen_yhdistäminen-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Voit halutessasi yhdistää eri tunnistautumistavat yhdeksi Helsinki-profiiliksi, jolloin voit tarkastella ja hallinnoida kaikkia tietojasi ja hyödyntämiäsi palveluja kerralla. Yhdistääksesi tunnistautumistavat, luo ensin Helsinki-tunnus sähköpostiosoite-salasana-yhdistelmällä. Käytä sitten samaa sähköpostiosoitetta, kun kirjaudut ensimmäistä kertaa käyttäen Suomi.fi-tunnistautumista.
+                    </p>
+                    <p>
+                      <b>
+                        Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                      </b>
+                    </p>
+                    <p>
+                      Jos Helsinki-profiili on luotu Suomi.fi-tunnistautumisella, sisäänkirjautumisnäkymässä voi klikata
+                       
+                      <i>
+                        Olen unohtanut salasanani
+                      </i>
+                       -linkkiä. Tästä ohjeet seuraavassa osiossa 
+                      <a
+                        href="#_Unohtunut_salasana"
+                      >
+                        Unohtunut salasana
+                      </a>
+                      .
+                    </p>
+                    <button
+                      aria-label="Sulje Tunnistautumistapojen yhdistäminen"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Tunnistautumistapojen_yhdistäminen-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Kirjautuminen"
+                >
+                  Kirjautuminen
+                </h2>
+                <p>
+                  Helsinki-profiililla voit kirjautua Helsingin kaupungin digitaalisiin palveluihin. Voit käyttää kirjautumiseen Suomi.fi-tunnistautumista tai profiilin luomisen yhteydessä annettua sähköpostiosoitetta ja salasanaa.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-26"
+                  id="_Unohtunut_salasana"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Unohtunut_salasana-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Unohtunut_salasana-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Unohtunut salasana
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Unohtunut_salasana-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Unohtunut_salasana-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Jos et muista salasanaasi, voit luoda uuden kirjautumisikkunassa
+                       
+                      <i>
+                        Olen unohtanut salasanani
+                      </i>
+                       -linkistä. Salasanan ”unohtuminen” voi myös johtua siitä, että olet aiemmilla kerroilla kirjautunut palveluun Suomi.fi-tunnistautuen, jolloin salasanaa ei ole luotu.
+                    </p>
+                    <p>
+                      Sähköpostin antamisen jälkeen saat sähköpostiisi linkin uuden salasanan antamiseen. Linkki on voimassa 30 minuuttia.
+                    </p>
+                    <p>
+                      Salasanan pitää olla vähintään 12 merkkiä pitkä. Siinä pitää käyttää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
+                    </p>
+                    <div>
+                      <img
+                        alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
+                        loading="lazy"
+                        src="/src/userGuide/assets/14-salasanan-unohdus.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
+                        loading="lazy"
+                        src="/src/userGuide/assets/15-sahkoposti-salasanalle.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
+                        loading="lazy"
+                        src="/src/userGuide/assets/16-salasanan-vaihtopyynto.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
+                        loading="lazy"
+                        src="/src/userGuide/assets/17-salasanan-vaihtoviesti.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. 
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+            vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä."
+                        loading="lazy"
+                        src="/src/userGuide/assets/18-uusi-salasana.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+            vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Unohtunut salasana"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Unohtunut_salasana-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-27"
+                  id="_Ongelma_kirjautumisessa"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Ongelma_kirjautumisessa-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Ongelma_kirjautumisessa-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Ongelma kirjautumisessa
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Ongelma_kirjautumisessa-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Ongelma_kirjautumisessa-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Kun siirryt palvelusta toiseen, tunnistautumistapa voi olla erilainen eri palveluissa. Esimerkiksi olit kirjautuneena ensimmäiseen palveluun Helsinki-tunnuksella eli sähköpostin ja salasanan yhdistelmällä, mutta toinen palvelu tarvitsee Suomi.fi-tunnistautumisen. Tällöin saat ilmoituksen, ettei tunnistautumistapa ole yhteensopiva. Sinun tulee kirjautua ulos aiemmasta palvelusta, jotta voit tunnistautua uuteen palveluun. Kahta eri tunnistautumistapaa ei voi olla samaan aikaa avoinna.
+                    </p>
+                    <div>
+                      <img
+                        alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
+                        loading="lazy"
+                        src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
+                        loading="lazy"
+                        src="/src/userGuide/assets/20-kirjautumislogout.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Vahvista uloskirjautuminen aiemmasta palvelusta.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Ongelma kirjautumisessa"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Ongelma_kirjautumisessa-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Omien_tietojen_katselu"
+                >
+                  Omien tietojen katselu ja muokkaaminen
+                </h2>
+                <p>
+                  Kirjautumalla Helsinki-profiiliin osoitteessa
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                  voit katsella ja muokata omia tietojasi ja sitä, miten palvelut niitä käyttävät.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-28"
+                  id="_Profiili_tietojen_muokkaaminen"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Profiili_tietojen_muokkaaminen-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Profiili_tietojen_muokkaaminen-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Profiili-tietojen muokkaaminen
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Profiili_tietojen_muokkaaminen-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Profiili_tietojen_muokkaaminen-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Viralliset tiedot tulevat profiiliin ja näkyvät vain, kun käytät Suomi.fi-tunnistautumista. Näiden tietojen päivittäminen tehdään väestörekisterikeskuksen palvelussa.
+                    </p>
+                    <p>
+                      Helsinki-profiilin omissa tiedoissa voit lisätä puhelinnumeron, vaihtaa sähköpostiosoitteen ja lisätä osoitetiedot. Jos vaihdat nimitietosi Helsinki-profiilissa, niin seuraavalla Suomi.fi-tunnistautumiskerralla nimitiedot päivittyvät väestötietojärjestelmän tietojen mukaisesti.
+                    </p>
+                    <p>
+                      Voit lisätä tai muuttaa itse syöttämiäsi tietoja Lisää-painikkeella tai Muokkaa-painikkeella. Tiedot tallentuvat tietokantaan Tallenna-painikkeella.
+                    </p>
+                    <p>
+                      Helsinki-profiilin asiointikieli-kohta määrittää, millä kielellä esimerkiksi palvelun sähköpostit lähetetään. Näet myös miten olet tunnistautunut Helsinki-profiiliin.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä."
+                        loading="lazy"
+                        src="/src/userGuide/assets/21-omat-tiedot.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
+                        loading="lazy"
+                        src="/src/userGuide/assets/22-omat-nimitiedot.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
+                        loading="lazy"
+                        src="/src/userGuide/assets/23-omat-yhteystiedot.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Profiili-tietojen muokkaaminen"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Profiili_tietojen_muokkaaminen-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-29"
+                  id="_Tietojen_käsittely_eri"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Tietojen_käsittely_eri-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Tietojen_käsittely_eri-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Tietojen käsittely eri palveluissa
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Tietojen_käsittely_eri-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Tietojen_käsittely_eri-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Palvelut hyödyntävät Helsinki-profiilin hallinnoimia tietoja ilmoittamallaan tavalla. Kirjautumalla ensimmäisen kerran palveluun näet mitä tietoja palvelu hyödyntää.
+                    </p>
+                    <p>
+                      Helsinki-profiilissa voit tarkistaa myöhemmin nämä tiedot sekä halutessasi poistaa tietosi palvelusta. Poisto ei ole mahdollista, jos asiointi on kesken palvelussa. On myös suositeltavaa
+                       
+                      <a
+                        href="#_Tietojen_lataaminen"
+                      >
+                        ladata omat tiedot talteen
+                      </a>
+                       ennen poistoa.
+                    </p>
+                    <div>
+                      <img
+                        alt="Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+            Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä."
+                        loading="lazy"
+                        src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+            Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+            tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista."
+                        loading="lazy"
+                        src="/src/userGuide/assets/25-kayttamasi-palvelut.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+            tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Tietojen käsittely eri palveluissa"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Tietojen_käsittely_eri-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-30"
+                  id="_Tietojen_lataaminen"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Tietojen_lataaminen-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Tietojen_lataaminen-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Tietojesi lataaminen
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Tietojen_lataaminen-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Tietojen_lataaminen-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Voit ladata eri palveluihin tallentamasi tiedot yhtenä json-tiedostona. Lisää tietoa
+                       
+                      <a
+                        href="https://fi.wikipedia.org/wiki/JSON"
+                      >
+                        json-tiedostomuodosta Wikipediassa (linkki avautuu uuteen ikkunaan)
+                      </a>
+                      . Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, tietojen lataus pitää tehdä Suomi.fi-tunnistautuneena.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
+                        loading="lazy"
+                        src="/src/userGuide/assets/26-tietojen-lataus.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Tietojesi lataaminen"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Tietojen_lataaminen-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Tietojen_poisto"
+                >
+                  Tietojen poisto
+                </h2>
+                <p>
+                  Voit poistaa tietosi yksittäisistä palveluista tai halutessasi koko profiilin. Poiston myötä kaikki tietosi palvelusta poistetaan. Jos palvelu joutuu esim. lakisääteisistä syistä säilyttämään tietoja, tiedot anonymisoidaan poiston sijaan. Sinulla ei kuitenkaan ole poiston jälkeen pääsyä tietoihin, eikä niitä voi yhdistää sinuun.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-31"
+                  id="_Tietojen_poisto"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Tietojen_poisto-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Tietojen_poisto-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Tietojesi poisto yksittäisestä palvelusta
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Tietojen_poisto-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Tietojen_poisto-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, palvelun poistaminen pitää tehdä Suomi.fi-tunnistautuneena.
+                    </p>
+                    <p>
+                      Kun valitset poistettavan palvelun Käyttämäsi palvelut -välilehdellä, saat ponnahdusikkunaan vahvistusviestin poistosta.
+                    </p>
+                    <div>
+                      <img
+                        alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
+                        loading="lazy"
+                        src="/src/userGuide/assets/27-tietojen-poisto-palvelusta.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa."
+                        loading="lazy"
+                        src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Tietojesi poisto yksittäisestä palvelusta"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Tietojen_poisto-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-32"
+                  id="_Profiilin_poisto"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Profiilin_poisto-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Profiilin_poisto-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Helsinki-profiilin poisto
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Profiilin_poisto-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Profiilin_poisto-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Jos haluat poistaa koko Helsinki-profiilin, voit tehdä sen Poista omat tiedot -näppäintä painamalla. Tämän jälkeen sinulta vielä varmistetaan, että haluat poistaa tietosi. Vahvistamalla pyynnön kaikki tiedot poistetaan profiilista sekä kaikista asiointipalveluista, jos mitään asiointia ei ole kesken.
+                    </p>
+                    <p>
+                      Jotkin lakisääteiset asiointipalvelut voivat edellyttää tietojen säilyttämistä määräajan tai pysyvästi. Asioinnista ja asiointipalvelusta riippuen tiedot voidaan joissakin tapauksissa anonymisoida. Jos lakisääteisen palvelun pitää säilyttää tiedot, tällöin profiilia tai kyseisen palvelun käyttöoikeutta tietoihin ei voida poistaa.
+                    </p>
+                    <p>
+                      Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, profiilin poisto pitää tehdä Suomi.fi-tunnistautuneena.
+                    </p>
+                    <p>
+                      Helsinki-profiilin poistamisen jälkeen voit aina tarvittaessa tehdä uuden profiilin, mutta kaikki aiemmat tiedot on menetetty.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
+                        loading="lazy"
+                        src="/src/userGuide/assets/29-tietojen-poisto.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
+                        loading="lazy"
+                        src="/src/userGuide/assets/30-tietojen-poisto-popup.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Sulje Helsinki-profiilin poisto"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Profiilin_poisto-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Sulje
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <footer
+          class="Footer-module_footer__1aD3T custom-theme-33"
+        >
+          <div
+            class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+            style="height: 15px;"
+          >
+            <svg
+              aria-hidden="true"
+              height="85"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <pattern
+                  height="85"
+                  id="koros_basic-34"
+                  patternUnits="userSpaceOnUse"
+                  width="96"
+                  x="0"
+                  y="0"
+                >
+                  <path
+                    d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                    transform="scale(3)"
+                  />
+                </pattern>
+              </defs>
+              <rect
+                fill="url(#koros_basic-34)"
+                height="85"
+                style="shape-rendering: crispEdges;"
+                width="100%"
+              />
+            </svg>
+          </div>
+          <div
+            class="Footer-module_footerContent__3MC14"
+          >
+            <div
+              class="Footer-module_footerSections__2nrr8"
+            >
+              <h2
+                class="Footer-module_title__269y7"
+              >
+                appName
+              </h2>
+              <div
+                class="FooterUtilities-module_utilities__10PzW"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterUtilities-module_divider__2VjbX"
+                />
+                <div
+                  class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.needHelp
+                      </h3>
+                      <a
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="/guide"
+                      >
+                        <span>
+                          footer.userGuide
+                        </span>
+                      </a>
+                      <div
+                        variant="utility"
+                      >
+                        <span>
+                          footer.helsinkiProfileSupport
+                        </span>
+                        <ul
+                          class="contacts-list"
+                        >
+                          <li>
+                            footer.openingHours
+                          </li>
+                          <li>
+                            <a
+                              class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                              href="tel:0931088800"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-label="phone"
+                                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                              <span>
+                                09 310 88800
+                              </span>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.otherContactInformation
+                      </h3>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.contactUsLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.contactUs
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.feedbackLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.feedback
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="FooterBase-module_base__2f0eu"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterBase-module_divider__3sz3q"
+                />
+                <div
+                  class="FooterBase-module_logoWrapper__3BI7d"
+                >
+                  <a
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                    href="https://hel.fi/fi"
+                    tabindex="0"
+                  >
+                    <img
+                      alt="cityOfHelsinki"
+                      class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgY2xhc3M9IkxvZ28tbW9kdWxlX2xvZ29fX1kybXdQIExvZ28tbW9kdWxlX21lZGl1bV9fMXp5V20iIGFyaWEtaGlkZGVuPSJ0cnVlIiBzdHlsZT0iCiAgICBjb2xvcjogd2hpdGU7CiI+CiAgICA8cGF0aAogICAgICAgIGQ9Ik03NS43NTMgMi4yNTF2MjAuN2MwIDMuOTUtMy4yNzUgNy4xNzgtNy4zMSA3LjE3OGgtMjIuMjZjLTIuNjc0IDAtNS4yMDUuOTYtNy4xODMgMi43MzlhMTAuNzQ5IDEwLjc0OSAwIDAwLTcuMTgzLTIuNzRIOS41MDljLTQuMDAzIDAtNy4yNDctMy4yMS03LjI0Ny03LjE3N1YyLjI1aDczLjQ5MXpNNDAuMTg3IDM0LjgzNWE4LjQ3IDguNDcgMCAwMTYuMDEyLTIuNDcxaDIyLjI0NWM1LjI2OCAwIDkuNTU2LTQuMjE5IDkuNTU2LTkuNDEzVjBIMHYyMi45MzVjMCA1LjE5NCA0LjI1NiA5LjQxMyA5LjUwOSA5LjQxM2gyMi4zMDhjMi4yNjMgMCA0LjM5OC44ODIgNi4wMTIgMi40NzFMMzkuMDE2IDM2bDEuMTctMS4xNjV6IgogICAgICAgIGZpbGw9ImN1cnJlbnRDb2xvciI+PC9wYXRoPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiPjwvcGF0aD4KPC9zdmc+"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="FooterBase-module_copyright__2iiev"
+                >
+                  <span>
+                    © 
+                    cityOfHelsinki
+                     
+                    2024
+                  </span>
+                  <span
+                    class="FooterBase-module_copyrightDot__2AfS6"
+                  >
+                    •
+                  </span>
+                  <span>
+                    footer.reserveRights
+                  </span>
+                </div>
+                <div
+                  class="FooterBase-module_baseActions__1hCiR"
+                >
+                  <div
+                    class="FooterBase-module_links__3lfLo"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                      href="profileForm.termsFileDescriptionLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.privacy
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                  </div>
+                  <button
+                    class="FooterBase-module_backToTopButton__hXTHm"
+                    role="link"
+                    type="button"
+                  >
+                    footer.backToTop
+                    <svg
+                      aria-hidden="true"
+                      aria-label="arrow-up"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wrapper"
+    >
+      <header
+        class="hds-header Header-module_header__291GF"
+      >
+        <div
+          class="Header-module_headerBackgroundWrapper__KsFy2"
+        >
+          <a
+            class="SkipLink-module_skipLink__1knzF"
+            href="#main-content"
+          >
+            <span
+              class="SkipLink-module_skipLinkLabel__21n5B"
+            >
+              skipToContent
+            </span>
+          </a>
+          <div
+            class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+          >
+            <div
+              class="HeaderActionBar-module_headerActionBar__lPeGE"
+            >
+              <span
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                role="link"
+              >
+                <span
+                  class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                >
+                  <img
+                    alt="helsinkiLogo"
+                    class="Logo-module_logo__Y2mwP"
+                    src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                  />
+                </span>
+              </span>
+              <a
+                aria-label="nav.titleAriaLabel"
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                href="/"
+              >
+                <span
+                  class="HeaderActionBar-module_title__opzt9"
+                >
+                  appName
+                </span>
+              </a>
+              <div
+                class="HeaderActionBar-module_headerActions__3lNnM"
+              >
+                <div
+                  class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                  >
+                    <button
+                      aria-current="true"
+                      class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                      lang="fi"
+                      type="button"
+                    >
+                      <span>
+                        Suomi
+                      </span>
+                    </button>
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="sv"
+                      type="button"
+                    >
+                      <span>
+                        Svenska
+                      </span>
+                    </button>
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="en"
+                      type="button"
+                    >
+                      <span>
+                        English
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <hr
+                  aria-hidden="true"
+                />
+                <button
+                  aria-label="nav.signin"
+                  class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                  data-hds-header-error-usage="login"
+                  id="action-bar-login-action"
+                  type="button"
+                >
+                  <div
+                    class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                  >
+                    <span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="signin"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                      >
+                        nav.signin
+                      </span>
+                    </span>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main
+        class="content"
+        id="main-content"
+      >
+        <div
+          class="wrapper"
+        >
+          <div
+            class="common-content-area common-bottom-padding content"
+          >
+            <div
+              class="inner-content"
+            >
+              <h1
+                class="page-load-focus-element hide-focus-borders"
+                tabindex="-1"
+              >
+                Helsinki-profiilin ohje
+              </h1>
+              <p>
+                Helsinki-profiili on kaupungin digitaalisten asiointipalvelujen käyttäjän asiakasprofiili, joka toimii ensisijaisena tunnistautumistapana kaupungin palveluihin. Profiili kokoaa yhteen paikkaan käyttäjän henkilö- ja yhteystiedot sekä yhteydet eri kaupungin palveluihin. Profiilissa voit hallinnoida omia tietojasi ja niiden näkyvyyttä eri palveluissa.
+              </p>
+              <a
+                class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                download="Helsinki-profiili-ohjeet.pdf"
+                href="/Helsinki-profiili-ohjeet.pdf"
+              >
+                <span
+                  aria-hidden="true"
+                  class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="download"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                >
+                  Helsinki-profiilin ohje (.pdf)
+                </span>
+              </a>
+              <div
+                class="table-of-contents"
+              >
+                <div
+                  class="table-of-contents__container"
+                >
+                  <h2
+                    class="table-of-contents__title"
+                  >
+                    Tällä sivulla
+                  </h2>
+                  <nav
+                    class="table-of-contents__content"
+                    id="helfi-toc-table-of-contents-list"
+                  >
+                    <ul
+                      class="table-of-contents__list"
+                    >
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Helsinki_profiilin_luonti"
+                        >
+                          Helsinki-profiilin luonti
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Kirjautuminen"
+                        >
+                          Kirjautuminen
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Omien_tietojen_katselu"
+                        >
+                          Omien tietojen katselu ja muokkaaminen
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Tietojen_poisto"
+                        >
+                          Tietojen poisto
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+              </div>
+              <h2
+                id="_Helsinki_profiilin_luonti"
+              >
+                Helsinki-profiilin luonti
+              </h2>
+              <p>
+                Helsinki-profiilia käytetään kirjautumalla Helsingin kaupungin asiointipalveluihin. Ensimmäisellä kirjautumiskerralla sinua pyydetään luomaan Helsinki-profiili ja antamaan suostumus palvelun tarvitsemien tietojen käyttöön.
+              </p>
+              <p>
+                Voit myös luoda Helsinki-profiilin osoitteessa
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+                .
+              </p>
+              <p>
+                Helsinki-profiilin voit luoda käyttäen Suomi.fi-tunnistautumista tai sähköpostia ja salasanaa. Helsingin kaupungin digitaalisiin palveluihin voi myös kirjautua Google- tai Yle-tunnuksilla, jotka poistuvat käytöstä vuoden 2024 aikana.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-23"
+                id="_Suomi.fi-tunnistautuminen"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Suomi.fi-tunnistautuminen-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Suomi.fi-tunnistautuminen-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Suomi.fi-tunnistautuminen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Suomi.fi-tunnistautuminen-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Suomi.fi-tunnistautuminen-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Tunnistautumisen valinta
+                  </h4>
+                  <p>
+                    Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Suomi.fi-tunnistautuminen. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
+                  </p>
+                  <div>
+                    <img
+                      alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
+                      loading="lazy"
+                      src="/src/userGuide/assets/01-sisaankirjautuminen.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
+                      loading="lazy"
+                      src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen.
+                    </p>
+                  </div>
+                  <h4>
+                    Tunnistautuminen Suomi.fi-palvelussa
+                  </h4>
+                  <p>
+                    Suomi.fi-tunnistautumisen valinnan jälkeen käyttäjä saa ruudulleen erilaisia tunnistautumistapoja. Vaihtoehdot ovat samat kuin muissakin julkishallinnon vahvaa tunnistautumista tarjoavissa palveluissa.
+                  </p>
+                  <p>
+                    Tunnistautumisen jälkeen tarkista, että käytettävät tiedot ovat oikein. Mikäli havaitset tiedoissa virheitä, ne tulee korjata väestörekisterikeskuksen palvelussa.
+                  </p>
+                  <div>
+                    <img
+                      alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
+                      loading="lazy"
+                      src="/src/userGuide/assets/03-vahvan-valinta.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
+                      loading="lazy"
+                      src="/src/userGuide/assets/04-vahvat-tiedot.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun.
+                    </p>
+                  </div>
+                  <h4>
+                    Sähköpostiosoitteen vahvistus
+                  </h4>
+                  <p>
+                    Tunnistautumisen jälkeen sinulta kysytään sähköpostiosoite. Sähköpostiosoitteeseen lähetetään vahvistusviesti osoitteen aitouden varmistamiseksi.
+                  </p>
+                  <p>
+                    Jos olet jo aiemmin luonut Helsinki-profiilin sähköpostiosoitteella ja salasanalla, voit käyttää samaa sähköpostiosoitetta. Tällöin eri tunnistautumistavat yhdistyvät, ja näet jatkossa kaikkien käyttämiesi palvelujen tiedot kerralla.
+                     
+                    <b>
+                      Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                    </b>
+                  </p>
+                  <p>
+                    Sähköpostin vahvistamiseksi saat antamaasi sähköpostiosoitteeseen 6-numeroisen koodin. Syötä koodi ruudulla näkyvään kenttään. Jos viesti ei tule sähköpostiisi lähes välittömästi, tarkista roskapostikansiosi.
+                  </p>
+                  <p>
+                    <b>
+                      Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
+                    </p>
+                  </div>
+                  <h4>
+                    Helsinki-profiilin luonti
+                  </h4>
+                  <p>
+                    Sähköpostin vahvistamisen jälkeen sinun pitää vielä tarkistaa tietosi ja antaa suostumus tietojesi käyttöön. Ilman suostumusta Helsinki-profiilia ei voida luoda, eivätkä palvelut voi käyttää tietojasi.
+                  </p>
+                  <p>
+                    Tämän jälkeen sinulle syntyy Helsinki-profiili ja Suomi.fi-tunnistautumisen tiedot tallentuvat profiiliin. Eri asiointipalvelut hyödyntävät tietojasi eri tavoin, mutta nämä tiedot kerrotaan aina ensimmäisellä kirjautumiskerralla. Tiedot löytyvät myös aina Helsinki-profiilista.
+                  </p>
+                  <p>
+                    Helsinki-profiilin luomisen jälkeen olet tunnistautuneena siinä palvelussa, josta aloitit kirjautumisprosessin. Helsinki-profiiliin pääset osoitteessa
+                     
+                    <a
+                      href="https://profiili.hel.fi"
+                    >
+                      https://profiili.hel.fi
+                    </a>
+                    .
+                  </p>
+                  <p>
+                    Kun kirjaudut seuraavan kerran samaan palveluun, valitse tunnistautumisvaihtoehdoksi Suomi.fi.
+                  </p>
+                  <div>
+                    <img
+                      alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
+                      loading="lazy"
+                      src="/src/userGuide/assets/08-profiilin-luominen.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Suomi.fi-tunnistautuminen"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Suomi.fi-tunnistautuminen-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-24"
+                id="_Helsinki-tunnuksen_käyttö"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Helsinki-tunnuksen_käyttö-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Helsinki-tunnuksen_käyttö-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Sähköposti-tunnistautuminen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Helsinki-tunnuksen_käyttö-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Helsinki-tunnuksen_käyttö-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Tunnistautumisen valinta
+                  </h4>
+                  <p>
+                    Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Luo Helsinki-profiili. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
+                      loading="lazy"
+                      src="/src/userGuide/assets/09-helsinki-tunnus-luonti.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta.
+                    </p>
+                  </div>
+                  <h4>
+                    Sähköpostiosoitteen vahvistus
+                  </h4>
+                  <p>
+                    Profiilin luomisen yhteydessä sinulta pyydetään sähköpostiosoite, joka toimii myös käyttäjätunnuksenasi. Sähköpostiosoitteeseen lähetetään vahvistusviesti osoitteen aitouden varmistamiseksi.
+                  </p>
+                  <p>
+                    Jos olet jo aiemmin luonut Helsinki-profiilin Suomi.fi-tunnistautuen, voit luoda profiilille salasanan klikkaamalla Olen unohtanut salasanani -linkkiä. Salasanan luomisesta on enemmän
+                     
+                    <a
+                      href="#_Unohtunut_salasana"
+                    >
+                       Unohtunut salasana
+                    </a>
+                     -kohdassa. Tällöin eri tunnistautumistavat yhdistyvät, ja näet jatkossa kaikkien käyttämiesi palvelujen tiedot kerralla.
+                     
+                    <b>
+                      Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                    </b>
+                  </p>
+                  <p>
+                    Sähköpostin vahvistamiseksi saat antamaasi sähköpostiosoitteeseen 6-numeroisen koodin. Syötä koodi ruudulla näkyvään kenttään. Jos viesti ei tule sähköpostiisi lähes välittömästi, tarkista roskapostikansiosi.
+                  </p>
+                  <p>
+                    <b>
+                      Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+  Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
+                    </p>
+                  </div>
+                  <h4>
+                    Helsinki-profiilin luonti
+                  </h4>
+                  <p>
+                    Sähköpostin vahvistamisen jälkeen täytä nimitietosi ja anna salasana. Salasanassa pitää olla vähintään 12 merkkiä, pieniä ja isoja kirjaimia, numeroita sekä erikoismerkkejä.
+                  </p>
+                  <p>
+                    Vahvista vielä suostumus tietojesi käyttöön. Ilman suostumusta Helsinki-profiilia ei voida luoda, eivätkä palvelut voi käyttää tietojasi.
+                  </p>
+                  <p>
+                    Nyt sinulle on luotu Helsinki-profiili. Palveluihin tunnistautumiseen tarvitsemasi Helsinki-tunnus on tämä sähköpostiosoite-salasana-yhdistelmä.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+            salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda."
+                      loading="lazy"
+                      src="/src/userGuide/assets/13-helsinki-tunnus-teko.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+            salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Sähköposti-tunnistautuminen"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Helsinki-tunnuksen_käyttö-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-25"
+                id="_Tunnistautumistapojen_yhdistäminen"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Tunnistautumistapojen_yhdistäminen-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Tunnistautumistapojen_yhdistäminen-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Tunnistautumistapojen yhdistäminen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Tunnistautumistapojen_yhdistäminen-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Tunnistautumistapojen_yhdistäminen-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Voit halutessasi yhdistää eri tunnistautumistavat yhdeksi Helsinki-profiiliksi, jolloin voit tarkastella ja hallinnoida kaikkia tietojasi ja hyödyntämiäsi palveluja kerralla. Yhdistääksesi tunnistautumistavat, luo ensin Helsinki-tunnus sähköpostiosoite-salasana-yhdistelmällä. Käytä sitten samaa sähköpostiosoitetta, kun kirjaudut ensimmäistä kertaa käyttäen Suomi.fi-tunnistautumista.
+                  </p>
+                  <p>
+                    <b>
+                      Huomaa kuitenkin, ettei yhdistämistä voi perua myöhemmin.
+                    </b>
+                  </p>
+                  <p>
+                    Jos Helsinki-profiili on luotu Suomi.fi-tunnistautumisella, sisäänkirjautumisnäkymässä voi klikata
+                     
+                    <i>
+                      Olen unohtanut salasanani
+                    </i>
+                     -linkkiä. Tästä ohjeet seuraavassa osiossa 
+                    <a
+                      href="#_Unohtunut_salasana"
+                    >
+                      Unohtunut salasana
+                    </a>
+                    .
+                  </p>
+                  <button
+                    aria-label="Sulje Tunnistautumistapojen yhdistäminen"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Tunnistautumistapojen_yhdistäminen-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Kirjautuminen"
+              >
+                Kirjautuminen
+              </h2>
+              <p>
+                Helsinki-profiililla voit kirjautua Helsingin kaupungin digitaalisiin palveluihin. Voit käyttää kirjautumiseen Suomi.fi-tunnistautumista tai profiilin luomisen yhteydessä annettua sähköpostiosoitetta ja salasanaa.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-26"
+                id="_Unohtunut_salasana"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Unohtunut_salasana-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Unohtunut_salasana-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Unohtunut salasana
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Unohtunut_salasana-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Unohtunut_salasana-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Jos et muista salasanaasi, voit luoda uuden kirjautumisikkunassa
+                     
+                    <i>
+                      Olen unohtanut salasanani
+                    </i>
+                     -linkistä. Salasanan ”unohtuminen” voi myös johtua siitä, että olet aiemmilla kerroilla kirjautunut palveluun Suomi.fi-tunnistautuen, jolloin salasanaa ei ole luotu.
+                  </p>
+                  <p>
+                    Sähköpostin antamisen jälkeen saat sähköpostiisi linkin uuden salasanan antamiseen. Linkki on voimassa 30 minuuttia.
+                  </p>
+                  <p>
+                    Salasanan pitää olla vähintään 12 merkkiä pitkä. Siinä pitää käyttää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
+                  </p>
+                  <div>
+                    <img
+                      alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
+                      loading="lazy"
+                      src="/src/userGuide/assets/14-salasanan-unohdus.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
+                      loading="lazy"
+                      src="/src/userGuide/assets/15-sahkoposti-salasanalle.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
+                      loading="lazy"
+                      src="/src/userGuide/assets/16-salasanan-vaihtopyynto.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
+                      loading="lazy"
+                      src="/src/userGuide/assets/17-salasanan-vaihtoviesti.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. 
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+            vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä."
+                      loading="lazy"
+                      src="/src/userGuide/assets/18-uusi-salasana.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+            vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Unohtunut salasana"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Unohtunut_salasana-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-27"
+                id="_Ongelma_kirjautumisessa"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Ongelma_kirjautumisessa-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Ongelma_kirjautumisessa-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Ongelma kirjautumisessa
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Ongelma_kirjautumisessa-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Ongelma_kirjautumisessa-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Kun siirryt palvelusta toiseen, tunnistautumistapa voi olla erilainen eri palveluissa. Esimerkiksi olit kirjautuneena ensimmäiseen palveluun Helsinki-tunnuksella eli sähköpostin ja salasanan yhdistelmällä, mutta toinen palvelu tarvitsee Suomi.fi-tunnistautumisen. Tällöin saat ilmoituksen, ettei tunnistautumistapa ole yhteensopiva. Sinun tulee kirjautua ulos aiemmasta palvelusta, jotta voit tunnistautua uuteen palveluun. Kahta eri tunnistautumistapaa ei voi olla samaan aikaa avoinna.
+                  </p>
+                  <div>
+                    <img
+                      alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
+                      loading="lazy"
+                      src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
+                      loading="lazy"
+                      src="/src/userGuide/assets/20-kirjautumislogout.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Vahvista uloskirjautuminen aiemmasta palvelusta.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Ongelma kirjautumisessa"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Ongelma_kirjautumisessa-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Omien_tietojen_katselu"
+              >
+                Omien tietojen katselu ja muokkaaminen
+              </h2>
+              <p>
+                Kirjautumalla Helsinki-profiiliin osoitteessa
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+                voit katsella ja muokata omia tietojasi ja sitä, miten palvelut niitä käyttävät.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-28"
+                id="_Profiili_tietojen_muokkaaminen"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Profiili_tietojen_muokkaaminen-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Profiili_tietojen_muokkaaminen-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Profiili-tietojen muokkaaminen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Profiili_tietojen_muokkaaminen-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Profiili_tietojen_muokkaaminen-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Viralliset tiedot tulevat profiiliin ja näkyvät vain, kun käytät Suomi.fi-tunnistautumista. Näiden tietojen päivittäminen tehdään väestörekisterikeskuksen palvelussa.
+                  </p>
+                  <p>
+                    Helsinki-profiilin omissa tiedoissa voit lisätä puhelinnumeron, vaihtaa sähköpostiosoitteen ja lisätä osoitetiedot. Jos vaihdat nimitietosi Helsinki-profiilissa, niin seuraavalla Suomi.fi-tunnistautumiskerralla nimitiedot päivittyvät väestötietojärjestelmän tietojen mukaisesti.
+                  </p>
+                  <p>
+                    Voit lisätä tai muuttaa itse syöttämiäsi tietoja Lisää-painikkeella tai Muokkaa-painikkeella. Tiedot tallentuvat tietokantaan Tallenna-painikkeella.
+                  </p>
+                  <p>
+                    Helsinki-profiilin asiointikieli-kohta määrittää, millä kielellä esimerkiksi palvelun sähköpostit lähetetään. Näet myös miten olet tunnistautunut Helsinki-profiiliin.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä."
+                      loading="lazy"
+                      src="/src/userGuide/assets/21-omat-tiedot.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
+                      loading="lazy"
+                      src="/src/userGuide/assets/22-omat-nimitiedot.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
+                      loading="lazy"
+                      src="/src/userGuide/assets/23-omat-yhteystiedot.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Profiili-tietojen muokkaaminen"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Profiili_tietojen_muokkaaminen-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-29"
+                id="_Tietojen_käsittely_eri"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Tietojen_käsittely_eri-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Tietojen_käsittely_eri-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Tietojen käsittely eri palveluissa
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Tietojen_käsittely_eri-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Tietojen_käsittely_eri-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Palvelut hyödyntävät Helsinki-profiilin hallinnoimia tietoja ilmoittamallaan tavalla. Kirjautumalla ensimmäisen kerran palveluun näet mitä tietoja palvelu hyödyntää.
+                  </p>
+                  <p>
+                    Helsinki-profiilissa voit tarkistaa myöhemmin nämä tiedot sekä halutessasi poistaa tietosi palvelusta. Poisto ei ole mahdollista, jos asiointi on kesken palvelussa. On myös suositeltavaa
+                     
+                    <a
+                      href="#_Tietojen_lataaminen"
+                    >
+                      ladata omat tiedot talteen
+                    </a>
+                     ennen poistoa.
+                  </p>
+                  <div>
+                    <img
+                      alt="Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+            Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä."
+                      loading="lazy"
+                      src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+            Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+            tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista."
+                      loading="lazy"
+                      src="/src/userGuide/assets/25-kayttamasi-palvelut.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+            tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Tietojen käsittely eri palveluissa"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Tietojen_käsittely_eri-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-30"
+                id="_Tietojen_lataaminen"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Tietojen_lataaminen-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Tietojen_lataaminen-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Tietojesi lataaminen
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Tietojen_lataaminen-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Tietojen_lataaminen-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Voit ladata eri palveluihin tallentamasi tiedot yhtenä json-tiedostona. Lisää tietoa
+                     
+                    <a
+                      href="https://fi.wikipedia.org/wiki/JSON"
+                    >
+                      json-tiedostomuodosta Wikipediassa (linkki avautuu uuteen ikkunaan)
+                    </a>
+                    . Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, tietojen lataus pitää tehdä Suomi.fi-tunnistautuneena.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
+                      loading="lazy"
+                      src="/src/userGuide/assets/26-tietojen-lataus.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Tietojesi lataaminen"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Tietojen_lataaminen-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Tietojen_poisto"
+              >
+                Tietojen poisto
+              </h2>
+              <p>
+                Voit poistaa tietosi yksittäisistä palveluista tai halutessasi koko profiilin. Poiston myötä kaikki tietosi palvelusta poistetaan. Jos palvelu joutuu esim. lakisääteisistä syistä säilyttämään tietoja, tiedot anonymisoidaan poiston sijaan. Sinulla ei kuitenkaan ole poiston jälkeen pääsyä tietoihin, eikä niitä voi yhdistää sinuun.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-31"
+                id="_Tietojen_poisto"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Tietojen_poisto-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Tietojen_poisto-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Tietojesi poisto yksittäisestä palvelusta
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Tietojen_poisto-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Tietojen_poisto-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, palvelun poistaminen pitää tehdä Suomi.fi-tunnistautuneena.
+                  </p>
+                  <p>
+                    Kun valitset poistettavan palvelun Käyttämäsi palvelut -välilehdellä, saat ponnahdusikkunaan vahvistusviestin poistosta.
+                  </p>
+                  <div>
+                    <img
+                      alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
+                      loading="lazy"
+                      src="/src/userGuide/assets/27-tietojen-poisto-palvelusta.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa."
+                      loading="lazy"
+                      src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Tietojesi poisto yksittäisestä palvelusta"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Tietojen_poisto-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-32"
+                id="_Profiilin_poisto"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Profiilin_poisto-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Profiilin_poisto-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Helsinki-profiilin poisto
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Profiilin_poisto-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Profiilin_poisto-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Jos haluat poistaa koko Helsinki-profiilin, voit tehdä sen Poista omat tiedot -näppäintä painamalla. Tämän jälkeen sinulta vielä varmistetaan, että haluat poistaa tietosi. Vahvistamalla pyynnön kaikki tiedot poistetaan profiilista sekä kaikista asiointipalveluista, jos mitään asiointia ei ole kesken.
+                  </p>
+                  <p>
+                    Jotkin lakisääteiset asiointipalvelut voivat edellyttää tietojen säilyttämistä määräajan tai pysyvästi. Asioinnista ja asiointipalvelusta riippuen tiedot voidaan joissakin tapauksissa anonymisoida. Jos lakisääteisen palvelun pitää säilyttää tiedot, tällöin profiilia tai kyseisen palvelun käyttöoikeutta tietoihin ei voida poistaa.
+                  </p>
+                  <p>
+                    Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, profiilin poisto pitää tehdä Suomi.fi-tunnistautuneena.
+                  </p>
+                  <p>
+                    Helsinki-profiilin poistamisen jälkeen voit aina tarvittaessa tehdä uuden profiilin, mutta kaikki aiemmat tiedot on menetetty.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
+                      loading="lazy"
+                      src="/src/userGuide/assets/29-tietojen-poisto.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
+                      loading="lazy"
+                      src="/src/userGuide/assets/30-tietojen-poisto-popup.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Sulje Helsinki-profiilin poisto"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Profiilin_poisto-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Sulje
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <footer
+        class="Footer-module_footer__1aD3T custom-theme-33"
+      >
+        <div
+          class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+          style="height: 15px;"
+        >
+          <svg
+            aria-hidden="true"
+            height="85"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <defs>
+              <pattern
+                height="85"
+                id="koros_basic-34"
+                patternUnits="userSpaceOnUse"
+                width="96"
+                x="0"
+                y="0"
+              >
+                <path
+                  d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                  transform="scale(3)"
+                />
+              </pattern>
+            </defs>
+            <rect
+              fill="url(#koros_basic-34)"
+              height="85"
+              style="shape-rendering: crispEdges;"
+              width="100%"
+            />
+          </svg>
+        </div>
+        <div
+          class="Footer-module_footerContent__3MC14"
+        >
+          <div
+            class="Footer-module_footerSections__2nrr8"
+          >
+            <h2
+              class="Footer-module_title__269y7"
+            >
+              appName
+            </h2>
+            <div
+              class="FooterUtilities-module_utilities__10PzW"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterUtilities-module_divider__2VjbX"
+              />
+              <div
+                class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+              >
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.needHelp
+                    </h3>
+                    <a
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="/guide"
+                    >
+                      <span>
+                        footer.userGuide
+                      </span>
+                    </a>
+                    <div
+                      variant="utility"
+                    >
+                      <span>
+                        footer.helsinkiProfileSupport
+                      </span>
+                      <ul
+                        class="contacts-list"
+                      >
+                        <li>
+                          footer.openingHours
+                        </li>
+                        <li>
+                          <a
+                            class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                            href="tel:0931088800"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label="phone"
+                              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                            <span>
+                              09 310 88800
+                            </span>
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.otherContactInformation
+                    </h3>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.contactUsLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.contactUs
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.feedbackLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.feedback
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="FooterBase-module_base__2f0eu"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterBase-module_divider__3sz3q"
+              />
+              <div
+                class="FooterBase-module_logoWrapper__3BI7d"
+              >
+                <a
+                  class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                  href="https://hel.fi/fi"
+                  tabindex="0"
+                >
+                  <img
+                    alt="cityOfHelsinki"
+                    class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                    src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgY2xhc3M9IkxvZ28tbW9kdWxlX2xvZ29fX1kybXdQIExvZ28tbW9kdWxlX21lZGl1bV9fMXp5V20iIGFyaWEtaGlkZGVuPSJ0cnVlIiBzdHlsZT0iCiAgICBjb2xvcjogd2hpdGU7CiI+CiAgICA8cGF0aAogICAgICAgIGQ9Ik03NS43NTMgMi4yNTF2MjAuN2MwIDMuOTUtMy4yNzUgNy4xNzgtNy4zMSA3LjE3OGgtMjIuMjZjLTIuNjc0IDAtNS4yMDUuOTYtNy4xODMgMi43MzlhMTAuNzQ5IDEwLjc0OSAwIDAwLTcuMTgzLTIuNzRIOS41MDljLTQuMDAzIDAtNy4yNDctMy4yMS03LjI0Ny03LjE3N1YyLjI1aDczLjQ5MXpNNDAuMTg3IDM0LjgzNWE4LjQ3IDguNDcgMCAwMTYuMDEyLTIuNDcxaDIyLjI0NWM1LjI2OCAwIDkuNTU2LTQuMjE5IDkuNTU2LTkuNDEzVjBIMHYyMi45MzVjMCA1LjE5NCA0LjI1NiA5LjQxMyA5LjUwOSA5LjQxM2gyMi4zMDhjMi4yNjMgMCA0LjM5OC44ODIgNi4wMTIgMi40NzFMMzkuMDE2IDM2bDEuMTctMS4xNjV6IgogICAgICAgIGZpbGw9ImN1cnJlbnRDb2xvciI+PC9wYXRoPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiPjwvcGF0aD4KPC9zdmc+"
+                  />
+                </a>
+              </div>
+              <div
+                class="FooterBase-module_copyright__2iiev"
+              >
+                <span>
+                  © 
+                  cityOfHelsinki
+                   
+                  2024
+                </span>
+                <span
+                  class="FooterBase-module_copyrightDot__2AfS6"
+                >
+                  •
+                </span>
+                <span>
+                  footer.reserveRights
+                </span>
+              </div>
+              <div
+                class="FooterBase-module_baseActions__1hCiR"
+              >
+                <div
+                  class="FooterBase-module_links__3lfLo"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <a
+                    aria-label="opensInNewWindow"
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                    href="profileForm.termsFileDescriptionLink"
+                    target="_blank"
+                  >
+                    <span>
+                      footer.privacy
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="link-external"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                </div>
+                <button
+                  class="FooterBase-module_backToTopButton__hXTHm"
+                  role="link"
+                  type="button"
+                >
+                  footer.backToTop
+                  <svg
+                    aria-hidden="true"
+                    aria-label="arrow-up"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`User guide > renders UserGuide component in Swedish 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wrapper"
+      >
+        <header
+          class="hds-header Header-module_header__291GF"
+        >
+          <div
+            class="Header-module_headerBackgroundWrapper__KsFy2"
+          >
+            <a
+              class="SkipLink-module_skipLink__1knzF"
+              href="#main-content"
+            >
+              <span
+                class="SkipLink-module_skipLinkLabel__21n5B"
+              >
+                skipToContent
+              </span>
+            </a>
+            <div
+              class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+            >
+              <div
+                class="HeaderActionBar-module_headerActionBar__lPeGE"
+              >
+                <span
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                  role="link"
+                >
+                  <span
+                    class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                  >
+                    <img
+                      alt="helsinkiLogo"
+                      class="Logo-module_logo__Y2mwP"
+                      src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTA0IDM2IiB0aXRsZT0iSGVsc2luZ2ZvcnMgc3RhZCIgcm9sZT0iaW1nIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPHBhdGgKICAgICAgICBkPSJNMTAzLjEwNSAwdjIyLjkzNWMwIDUuMTc5LTQuMjY2IDkuMzk3LTkuNTI0IDkuMzk3bC0zNC44NjcuMDMyYTguNDYgOC40NiAwIDAwLTUuOTgxIDIuNDcxTDUxLjU1MyAzNmwtMS4xODEtMS4xNjVhOC40MDUgOC40MDUgMCAwMC01Ljk4Mi0yLjQ3MUg5LjQ3NkM0LjI1IDMyLjM2NCAwIDI4LjE0NSAwIDIyLjk2NlYwaDEwMy4xMDV6bS0yLjIzNiAyLjIzNUgyLjI1MXYyMC43MzFjMCAzLjk1MSAzLjI0MyA3LjE2MyA3LjIyNSA3LjE2M0g0NC4zOWMyLjY3NiAwIDUuMTk1Ljk2IDcuMTYyIDIuNzM5IDEuOTY4LTEuNzggNC40ODYtMi43NCA3LjE2Mi0yLjc0bDM0Ljg2Ny0uMDNjNC4wMTQgMCA3LjI4OC0zLjIxMiA3LjI4OC03LjE2M3YtMjAuN3pNNjIuMDIgMTIuMDlsMiAxLjE1Yy0uMDMyIDEuMDA3LS40ODkgMS40NzktMS4zNTQgMS40NzktLjIwNSAwLS40NzMtLjA0Ny0uNjE0LS4wOTR2LjA2MmMuNDI1LjMzMS45NDQuODgyLjk0NCAxLjc2MyAwIDEuNTEyLTEuNDY0IDIuNDcyLTMuMjc0IDIuNDcyLS44MzQgMC0xLjU1OC4yNjctMS41NTguNjc3IDAgLjMxNS4yNjcuNDU2LjkxMy40NTYuNjQ1IDAgMS4zNjktLjEyNiAyLjIwMy0uMTI2IDEuNjUzIDAgMi43NTUuNjYxIDIuNzU1IDIuMTU3IDAgMS43OTQtMi4wMTUgMi41MDMtNC4yODIgMi41MDMtMi4xMDkgMC00LjAzLS41OTgtNC4wMy0xLjk1MiAwLS44MTkuODUtMS4zMDcgMS42MjItMS40NDh2LS4wNDhjLS41ODItLjE3My0xLjEwMi0uNTUtMS4xMDItMS4yMTIgMC0uODY1Ljg4Mi0xLjMzOCAxLjc3OS0xLjUyN3YtLjA0N2MtLjgzNC0uMzMtMS41NDMtMS4wMDctMS41NDMtMi4xODggMC0xLjUxMSAxLjMyMi0yLjU1IDMuMTMzLTIuNTUuNjkyIDAgMS4wODYuMTQyIDEuNjA1LjE0Mi42NDYgMCAuODgyLS4zNjIuODgyLS45NDUgMC0uMjY3LS4wNDctLjUzNS0uMDc5LS43MjR6bS0xLjczMSA5LjU0Yy0uOTMgMC0yLjcyNC4wNzgtMi43MjQuNzg2IDAgLjUzNi44OTguNzg3IDIuMTU3LjgwMyAxLjQxNyAwIDIuMjM1LS4yNjcgMi4yMzUtLjkxMyAwLS41MDQtLjc1NS0uNjc3LTEuNjY4LS42Nzd6bTI4Ljk5NS04LjAxM2MxLjUyNyAwIDIuOTI4LjcyNCAzLjUyNiAxLjc0N2wtMS44NDIgMS4wNGExLjYyNCAxLjYyNCAwIDAwLTEuNjA2LTEuMjEzYy0uNTUgMC0xLjAwNy4yMzYtMS4wMDcuNjc3IDAgLjU4MiAxLjAwNy42NDUgMi4xNTcgMS4wMDggMS4xOTYuMzc3IDIuMjk4LjkyOCAyLjI5OCAyLjMzIDAgMS41NDItMS40MzMgMi40NTUtMy4xMDEgMi40NTUtMS43OTUgMC0zLjIxMS0uNzcxLTMuODQxLTEuOTg0bDEuODczLTEuMDU0Yy4yNTIuODM0LjkxMyAxLjQ2NCAxLjkzNiAxLjQ2NC41OTggMCAxLjAyMy0uMjY4IDEuMDIzLS43NCAwLS42MTQtLjg1LS43NTYtMS44NDEtMS4wMjMtMS4xNjUtLjMxNS0yLjYxMy0uODgyLTIuNjEzLTIuMzQ2IDAtMS40NDggMS4zODUtMi4zNiAzLjAzOC0yLjM2em0tMTQuNjU1IDBjMi4wNzggMCAzLjY5OSAxLjUyNyAzLjY5OSA0LjAxNHMtMS42MDYgNC4wMTQtMy43IDQuMDE0Yy0yLjEwOSAwLTMuNzE0LTEuNTI3LTMuNzE0LTQuMDE0czEuNjA1LTQuMDE0IDMuNzE1LTQuMDE0em0tNDkuNjggMGMyLjA2MyAwIDMuNDMyIDEuNDY0IDMuNDMyIDMuNTQyLjAxNi42MTQtLjA5NCAxLjAzOS0uMDk0IDEuMDM5aC00Ljk3NGMuMDk0IDEuMjQzLjc4NyAxLjg1NyAxLjY4NCAxLjg1Ny44MDMgMCAxLjM1NC0uNTM1IDEuNDgtMS4yNmwxLjgxIDEuMDI0Yy0uNTM1Ljk3Ni0xLjY4NCAxLjgyNi0zLjI5IDEuODI2LTIuMTQgMC0zLjcxNS0xLjQ5NS0zLjcxNS00LjAxNCAwLTIuNDg3IDEuNjA2LTQuMDE0IDMuNjY4LTQuMDE0em0xMy4wNjYtLjAxNmMxLjUyNyAwIDIuOTI4LjcyNCAzLjUyNiAxLjc0OGwtMS44NDIgMS4wMzljLS4xODktLjY3Ny0uNzU1LTEuMjEzLTEuNjA1LTEuMjEzLS41NTEgMC0xLjAwOC4yMzctMS4wMDguNjc3IDAgLjU4MyAxLjAwOC42NDYgMi4xNCAxLjAwOCAxLjE5Ny4zNzggMi4zLjkyOCAyLjMgMi4zMyAwIDEuNTQyLTEuNDMzIDIuNDQtMy4wODYgMi40NC0xLjc5NSAwLTMuMjExLS43NTYtMy44NDEtMS45ODRsMS44NzMtMS4wNTVjLjIzNi44MzUuOTEzIDEuNDY0IDEuOTM2IDEuNDY0LjU4My4wMTYgMS4wMDgtLjIzNiAxLjAwOC0uNzI0IDAtLjYxNC0uODUtLjc0LTEuODQyLTEuMDIzLTEuMTY1LS4zLTIuNTk3LS44ODItMi41OTctMi4zNDUgMC0xLjQ0OSAxLjM4NS0yLjM2MiAzLjAzOC0yLjM2MnpNMzIuMyAxMC41M3Y4LjUwMWMwIC4zNjIuMDQ3LjYxNC4xNTcuNzU2LjA5NS4xNTcuMjIuMjIuNTA0LjIyLjE3MyAwIC4zMyAwIC40NTYtLjAzMWEyLjAxIDIuMDEgMCAwMC40NTctLjEyNmwtLjE4OSAxLjQ0OGEyLjUzMiAyLjUzMiAwIDAxLS42NDUuMjM2Yy0uMjUyLjA0Ny0uNTIuMDc5LS43NzIuMDc5LS43NCAwLTEuMjc1LS4xNzQtMS42MjEtLjUzNi0uMzMtLjM2Mi0uNTA0LS45NDQtLjUwNC0xLjczMVYxMC41M2gyLjE1N3ptMTkuODE4IDMuMDg2YzEuNDggMCAyLjQwOCAxLjAyMyAyLjQwOCAyLjkyOHY0LjkxMWgtMi4xNTZWMTYuOTdjMC0xLjAwNy0uMzYyLTEuNTQzLTEuMTY1LTEuNTQzcy0xLjMyMi42MTQtMS4zMjIgMS40OTZ2NC41NDloLTIuMTQxdi03LjY2NmgyLjE0bC0uMTEgMS4yNmguMDQ4Yy4zNzgtLjcxIDEuMDM5LTEuNDQ5IDIuMjk4LTEuNDQ5em0xNi43MzMtMy4zMzdhMy4yNyAzLjI3IDAgMDEyLjczOSAxLjRsLTEuODU4IDEuMTM0Yy0uMDMxLS40NTYtLjI1Mi0uOTI4LS43NzEtLjkyOC0uNTM1IDAtLjc4Ny40MDktLjc4NyAxLjA4NnYuODM0aDEuNjg0djEuNjM3aC0xLjY4NHY2LjAyOWgtMi4xNHYtNi4wMjloLTEuMTgxdi0xLjYzN2gxLjE4di0uODE5YzAtMS43OTQgMS4xOC0yLjcwNyAyLjgxOC0yLjcwN3ptMTQuODEyIDMuMzg0YzEuMDg2IDAgMS42ODQuOTEzIDEuNjg0IDIuMDMgMCAuNTA1LS4wNzguODk4LS4wNzguODk4bC0xLjkzNiAxLjExOGMuMDMxLS4yMi4xMjYtLjc0LjEyNi0xLjI2IDAtLjUwMy0uMTktLjk3NS0uNzI1LS45NzUtLjY3NiAwLS45NDQuNjMtLjk0NCAxLjYydjQuMzc3aC0yLjE1N3YtNy42NWgyLjE1N2wtLjExIDEuMjU5aC4wNDdjLjM3OC0uNzQuOTYtMS40MTcgMS45MzYtMS40MTd6bS03MC41Mi0yLjcyM3Y0LjE3MWg0LjIwM3YtNC4xN2gyLjIzNXYxMC41MTRoLTIuMjM1di00LjM2aC00LjIwM3Y0LjM2aC0yLjIzNVYxMC45NGgyLjIzNXptMzIuMzMyIDIuODV2Ny42NjVINDMuMzJWMTMuNzloMi4xNTZ6bTI5LjE1MyAxLjQ2M2MtMS4wNyAwLTEuNTQzIDEuMDA4LTEuNTQzIDIuMzc3IDAgMS4zNy40NzIgMi4zNzcgMS41NDMgMi4zNzcgMS4wNTQgMCAxLjUyNy0xLjAwNyAxLjUyNy0yLjM3NyAwLTEuMzctLjQ3My0yLjM3Ny0xLjUyNy0yLjM3N3ptLTE0Ljg5MS0uMTg5Yy0uNzI0IDAtMS4zMDcuNDczLTEuMzA3IDEuMTk3IDAgLjc0LjU4MyAxLjIxMiAxLjMwNyAxLjE5Ni43MjQgMCAxLjMwNi0uNDcyIDEuMzA2LTEuMTk2cy0uNTgyLTEuMTk3LTEuMzA2LTEuMTk3em0tMzQuNzczLjA5NWMtLjc4NyAwLTEuNDMyLjU2Ni0xLjYwNSAxLjYwNWgzLjAzOGMwLS45MTMtLjU5OC0xLjYwNS0xLjQzMy0xLjYwNXptMTkuNDQtNC42NzVjLjY5MyAwIDEuMjQ0LjUwMyAxLjI0NCAxLjE5NnMtLjU1IDEuMTk2LTEuMjQzIDEuMTk2Yy0uNzA5IDAtMS4yNDQtLjUwMy0xLjI0NC0xLjE5NnMuNTUxLTEuMTk2IDEuMjQ0LTEuMTk2eiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                    />
+                  </span>
+                </span>
+                <a
+                  aria-label="nav.titleAriaLabel"
+                  class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                  href="/"
+                >
+                  <span
+                    class="HeaderActionBar-module_title__opzt9"
+                  >
+                    appName
+                  </span>
+                </a>
+                <div
+                  class="HeaderActionBar-module_headerActions__3lNnM"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                  >
+                    <div
+                      class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                    >
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="fi"
+                        type="button"
+                      >
+                        <span>
+                          Suomi
+                        </span>
+                      </button>
+                      <button
+                        aria-current="true"
+                        class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                        lang="sv"
+                        type="button"
+                      >
+                        <span>
+                          Svenska
+                        </span>
+                      </button>
+                      <button
+                        aria-current="false"
+                        class="HeaderLanguageSelector-module_item__3_I7N"
+                        lang="en"
+                        type="button"
+                      >
+                        <span>
+                          English
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <hr
+                    aria-hidden="true"
+                  />
+                  <button
+                    aria-label="nav.signin"
+                    class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                    data-hds-header-error-usage="login"
+                    id="action-bar-login-action"
+                    type="button"
+                  >
+                    <div
+                      class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                    >
+                      <span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-label="signin"
+                            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                        >
+                          nav.signin
+                        </span>
+                      </span>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <main
+          class="content"
+          id="main-content"
+        >
+          <div
+            class="wrapper"
+          >
+            <div
+              class="common-content-area common-bottom-padding content"
+            >
+              <div
+                class="inner-content"
+              >
+                <h1
+                  class="page-load-focus-element hide-focus-borders"
+                  tabindex="-1"
+                >
+                  Helsingforsprofilens hjälp
+                </h1>
+                <p>
+                  Helsingforsprofilen är kundprofilen för en medborgare som använder stadens digitala tjänster. Den är det primära autentiseringsmedlet för stadens digitala tjänster. Helsingforsprofilen samlar kundens person- och kontaktuppgifter samt länkar till stadens olika tjänster på ett och samma ställe. Med hjälp av profilen kan användaren hantera sina egna uppgifter och deras synlighet i olika tjänster.
+                </p>
+                <a
+                  class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                  download="Helsingforsprofilens-hjalp.pdf"
+                  href="/Helsingforsprofilens-hjalp.pdf"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label="download"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                  >
+                    Helsingforsprofilens hjälp (.pdf)
+                  </span>
+                </a>
+                <div
+                  class="table-of-contents"
+                >
+                  <div
+                    class="table-of-contents__container"
+                  >
+                    <h2
+                      class="table-of-contents__title"
+                    >
+                      På den här sidan
+                    </h2>
+                    <nav
+                      class="table-of-contents__content"
+                      id="helfi-toc-table-of-contents-list"
+                    >
+                      <ul
+                        class="table-of-contents__list"
+                      >
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Create_a_Helsinki_profile"
+                          >
+                            Skapa en Helsingforsprofilen
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Login"
+                          >
+                            Logga in
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_viewing_and_editing"
+                          >
+                            Visa och redigera dina egna uppgifter
+                          </a>
+                        </li>
+                        <li
+                          class="table-of-contents__item"
+                        >
+                          <a
+                            class="table-of-contents__link"
+                            href="#_Deleting_your_information"
+                          >
+                            Radering av uppgifter
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+                <h2
+                  id="_Create_a_Helsinki_profile"
+                >
+                  Skapa en Helsingforsprofilen
+                </h2>
+                <p>
+                  Helsingfors-profilen används för att logga in i Helsingfors stads tjänster. Första gången du loggar in blir du ombedd att skapa en Helsingforsprofilen och ge ditt samtycke till att de uppgifter som tjänsten kräver får användas.
+                </p>
+                <p>
+                  Du kan också skapa en Helsingforsprofil på
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                  .
+                </p>
+                <p>
+                  Du kan skapa en Helsingforsprofilen med din Suomi.fi-identifikation eller med din e-post och ditt lösenord. Du kan också logga in i Helsingfors stads digitala tjänster med Google eller Yle Konto, som tas ur bruk 2024.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-45"
+                  id="_Suomi.fi_identifiering"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Suomi.fi_identifiering-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Suomi.fi_identifiering-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Suomi.fi identifiering
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Suomi.fi_identifiering-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Suomi.fi_identifiering-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Val av autentisering
+                    </h4>
+                    <p>
+                      Efter att ha tryckt på länken Logga in i kundtjänsten visas en skärm med olika inloggningsalternativ, där inloggningen till Suomi.fi väljs. Visningen av inloggningsalternativen varierar från en tjänst till en annan.
+                    </p>
+                    <div>
+                      <img
+                        alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+                        loading="lazy"
+                        src="/src/userGuide/assets/01-sisaankirjautuminen-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I autentiseringsfönstret väljer du Suomi.fi-identifikation.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+                        loading="lazy"
+                        src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I autentiseringsfönstret väljer du Suomi.fi-identifikation.
+                      </p>
+                    </div>
+                    <h4>
+                      Identifiering i tjänsten Suomi.fi
+                    </h4>
+                    <p>
+                      Efter att ha valt Suomi.fi-inloggning presenteras användaren med olika inloggningsalternativ. Alternativen är desamma som för andra myndighetstjänster som erbjuder stark autentisering.
+                    </p>
+                    <p>
+                      Efter autentiseringen ska du kontrollera att de uppgifter du använder är korrekta. Om du hittar fel i uppgifterna ska de korrigeras i Befolkningsregistercentralens tjänst.
+                    </p>
+                    <div>
+                      <img
+                        alt="Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi."
+                        loading="lazy"
+                        src="/src/userGuide/assets/03-vahvan-valinta-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta."
+                        loading="lazy"
+                        src="/src/userGuide/assets/04-vahvat-tiedot-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta.
+                      </p>
+                    </div>
+                    <h4>
+                      Verifiering av e-postadress
+                    </h4>
+                    <p>
+                      Efter autentiseringen kommer du att bli ombedd att ange din e-postadress. Ett bekräftelsemeddelande skickas till e-postadressen för att verifiera att adressen är äkta.
+                    </p>
+                    <p>
+                      För att validera din e-post får du en sexsiffrig kod för den e-postadress du angav, som du måste ange i fältet på skärmen. I så fall kombineras de olika autentiseringsmetoderna och du kan se alla tjänster du använder på en gång.
+                       
+                      <b>
+                        Observera dock att du inte kommer att kunna koppla bort dem senare.
+                      </b>
+                    </p>
+                    <p>
+                      För att bekräfta din e-post får du en 6-siffrig kod till den e-postadress du angav. Om meddelandet inte kommer till din inbox nästan omedelbart, kontrollera din skräppostmapp.
+                    </p>
+                    <p>
+                      <b>
+                        Stäng inte webbläsarfönstret i din Helsingforsprofil när du hämtar bekräftelsemeddelandet från din e-post. I annat fall kommer systemet att anta att du har avbrutit autentiseringsprocessen.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret.
+                      </p>
+                    </div>
+                    <h4>
+                      Skapa en Helsingforsprofilen
+                    </h4>
+                    <p>
+                      När du har bekräftat e-postmeddelandet måste du fortfarande ge ditt samtycke till att dina uppgifter används. Utan samtycke kan Helsingforsprofilen inte skapas och tjänsterna kan inte använda dina uppgifter.
+                    </p>
+                    <p>
+                      Då har du Helsingforsprofilen och dina autentiseringsuppgifter för Suomi.fi sparas i din profil. Olika tjänster använder dina uppgifter på olika sätt, men de kommer alltid att berätta för dig hur de använder dem när du loggar in första gången. Informationen finns också alltid tillgänglig i din Helsingforsprofil.
+                    </p>
+                    <p>
+                      När du har skapat din Helsingforsprofil kommer du att vara inloggad på den tjänst där du inledde registreringsprocessen. Du hittar din Helsingforsprofil på adressen
+                       
+                      <a
+                        href="https://profiili.hel.fi"
+                      >
+                        https://profiili.hel.fi
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      Nästa gång du loggar in på samma tjänst väljer du bara Suomi.fi, det autentiseringsalternativ du valt och du är inne i tjänsten.
+                    </p>
+                    <div>
+                      <img
+                        alt="Innan du kan använda den tjänst du vill ha eller innan du kan skapa Helsingforsprofilen måste du 
+          ge ditt samtycke till att dina uppgifter används. Utan samtycke kan dina uppgifter inte användas och 
+          därför kan ingen profil skapas."
+                        loading="lazy"
+                        src="/src/userGuide/assets/08-profiilin-luominen-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Innan du kan använda den tjänst du vill ha eller innan du kan skapa Helsingforsprofilen måste du 
+          ge ditt samtycke till att dina uppgifter används. Utan samtycke kan dina uppgifter inte användas och 
+          därför kan ingen profil skapas.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Suomi.fi identifiering"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Suomi.fi_identifiering-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-46"
+                  id="_Identifiering_av_e-post"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Identifiering_av_e-post-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Identifiering_av_e-post-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Identifiering av e-post
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Identifiering_av_e-post-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Identifiering_av_e-post-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <h4>
+                      Val av autentisering
+                    </h4>
+                    <p>
+                      När du har tryckt på länken Logga in i kundtjänsten ser du olika inloggningsalternativ, där du kan välja Skapa Helsingforsprofil. Visningen av inloggningsalternativen varierar från en tjänst till en annan.
+                    </p>
+                    <div>
+                      <img
+                        alt="Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen."
+                        loading="lazy"
+                        src="/src/userGuide/assets/09-helsinki-tunnus-luonti-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen.
+                      </p>
+                    </div>
+                    <h4>
+                      Verifiering av e-postadress
+                    </h4>
+                    <p>
+                      Du kommer att bli ombedd att ange din e-postadress, till vilken ett bekräftelsemeddelande kommer att skickas för att verifiera adressens äkthet.
+                    </p>
+                    <p>
+                      Om du redan har skapat Helsingforsprofilen med Suomi.fi-autentisering, kan du skapa ett lösenord för din profil genom att klicka på länken Jag har glömt mitt lösenord. Mer information om hur du skapar ett lösenord finns under 
+                      <a
+                        href="#_Glömt_lösenord"
+                      >
+                        Glömt lösenord
+                      </a>
+                      . De olika autentiseringsmetoderna kommer sedan att slås samman och du kommer att kunna se all information om alla de tjänster du använder på en gång.
+                       
+                      <b>
+                        Observera dock att du inte kommer att kunna avbryta sammanslagningen senare.
+                      </b>
+                    </p>
+                    <p>
+                      För att validera din e-postadress får du en 6-siffrig kod till den e-postadress du angav. Om meddelandet inte kommer till din inkorg nästan omedelbart, kontrollera din skräppostmapp.
+                    </p>
+                    <p>
+                      <b>
+                        Stäng inte webbläsarfönstret i din Helsingforsprofil när du hämtar bekräftelsemeddelandet från din e-post.
+                      </b>
+                      <b>
+                        I annat fall kommer systemet att anta att du har avbrutit autentiseringsprocessen.
+                      </b>
+                    </p>
+                    <div>
+                      <img
+                        alt="Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare."
+                        loading="lazy"
+                        src="/src/userGuide/assets/05-10-sahkopostiosoite-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
+                        loading="lazy"
+                        src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+                        loading="lazy"
+                        src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret.
+                      </p>
+                    </div>
+                    <h4>
+                      Skapa en Helsingforsprofilen
+                    </h4>
+                    <p>
+                      När du har bekräftat e-postmeddelandet fyller du i ditt namn och lösenord. Ditt lösenord måste vara minst 12 tecken långt och innehålla stora och små bokstäver, siffror och specialtecken.
+                    </p>
+                    <p>
+                      Bekräfta att du samtycker till användningen av dina uppgifter. Utan ditt samtycke kan din Helsingforsprofil inte skapas och dina uppgifter kan inte användas av tjänsterna.
+                    </p>
+                    <p>
+                      Nu har du Helsingforsprofilen. Det Helsingfors-ID du behöver för att autentisera dig till tjänsterna är denna kombination av e-postadress och lösenord.
+                    </p>
+                    <div>
+                      <img
+                        alt="När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
+            också ge ditt samtycke till att dina uppgifter används för att skapa Helsingforsprofilen."
+                        loading="lazy"
+                        src="/src/userGuide/assets/13-helsinki-tunnus-teko-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
+            också ge ditt samtycke till att dina uppgifter används för att skapa Helsingforsprofilen.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Identifiering av e-post"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Identifiering_av_e-post-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-47"
+                  id="_Kombinera_identifieringsmetoder"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Kombinera_identifieringsmetoder-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Kombinera_identifieringsmetoder-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Kombinera identifieringsmetoder
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Kombinera_identifieringsmetoder-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Kombinera_identifieringsmetoder-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Om du vill kan du kombinera olika autentiseringsmetoder i en enda Helsingforsprofil, så att du kan se och hantera alla dina data och tjänster på en gång. Detta kan göras genom att först skapa ett Helsingfors-ID med en e-postadress/lösenordskombination och sedan använda samma e-postadress för den första Suomi.fi-inloggningen.
+                    </p>
+                    <p>
+                      <b>
+                        Observera dock att du inte kommer att kunna koppla bort dem senare.
+                      </b>
+                    </p>
+                    <p>
+                      Om din Helsingforsprofil skapades med en Suomi.fi-autentisering kan du klicka på länken 
+                      <i>
+                        Jag har glömt mitt lösenord 
+                      </i>
+                      på inloggningsskärmen. För instruktioner om hur du gör detta, se avsnittet 
+                      <a
+                        href="#_Glömt_lösenord"
+                      >
+                        Glömt lösenord
+                      </a>
+                       nedan.
+                    </p>
+                    <button
+                      aria-label="Stäng Kombinera identifieringsmetoder"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Kombinera_identifieringsmetoder-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Login"
+                >
+                  Logga in
+                </h2>
+                <p>
+                  Med din Helsingforsprofil kan du logga in på alla Helsingfors stads digitala tjänster. Du kan logga in med Suomi.fi-inloggningen eller med den e-postadress och det lösenord som du angav när du skapade din profil.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-48"
+                  id="_Glömt_lösenord"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Glömt_lösenord-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Glömt_lösenord-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Glömt lösenord
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Glömt_lösenord-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Glömt_lösenord-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Om du inte kommer ihåg ditt lösenord kan du skapa ett nytt i inloggningsfönstret genom att klicka på länken
+                       
+                      <i>
+                        Jag har glömt mitt lösenord
+                      </i>
+                      . Du kan också ha "glömt" ditt lösenord eftersom du tidigare har loggat in i tjänsten via Suomi.fi autentisering och då inte behövt ange ett lösenord.
+                    </p>
+                    <p>
+                      När du har angett din e-postadress kommer du att få en länk för att ange ett nytt lösenord i din e-post. Länken kommer att vara giltig i 30 minuter.
+                    </p>
+                    <p>
+                      Lösenordet måste vara minst 12 tecken långt. Det måste innehålla både stora och små bokstäver, nummer och specialtecken.
+                    </p>
+                    <div>
+                      <img
+                        alt="I inloggningsfönstret klickar du på länken Jag har glömt mitt lösenord."
+                        loading="lazy"
+                        src="/src/userGuide/assets/14-salasanan-unohdus-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I inloggningsfönstret klickar du på länken Jag har glömt mitt lösenord.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post."
+                        loading="lazy"
+                        src="/src/userGuide/assets/15-sahkoposti-salasanalle-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord."
+                        loading="lazy"
+                        src="/src/userGuide/assets/16-salasanan-vaihtopyynto-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
+            kommer att vara giltig i 30 minuter."
+                        loading="lazy"
+                        src="/src/userGuide/assets/17-salasanan-vaihtoviesti-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
+            kommer att vara giltig i 30 minuter.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
+            12 tecken långt. Lösenordet måste innehålla både stora och små bokstäver, nummer och specialtecken."
+                        loading="lazy"
+                        src="/src/userGuide/assets/18-uusi-salasana-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
+            12 tecken långt. Lösenordet måste innehålla både stora och små bokstäver, nummer och specialtecken.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Glömt lösenord"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Glömt_lösenord-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-49"
+                  id="_Problem_med_identifiering"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Problem_med_identifiering-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Problem_med_identifiering-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Problem med identifiering
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Problem_med_identifiering-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Problem_med_identifiering-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      När du flyttar från en tjänst till en annan kan autentiseringen vara olika för de olika tjänsterna. Du loggade t.ex. in på den första tjänsten med ditt Helsingforsprofil, dvs. en kombination av e-post och lösenord, men den andra tjänsten kräver att du identifierar dig med Suomi.fi. I så fall får du ett meddelande om att autentiseringsmetoden inte är kompatibel. Du måste logga ut från den tidigare tjänsten för att autentisera dig i den nya tjänsten. Två olika autentiseringsmetoder kan inte vara öppna samtidigt.
+                    </p>
+                    <div>
+                      <img
+                        alt="En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
+            kombination av e-post och lösenord och går vidare till nästa tjänst, som kräver en Suomi.fi-autentisering. 
+            I detta fall måste du logga ut från den första tjänsten för att kunna autentisera dig till den nya tjänsten."
+                        loading="lazy"
+                        src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
+            kombination av e-post och lösenord och går vidare till nästa tjänst, som kräver en Suomi.fi-autentisering. 
+            I detta fall måste du logga ut från den första tjänsten för att kunna autentisera dig till den nya tjänsten.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Bekräfta din utloggning från en tidigare tjänst."
+                        loading="lazy"
+                        src="/src/userGuide/assets/20-kirjautumislogout-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Bekräfta din utloggning från en tidigare tjänst.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Problem med identifiering"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Problem_med_identifiering-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_viewing_and_editing"
+                >
+                  Visa och redigera dina egna uppgifter
+                </h2>
+                <p>
+                  Genom att logga in på din Helsingforsprofil på
+                   
+                  <a
+                    href="https://profiili.hel.fi"
+                  >
+                    https://profiili.hel.fi
+                  </a>
+                  kan du se och redigera dina uppgifter och hur de används av tjänsterna.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-50"
+                  id="_Redigera_profilinformation"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Redigera_profilinformation-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Redigera_profilinformation-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Redigera profilinformation
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Redigera_profilinformation-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Redigera_profilinformation-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      De officiella uppgifterna läggs till i din profil och syns endast när du autentiserar dig med Suomi.fi. Uppdateringen av uppgifterna görs i Befolkningsregistercentralens tjänst.
+                    </p>
+                    <p>
+                      I avsnittet Personuppgifter i din Helsingforsprofil kan du lägga till ett telefonnummer, ändra din e-postadress och lägga till adressuppgifter. Om du uppdaterar dina namnuppgifter i din Helsingforsprofil, kommer de officiella uppgifterna att uppdateras nästa gång du autentiserar dig in med Suomi.fi.
+                    </p>
+                    <p>
+                      Du kan lägga till eller ändra information som du själv har lagt in genom att klicka på knappen Lägg till, eller på knappen Redigera om informationen redan finns. Tryck på knappen Spara för att spara uppgifterna i databasen.
+                    </p>
+                    <p>
+                      I Helsingforsprofilen bestämmer avsnittet om tjänstens kontaktspråk på vilket språk t.ex. e-post från tjänsten ska skickas. Du kan också se hur du är autentiserad dig på din Helsingforsprofil.
+                    </p>
+                    <div>
+                      <img
+                        alt="I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
+            Befolkningsregistercentralen och uppdateras också där."
+                        loading="lazy"
+                        src="/src/userGuide/assets/21-omat-tiedot-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
+            Befolkningsregistercentralen och uppdateras också där.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information."
+                        loading="lazy"
+                        src="/src/userGuide/assets/22-omat-nimitiedot-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
+            Tjänstens kontaktspråk avgör på vilket språk du tar emot meddelanden från tjänsten. Den 
+            autentiseringsmetoden hur du är inloggad i tjänsten, dvs. Suomi.fi-autentisering eller en kombination 
+            av e-post och lösenord, dvs. Helsingfors-ID."
+                        loading="lazy"
+                        src="/src/userGuide/assets/23-omat-yhteystiedot-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
+            Tjänstens kontaktspråk avgör på vilket språk du tar emot meddelanden från tjänsten. Den 
+            autentiseringsmetoden hur du är inloggad i tjänsten, dvs. Suomi.fi-autentisering eller en kombination 
+            av e-post och lösenord, dvs. Helsingfors-ID.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Redigera profilinformation"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Redigera_profilinformation-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-51"
+                  id="_Olika_tjänsters_bearbetning"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Olika_tjänsters_bearbetning-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Olika_tjänsters_bearbetning-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Olika tjänsters bearbetning av dina uppgifter
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Olika_tjänsters_bearbetning-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Olika_tjänsters_bearbetning-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Tjänsterna kommer att använda de uppgifter som hanteras av Helsingforsprofilen enligt vad som anges. Första gången du identifierar dig i en tjänst kan du se vilka uppgifter tjänsten använder.
+                    </p>
+                    <p>
+                      I din Helsingforsprofil kan du kontrollera denna information senare och, om du vill, radera dina uppgifter från tjänsten. Det är inte möjligt att radera dina uppgifter om du befinner dig mitt i serviceprocessen. Det är också tillrådligt att
+                       
+                      <a
+                        href="#_Ladda_ner_din"
+                      >
+                        ladda ner dina egna information
+                      </a>
+                       innan du raderar dem.
+                    </p>
+                    <div>
+                      <img
+                        alt="När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
+            dina uppgifter som tjänsten kräver. Du kan senare återvända till denna information på avsnittet Dina 
+            tjänster i din Helsingforsprofil."
+                        loading="lazy"
+                        src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
+            dina uppgifter som tjänsten kräver. Du kan senare återvända till denna information på avsnittet Dina 
+            tjänster i din Helsingforsprofil.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="I avsnittet Dina tjänster i din Helsingforsprofil kan du se alla tjänster som du är autentiserad 
+          dig på och vilka data de använder. Du kan också radera dina uppgifter från enskilda tjänster."
+                        loading="lazy"
+                        src="/src/userGuide/assets/25-kayttamasi-palvelut-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I avsnittet Dina tjänster i din Helsingforsprofil kan du se alla tjänster som du är autentiserad 
+          dig på och vilka data de använder. Du kan också radera dina uppgifter från enskilda tjänster.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Olika tjänsters bearbetning av dina uppgifter"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Olika_tjänsters_bearbetning-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-52"
+                  id="_Ladda_ner_din"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Ladda_ner_din-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Ladda_ner_din-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Ladda ner din information
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Ladda_ner_din-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Ladda_ner_din-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Du kan ladda ner data som du har lagrat i olika tjänster som en enda json-fil. Mer information om
+                       
+                      <a
+                        href="https://sv.wikipedia.org/wiki/JSON"
+                      >
+                        filformatet json finns på Wikipedia (länken öppnas i ett nytt fönster)
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress + lösenord i samma Helsingforsprofil, måste datanerladdningen göras med Suomi.fi-autentiseringen.
+                    </p>
+                    <div>
+                      <img
+                        alt="I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil."
+                        loading="lazy"
+                        src="/src/userGuide/assets/26-tietojen-lataus-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Ladda ner din information"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Ladda_ner_din-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <h2
+                  id="_Deleting_your_information"
+                >
+                  Radering av uppgifter
+                </h2>
+                <p>
+                  Du kan radera dina uppgifter antingen för enskilda tjänster eller för hela din profil. Vid radering kommer alla dina uppgifter från tjänsten att raderas eller anonymiseras om tjänsten till exempel är skyldig enligt lag att behålla dem. Du kommer dock inte att ha tillgång till uppgifterna efter raderingen och de kommer inte att kunna kopplas till dig.
+                </p>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-53"
+                  id="_Radera_dina_uppgifter"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Radera_dina_uppgifter-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Radera_dina_uppgifter-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Radering av uppgifter från en och samma tjänst
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Radera_dina_uppgifter-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Radera_dina_uppgifter-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress och lösenord i samma Helsingforsprofil, måste du radera tjänsten medan du är autentiserad dig med Suomi.fi.
+                    </p>
+                    <p>
+                      När du väljer den tjänst som du vill ta bort på fliken Dina tjänster får du ett popup-meddelande som bekräftar borttagningen.
+                    </p>
+                    <div>
+                      <img
+                        alt="Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster."
+                        loading="lazy"
+                        src="/src/userGuide/assets/27-tietojen-poisto-palvelusta-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
+            popup-bekräftelsemeddelande på skärmen för att förhindra oavsiktlig radering av dina uppgifter."
+                        loading="lazy"
+                        src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
+            popup-bekräftelsemeddelande på skärmen för att förhindra oavsiktlig radering av dina uppgifter.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Radering av uppgifter från en och samma tjänst"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Radera_dina_uppgifter-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-54"
+                  id="_Radera_din_Helsingforsprofil"
+                  style="max-width: 800px; border: 1px solid #ffffff;"
+                >
+                  <div
+                    class="Accordion-module_accordionHeader__3_uK7"
+                  >
+                    <div
+                      aria-level="3"
+                      id="_Radera_din_Helsingforsprofil-heading"
+                      role="heading"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-labelledby="_Radera_din_Helsingforsprofil-heading"
+                        class="Accordion-module_headingContainer__1DzX3"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="label"
+                        >
+                          Radera din Helsingforsprofil
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-down"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="_Radera_din_Helsingforsprofil-heading"
+                    class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                    id="_Radera_din_Helsingforsprofil-content"
+                    role="region"
+                    style="display: none;"
+                  >
+                    <p>
+                      Om du vill radera hela din Helsingforsprofil kan du göra det genom att trycka på knappen 
+                      <i>
+                        Radera min information
+                      </i>
+                      . Du kommer då att se ett popup-fönster där du ombeds bekräfta att du vill radera din information. När du har bekräftat begäran raderas alla uppgifter från profilen och från alla tjänster, om ingen tjänst är på gång.
+                    </p>
+                    <p>
+                      Vissa lagstadgade tjänster kan kräva att uppgifter sparas under en begränsad eller permanent period. Beroende på transaktionen och tjänsten kan uppgifterna i vissa fall anonymiseras. Om en lagstadgad tjänst kräver att uppgifter sparas, kan profilen eller tjänstens tillgång till uppgifterna inte raderas.
+                    </p>
+                    <p>
+                      Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress och lösenord i samma Helsingforsprofil, måste du radera profilen medan du är autentiserad dig med Suomi.fi.
+                    </p>
+                    <p>
+                      Efter att du har raderat din Helsingforsprofil kan du alltid skapa en ny profil vid behov, men alla tidigare uppgifter försvinner.
+                    </p>
+                    <div>
+                      <img
+                        alt="I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
+            du kan radera hela din Helsingforsprofil och den information som du har använt i olika tjänster."
+                        loading="lazy"
+                        src="/src/userGuide/assets/29-tietojen-poisto-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
+            du kan radera hela din Helsingforsprofil och den information som du har använt i olika tjänster.
+                      </p>
+                    </div>
+                    <div>
+                      <img
+                        alt="Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data."
+                        loading="lazy"
+                        src="/src/userGuide/assets/30-tietojen-poisto-popup-sv.png"
+                      />
+                      <p
+                        class="image-text"
+                      >
+                        Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data.
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Stäng Radera din Helsingforsprofil"
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                      data-testid="_Radera_din_Helsingforsprofil-closeButton"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Stäng
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="angle-up"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <footer
+          class="Footer-module_footer__1aD3T custom-theme-55"
+        >
+          <div
+            class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+            style="height: 15px;"
+          >
+            <svg
+              aria-hidden="true"
+              height="85"
+              width="100%"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <pattern
+                  height="85"
+                  id="koros_basic-56"
+                  patternUnits="userSpaceOnUse"
+                  width="96"
+                  x="0"
+                  y="0"
+                >
+                  <path
+                    d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                    transform="scale(3)"
+                  />
+                </pattern>
+              </defs>
+              <rect
+                fill="url(#koros_basic-56)"
+                height="85"
+                style="shape-rendering: crispEdges;"
+                width="100%"
+              />
+            </svg>
+          </div>
+          <div
+            class="Footer-module_footerContent__3MC14"
+          >
+            <div
+              class="Footer-module_footerSections__2nrr8"
+            >
+              <h2
+                class="Footer-module_title__269y7"
+              >
+                appName
+              </h2>
+              <div
+                class="FooterUtilities-module_utilities__10PzW"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterUtilities-module_divider__2VjbX"
+                />
+                <div
+                  class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.needHelp
+                      </h3>
+                      <a
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="/guide"
+                      >
+                        <span>
+                          footer.userGuide
+                        </span>
+                      </a>
+                      <div
+                        variant="utility"
+                      >
+                        <span>
+                          footer.helsinkiProfileSupport
+                        </span>
+                        <ul
+                          class="contacts-list"
+                        >
+                          <li>
+                            footer.openingHours
+                          </li>
+                          <li>
+                            <a
+                              class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                              href="tel:0931088800"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-label="phone"
+                                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                              <span>
+                                09 310 88800
+                              </span>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                  >
+                    <div
+                      class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                    >
+                      <h3
+                        class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                      >
+                        footer.otherContactInformation
+                      </h3>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.contactUsLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.contactUs
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                      <a
+                        aria-label="opensInNewWindow"
+                        class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                        href="footer.feedbackLink"
+                        target="_blank"
+                      >
+                        <span>
+                          footer.feedback
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          aria-label="link-external"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="FooterBase-module_base__2f0eu"
+              >
+                <hr
+                  aria-hidden="true"
+                  class="FooterBase-module_divider__3sz3q"
+                />
+                <div
+                  class="FooterBase-module_logoWrapper__3BI7d"
+                >
+                  <a
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                    href="https://hel.fi/sv"
+                    tabindex="0"
+                  >
+                    <img
+                      alt="cityOfHelsinki"
+                      class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgMTA0IDM2IiB0aXRsZT0iSGVsc2luZ2ZvcnMgc3RhZCIgcm9sZT0iaW1nIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgICBjbGFzcz0iTG9nby1tb2R1bGVfbG9nb19fWTJtd1AgTG9nby1tb2R1bGVfbWVkaXVtX18xenlXbSIgc3R5bGU9Im1hcmdpbi1yaWdodDogdmFyKC0tc3BhY2luZy14cyk7Ij4KICAgIDxwYXRoCiAgICAgICAgZD0iTTEwMy4xMDUgMHYyMi45MzVjMCA1LjE3OS00LjI2NiA5LjM5Ny05LjUyNCA5LjM5N2wtMzQuODY3LjAzMmE4LjQ2IDguNDYgMCAwMC01Ljk4MSAyLjQ3MUw1MS41NTMgMzZsLTEuMTgxLTEuMTY1YTguNDA1IDguNDA1IDAgMDAtNS45ODItMi40NzFIOS40NzZDNC4yNSAzMi4zNjQgMCAyOC4xNDUgMCAyMi45NjZWMGgxMDMuMTA1em0tMi4yMzYgMi4yMzVIMi4yNTF2MjAuNzMxYzAgMy45NTEgMy4yNDMgNy4xNjMgNy4yMjUgNy4xNjNINDQuMzljMi42NzYgMCA1LjE5NS45NiA3LjE2MiAyLjczOSAxLjk2OC0xLjc4IDQuNDg2LTIuNzQgNy4xNjItMi43NGwzNC44NjctLjAzYzQuMDE0IDAgNy4yODgtMy4yMTIgNy4yODgtNy4xNjN2LTIwLjd6TTYyLjAyIDEyLjA5bDIgMS4xNWMtLjAzMiAxLjAwNy0uNDg5IDEuNDc5LTEuMzU0IDEuNDc5LS4yMDUgMC0uNDczLS4wNDctLjYxNC0uMDk0di4wNjJjLjQyNS4zMzEuOTQ0Ljg4Mi45NDQgMS43NjMgMCAxLjUxMi0xLjQ2NCAyLjQ3Mi0zLjI3NCAyLjQ3Mi0uODM0IDAtMS41NTguMjY3LTEuNTU4LjY3NyAwIC4zMTUuMjY3LjQ1Ni45MTMuNDU2LjY0NSAwIDEuMzY5LS4xMjYgMi4yMDMtLjEyNiAxLjY1MyAwIDIuNzU1LjY2MSAyLjc1NSAyLjE1NyAwIDEuNzk0LTIuMDE1IDIuNTAzLTQuMjgyIDIuNTAzLTIuMTA5IDAtNC4wMy0uNTk4LTQuMDMtMS45NTIgMC0uODE5Ljg1LTEuMzA3IDEuNjIyLTEuNDQ4di0uMDQ4Yy0uNTgyLS4xNzMtMS4xMDItLjU1LTEuMTAyLTEuMjEyIDAtLjg2NS44ODItMS4zMzggMS43NzktMS41Mjd2LS4wNDdjLS44MzQtLjMzLTEuNTQzLTEuMDA3LTEuNTQzLTIuMTg4IDAtMS41MTEgMS4zMjItMi41NSAzLjEzMy0yLjU1LjY5MiAwIDEuMDg2LjE0MiAxLjYwNS4xNDIuNjQ2IDAgLjg4Mi0uMzYyLjg4Mi0uOTQ1IDAtLjI2Ny0uMDQ3LS41MzUtLjA3OS0uNzI0em0tMS43MzEgOS41NGMtLjkzIDAtMi43MjQuMDc4LTIuNzI0Ljc4NiAwIC41MzYuODk4Ljc4NyAyLjE1Ny44MDMgMS40MTcgMCAyLjIzNS0uMjY3IDIuMjM1LS45MTMgMC0uNTA0LS43NTUtLjY3Ny0xLjY2OC0uNjc3em0yOC45OTUtOC4wMTNjMS41MjcgMCAyLjkyOC43MjQgMy41MjYgMS43NDdsLTEuODQyIDEuMDRhMS42MjQgMS42MjQgMCAwMC0xLjYwNi0xLjIxM2MtLjU1IDAtMS4wMDcuMjM2LTEuMDA3LjY3NyAwIC41ODIgMS4wMDcuNjQ1IDIuMTU3IDEuMDA4IDEuMTk2LjM3NyAyLjI5OC45MjggMi4yOTggMi4zMyAwIDEuNTQyLTEuNDMzIDIuNDU1LTMuMTAxIDIuNDU1LTEuNzk1IDAtMy4yMTEtLjc3MS0zLjg0MS0xLjk4NGwxLjg3My0xLjA1NGMuMjUyLjgzNC45MTMgMS40NjQgMS45MzYgMS40NjQuNTk4IDAgMS4wMjMtLjI2OCAxLjAyMy0uNzQgMC0uNjE0LS44NS0uNzU2LTEuODQxLTEuMDIzLTEuMTY1LS4zMTUtMi42MTMtLjg4Mi0yLjYxMy0yLjM0NiAwLTEuNDQ4IDEuMzg1LTIuMzYgMy4wMzgtMi4zNnptLTE0LjY1NSAwYzIuMDc4IDAgMy42OTkgMS41MjcgMy42OTkgNC4wMTRzLTEuNjA2IDQuMDE0LTMuNyA0LjAxNGMtMi4xMDkgMC0zLjcxNC0xLjUyNy0zLjcxNC00LjAxNHMxLjYwNS00LjAxNCAzLjcxNS00LjAxNHptLTQ5LjY4IDBjMi4wNjMgMCAzLjQzMiAxLjQ2NCAzLjQzMiAzLjU0Mi4wMTYuNjE0LS4wOTQgMS4wMzktLjA5NCAxLjAzOWgtNC45NzRjLjA5NCAxLjI0My43ODcgMS44NTcgMS42ODQgMS44NTcuODAzIDAgMS4zNTQtLjUzNSAxLjQ4LTEuMjZsMS44MSAxLjAyNGMtLjUzNS45NzYtMS42ODQgMS44MjYtMy4yOSAxLjgyNi0yLjE0IDAtMy43MTUtMS40OTUtMy43MTUtNC4wMTQgMC0yLjQ4NyAxLjYwNi00LjAxNCAzLjY2OC00LjAxNHptMTMuMDY2LS4wMTZjMS41MjcgMCAyLjkyOC43MjQgMy41MjYgMS43NDhsLTEuODQyIDEuMDM5Yy0uMTg5LS42NzctLjc1NS0xLjIxMy0xLjYwNS0xLjIxMy0uNTUxIDAtMS4wMDguMjM3LTEuMDA4LjY3NyAwIC41ODMgMS4wMDguNjQ2IDIuMTQgMS4wMDggMS4xOTcuMzc4IDIuMy45MjggMi4zIDIuMzMgMCAxLjU0Mi0xLjQzMyAyLjQ0LTMuMDg2IDIuNDQtMS43OTUgMC0zLjIxMS0uNzU2LTMuODQxLTEuOTg0bDEuODczLTEuMDU1Yy4yMzYuODM1LjkxMyAxLjQ2NCAxLjkzNiAxLjQ2NC41ODMuMDE2IDEuMDA4LS4yMzYgMS4wMDgtLjcyNCAwLS42MTQtLjg1LS43NC0xLjg0Mi0xLjAyMy0xLjE2NS0uMy0yLjU5Ny0uODgyLTIuNTk3LTIuMzQ1IDAtMS40NDkgMS4zODUtMi4zNjIgMy4wMzgtMi4zNjJ6TTMyLjMgMTAuNTN2OC41MDFjMCAuMzYyLjA0Ny42MTQuMTU3Ljc1Ni4wOTUuMTU3LjIyLjIyLjUwNC4yMi4xNzMgMCAuMzMgMCAuNDU2LS4wMzFhMi4wMSAyLjAxIDAgMDAuNDU3LS4xMjZsLS4xODkgMS40NDhhMi41MzIgMi41MzIgMCAwMS0uNjQ1LjIzNmMtLjI1Mi4wNDctLjUyLjA3OS0uNzcyLjA3OS0uNzQgMC0xLjI3NS0uMTc0LTEuNjIxLS41MzYtLjMzLS4zNjItLjUwNC0uOTQ0LS41MDQtMS43MzFWMTAuNTNoMi4xNTd6bTE5LjgxOCAzLjA4NmMxLjQ4IDAgMi40MDggMS4wMjMgMi40MDggMi45Mjh2NC45MTFoLTIuMTU2VjE2Ljk3YzAtMS4wMDctLjM2Mi0xLjU0My0xLjE2NS0xLjU0M3MtMS4zMjIuNjE0LTEuMzIyIDEuNDk2djQuNTQ5aC0yLjE0MXYtNy42NjZoMi4xNGwtLjExIDEuMjZoLjA0OGMuMzc4LS43MSAxLjAzOS0xLjQ0OSAyLjI5OC0xLjQ0OXptMTYuNzMzLTMuMzM3YTMuMjcgMy4yNyAwIDAxMi43MzkgMS40bC0xLjg1OCAxLjEzNGMtLjAzMS0uNDU2LS4yNTItLjkyOC0uNzcxLS45MjgtLjUzNSAwLS43ODcuNDA5LS43ODcgMS4wODZ2LjgzNGgxLjY4NHYxLjYzN2gtMS42ODR2Ni4wMjloLTIuMTR2LTYuMDI5aC0xLjE4MXYtMS42MzdoMS4xOHYtLjgxOWMwLTEuNzk0IDEuMTgtMi43MDcgMi44MTgtMi43MDd6bTE0LjgxMiAzLjM4NGMxLjA4NiAwIDEuNjg0LjkxMyAxLjY4NCAyLjAzIDAgLjUwNS0uMDc4Ljg5OC0uMDc4Ljg5OGwtMS45MzYgMS4xMThjLjAzMS0uMjIuMTI2LS43NC4xMjYtMS4yNiAwLS41MDMtLjE5LS45NzUtLjcyNS0uOTc1LS42NzYgMC0uOTQ0LjYzLS45NDQgMS42MnY0LjM3N2gtMi4xNTd2LTcuNjVoMi4xNTdsLS4xMSAxLjI1OWguMDQ3Yy4zNzgtLjc0Ljk2LTEuNDE3IDEuOTM2LTEuNDE3em0tNzAuNTItMi43MjN2NC4xNzFoNC4yMDN2LTQuMTdoMi4yMzV2MTAuNTE0aC0yLjIzNXYtNC4zNmgtNC4yMDN2NC4zNmgtMi4yMzVWMTAuOTRoMi4yMzV6bTMyLjMzMiAyLjg1djcuNjY1SDQzLjMyVjEzLjc5aDIuMTU2em0yOS4xNTMgMS40NjNjLTEuMDcgMC0xLjU0MyAxLjAwOC0xLjU0MyAyLjM3NyAwIDEuMzcuNDcyIDIuMzc3IDEuNTQzIDIuMzc3IDEuMDU0IDAgMS41MjctMS4wMDcgMS41MjctMi4zNzcgMC0xLjM3LS40NzMtMi4zNzctMS41MjctMi4zNzd6bS0xNC44OTEtLjE4OWMtLjcyNCAwLTEuMzA3LjQ3My0xLjMwNyAxLjE5NyAwIC43NC41ODMgMS4yMTIgMS4zMDcgMS4xOTYuNzI0IDAgMS4zMDYtLjQ3MiAxLjMwNi0xLjE5NnMtLjU4Mi0xLjE5Ny0xLjMwNi0xLjE5N3ptLTM0Ljc3My4wOTVjLS43ODcgMC0xLjQzMi41NjYtMS42MDUgMS42MDVoMy4wMzhjMC0uOTEzLS41OTgtMS42MDUtMS40MzMtMS42MDV6bTE5LjQ0LTQuNjc1Yy42OTMgMCAxLjI0NC41MDMgMS4yNDQgMS4xOTZzLS41NSAxLjE5Ni0xLjI0MyAxLjE5NmMtLjcwOSAwLTEuMjQ0LS41MDMtMS4yNDQtMS4xOTZzLjU1MS0xLjE5NiAxLjI0NC0xLjE5NnoiCiAgICAgICAgZmlsbD0id2hpdGUiPjwvcGF0aD4KPC9zdmc+"
+                    />
+                  </a>
+                </div>
+                <div
+                  class="FooterBase-module_copyright__2iiev"
+                >
+                  <span>
+                    © 
+                    cityOfHelsinki
+                     
+                    2024
+                  </span>
+                  <span
+                    class="FooterBase-module_copyrightDot__2AfS6"
+                  >
+                    •
+                  </span>
+                  <span>
+                    footer.reserveRights
+                  </span>
+                </div>
+                <div
+                  class="FooterBase-module_baseActions__1hCiR"
+                >
+                  <div
+                    class="FooterBase-module_links__3lfLo"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                      href="profileForm.termsFileDescriptionLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.privacy
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                    <span
+                      aria-hidden="true"
+                      class="FooterBase-module_separator__cwQTe"
+                    >
+                      |
+                    </span>
+                    <div />
+                  </div>
+                  <button
+                    class="FooterBase-module_backToTopButton__hXTHm"
+                    role="link"
+                    type="button"
+                  >
+                    footer.backToTop
+                    <svg
+                      aria-hidden="true"
+                      aria-label="arrow-up"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wrapper"
+    >
+      <header
+        class="hds-header Header-module_header__291GF"
+      >
+        <div
+          class="Header-module_headerBackgroundWrapper__KsFy2"
+        >
+          <a
+            class="SkipLink-module_skipLink__1knzF"
+            href="#main-content"
+          >
+            <span
+              class="SkipLink-module_skipLinkLabel__21n5B"
+            >
+              skipToContent
+            </span>
+          </a>
+          <div
+            class="HeaderActionBar-module_headerActionBarContainer__5tfj-"
+          >
+            <div
+              class="HeaderActionBar-module_headerActionBar__lPeGE"
+            >
+              <span
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_logo__2r2T0"
+                role="link"
+              >
+                <span
+                  class="HeaderActionBarLogo-module_logoWrapper__8NgfS"
+                >
+                  <img
+                    alt="helsinkiLogo"
+                    class="Logo-module_logo__Y2mwP"
+                    src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTA0IDM2IiB0aXRsZT0iSGVsc2luZ2ZvcnMgc3RhZCIgcm9sZT0iaW1nIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPHBhdGgKICAgICAgICBkPSJNMTAzLjEwNSAwdjIyLjkzNWMwIDUuMTc5LTQuMjY2IDkuMzk3LTkuNTI0IDkuMzk3bC0zNC44NjcuMDMyYTguNDYgOC40NiAwIDAwLTUuOTgxIDIuNDcxTDUxLjU1MyAzNmwtMS4xODEtMS4xNjVhOC40MDUgOC40MDUgMCAwMC01Ljk4Mi0yLjQ3MUg5LjQ3NkM0LjI1IDMyLjM2NCAwIDI4LjE0NSAwIDIyLjk2NlYwaDEwMy4xMDV6bS0yLjIzNiAyLjIzNUgyLjI1MXYyMC43MzFjMCAzLjk1MSAzLjI0MyA3LjE2MyA3LjIyNSA3LjE2M0g0NC4zOWMyLjY3NiAwIDUuMTk1Ljk2IDcuMTYyIDIuNzM5IDEuOTY4LTEuNzggNC40ODYtMi43NCA3LjE2Mi0yLjc0bDM0Ljg2Ny0uMDNjNC4wMTQgMCA3LjI4OC0zLjIxMiA3LjI4OC03LjE2M3YtMjAuN3pNNjIuMDIgMTIuMDlsMiAxLjE1Yy0uMDMyIDEuMDA3LS40ODkgMS40NzktMS4zNTQgMS40NzktLjIwNSAwLS40NzMtLjA0Ny0uNjE0LS4wOTR2LjA2MmMuNDI1LjMzMS45NDQuODgyLjk0NCAxLjc2MyAwIDEuNTEyLTEuNDY0IDIuNDcyLTMuMjc0IDIuNDcyLS44MzQgMC0xLjU1OC4yNjctMS41NTguNjc3IDAgLjMxNS4yNjcuNDU2LjkxMy40NTYuNjQ1IDAgMS4zNjktLjEyNiAyLjIwMy0uMTI2IDEuNjUzIDAgMi43NTUuNjYxIDIuNzU1IDIuMTU3IDAgMS43OTQtMi4wMTUgMi41MDMtNC4yODIgMi41MDMtMi4xMDkgMC00LjAzLS41OTgtNC4wMy0xLjk1MiAwLS44MTkuODUtMS4zMDcgMS42MjItMS40NDh2LS4wNDhjLS41ODItLjE3My0xLjEwMi0uNTUtMS4xMDItMS4yMTIgMC0uODY1Ljg4Mi0xLjMzOCAxLjc3OS0xLjUyN3YtLjA0N2MtLjgzNC0uMzMtMS41NDMtMS4wMDctMS41NDMtMi4xODggMC0xLjUxMSAxLjMyMi0yLjU1IDMuMTMzLTIuNTUuNjkyIDAgMS4wODYuMTQyIDEuNjA1LjE0Mi42NDYgMCAuODgyLS4zNjIuODgyLS45NDUgMC0uMjY3LS4wNDctLjUzNS0uMDc5LS43MjR6bS0xLjczMSA5LjU0Yy0uOTMgMC0yLjcyNC4wNzgtMi43MjQuNzg2IDAgLjUzNi44OTguNzg3IDIuMTU3LjgwMyAxLjQxNyAwIDIuMjM1LS4yNjcgMi4yMzUtLjkxMyAwLS41MDQtLjc1NS0uNjc3LTEuNjY4LS42Nzd6bTI4Ljk5NS04LjAxM2MxLjUyNyAwIDIuOTI4LjcyNCAzLjUyNiAxLjc0N2wtMS44NDIgMS4wNGExLjYyNCAxLjYyNCAwIDAwLTEuNjA2LTEuMjEzYy0uNTUgMC0xLjAwNy4yMzYtMS4wMDcuNjc3IDAgLjU4MiAxLjAwNy42NDUgMi4xNTcgMS4wMDggMS4xOTYuMzc3IDIuMjk4LjkyOCAyLjI5OCAyLjMzIDAgMS41NDItMS40MzMgMi40NTUtMy4xMDEgMi40NTUtMS43OTUgMC0zLjIxMS0uNzcxLTMuODQxLTEuOTg0bDEuODczLTEuMDU0Yy4yNTIuODM0LjkxMyAxLjQ2NCAxLjkzNiAxLjQ2NC41OTggMCAxLjAyMy0uMjY4IDEuMDIzLS43NCAwLS42MTQtLjg1LS43NTYtMS44NDEtMS4wMjMtMS4xNjUtLjMxNS0yLjYxMy0uODgyLTIuNjEzLTIuMzQ2IDAtMS40NDggMS4zODUtMi4zNiAzLjAzOC0yLjM2em0tMTQuNjU1IDBjMi4wNzggMCAzLjY5OSAxLjUyNyAzLjY5OSA0LjAxNHMtMS42MDYgNC4wMTQtMy43IDQuMDE0Yy0yLjEwOSAwLTMuNzE0LTEuNTI3LTMuNzE0LTQuMDE0czEuNjA1LTQuMDE0IDMuNzE1LTQuMDE0em0tNDkuNjggMGMyLjA2MyAwIDMuNDMyIDEuNDY0IDMuNDMyIDMuNTQyLjAxNi42MTQtLjA5NCAxLjAzOS0uMDk0IDEuMDM5aC00Ljk3NGMuMDk0IDEuMjQzLjc4NyAxLjg1NyAxLjY4NCAxLjg1Ny44MDMgMCAxLjM1NC0uNTM1IDEuNDgtMS4yNmwxLjgxIDEuMDI0Yy0uNTM1Ljk3Ni0xLjY4NCAxLjgyNi0zLjI5IDEuODI2LTIuMTQgMC0zLjcxNS0xLjQ5NS0zLjcxNS00LjAxNCAwLTIuNDg3IDEuNjA2LTQuMDE0IDMuNjY4LTQuMDE0em0xMy4wNjYtLjAxNmMxLjUyNyAwIDIuOTI4LjcyNCAzLjUyNiAxLjc0OGwtMS44NDIgMS4wMzljLS4xODktLjY3Ny0uNzU1LTEuMjEzLTEuNjA1LTEuMjEzLS41NTEgMC0xLjAwOC4yMzctMS4wMDguNjc3IDAgLjU4MyAxLjAwOC42NDYgMi4xNCAxLjAwOCAxLjE5Ny4zNzggMi4zLjkyOCAyLjMgMi4zMyAwIDEuNTQyLTEuNDMzIDIuNDQtMy4wODYgMi40NC0xLjc5NSAwLTMuMjExLS43NTYtMy44NDEtMS45ODRsMS44NzMtMS4wNTVjLjIzNi44MzUuOTEzIDEuNDY0IDEuOTM2IDEuNDY0LjU4My4wMTYgMS4wMDgtLjIzNiAxLjAwOC0uNzI0IDAtLjYxNC0uODUtLjc0LTEuODQyLTEuMDIzLTEuMTY1LS4zLTIuNTk3LS44ODItMi41OTctMi4zNDUgMC0xLjQ0OSAxLjM4NS0yLjM2MiAzLjAzOC0yLjM2MnpNMzIuMyAxMC41M3Y4LjUwMWMwIC4zNjIuMDQ3LjYxNC4xNTcuNzU2LjA5NS4xNTcuMjIuMjIuNTA0LjIyLjE3MyAwIC4zMyAwIC40NTYtLjAzMWEyLjAxIDIuMDEgMCAwMC40NTctLjEyNmwtLjE4OSAxLjQ0OGEyLjUzMiAyLjUzMiAwIDAxLS42NDUuMjM2Yy0uMjUyLjA0Ny0uNTIuMDc5LS43NzIuMDc5LS43NCAwLTEuMjc1LS4xNzQtMS42MjEtLjUzNi0uMzMtLjM2Mi0uNTA0LS45NDQtLjUwNC0xLjczMVYxMC41M2gyLjE1N3ptMTkuODE4IDMuMDg2YzEuNDggMCAyLjQwOCAxLjAyMyAyLjQwOCAyLjkyOHY0LjkxMWgtMi4xNTZWMTYuOTdjMC0xLjAwNy0uMzYyLTEuNTQzLTEuMTY1LTEuNTQzcy0xLjMyMi42MTQtMS4zMjIgMS40OTZ2NC41NDloLTIuMTQxdi03LjY2NmgyLjE0bC0uMTEgMS4yNmguMDQ4Yy4zNzgtLjcxIDEuMDM5LTEuNDQ5IDIuMjk4LTEuNDQ5em0xNi43MzMtMy4zMzdhMy4yNyAzLjI3IDAgMDEyLjczOSAxLjRsLTEuODU4IDEuMTM0Yy0uMDMxLS40NTYtLjI1Mi0uOTI4LS43NzEtLjkyOC0uNTM1IDAtLjc4Ny40MDktLjc4NyAxLjA4NnYuODM0aDEuNjg0djEuNjM3aC0xLjY4NHY2LjAyOWgtMi4xNHYtNi4wMjloLTEuMTgxdi0xLjYzN2gxLjE4di0uODE5YzAtMS43OTQgMS4xOC0yLjcwNyAyLjgxOC0yLjcwN3ptMTQuODEyIDMuMzg0YzEuMDg2IDAgMS42ODQuOTEzIDEuNjg0IDIuMDMgMCAuNTA1LS4wNzguODk4LS4wNzguODk4bC0xLjkzNiAxLjExOGMuMDMxLS4yMi4xMjYtLjc0LjEyNi0xLjI2IDAtLjUwMy0uMTktLjk3NS0uNzI1LS45NzUtLjY3NiAwLS45NDQuNjMtLjk0NCAxLjYydjQuMzc3aC0yLjE1N3YtNy42NWgyLjE1N2wtLjExIDEuMjU5aC4wNDdjLjM3OC0uNzQuOTYtMS40MTcgMS45MzYtMS40MTd6bS03MC41Mi0yLjcyM3Y0LjE3MWg0LjIwM3YtNC4xN2gyLjIzNXYxMC41MTRoLTIuMjM1di00LjM2aC00LjIwM3Y0LjM2aC0yLjIzNVYxMC45NGgyLjIzNXptMzIuMzMyIDIuODV2Ny42NjVINDMuMzJWMTMuNzloMi4xNTZ6bTI5LjE1MyAxLjQ2M2MtMS4wNyAwLTEuNTQzIDEuMDA4LTEuNTQzIDIuMzc3IDAgMS4zNy40NzIgMi4zNzcgMS41NDMgMi4zNzcgMS4wNTQgMCAxLjUyNy0xLjAwNyAxLjUyNy0yLjM3NyAwLTEuMzctLjQ3My0yLjM3Ny0xLjUyNy0yLjM3N3ptLTE0Ljg5MS0uMTg5Yy0uNzI0IDAtMS4zMDcuNDczLTEuMzA3IDEuMTk3IDAgLjc0LjU4MyAxLjIxMiAxLjMwNyAxLjE5Ni43MjQgMCAxLjMwNi0uNDcyIDEuMzA2LTEuMTk2cy0uNTgyLTEuMTk3LTEuMzA2LTEuMTk3em0tMzQuNzczLjA5NWMtLjc4NyAwLTEuNDMyLjU2Ni0xLjYwNSAxLjYwNWgzLjAzOGMwLS45MTMtLjU5OC0xLjYwNS0xLjQzMy0xLjYwNXptMTkuNDQtNC42NzVjLjY5MyAwIDEuMjQ0LjUwMyAxLjI0NCAxLjE5NnMtLjU1IDEuMTk2LTEuMjQzIDEuMTk2Yy0uNzA5IDAtMS4yNDQtLjUwMy0xLjI0NC0xLjE5NnMuNTUxLTEuMTk2IDEuMjQ0LTEuMTk2eiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg=="
+                  />
+                </span>
+              </span>
+              <a
+                aria-label="nav.titleAriaLabel"
+                class="HeaderActionBar-module_titleAndLogoContainer__2LEAb HeaderActionBar-module_title__opzt9 HeaderActionBar-module_normal__3B4qi"
+                href="/"
+              >
+                <span
+                  class="HeaderActionBar-module_title__opzt9"
+                >
+                  appName
+                </span>
+              </a>
+              <div
+                class="HeaderActionBar-module_headerActions__3lNnM"
+              >
+                <div
+                  class="HeaderLanguageSelector-module_languageSelector__3d38B"
+                >
+                  <div
+                    class="HeaderLanguageSelector-module_languageNodes__lTe8p"
+                  >
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="fi"
+                      type="button"
+                    >
+                      <span>
+                        Suomi
+                      </span>
+                    </button>
+                    <button
+                      aria-current="true"
+                      class="HeaderLanguageSelector-module_item__3_I7N HeaderLanguageSelector-module_activeItem__15LKg"
+                      lang="sv"
+                      type="button"
+                    >
+                      <span>
+                        Svenska
+                      </span>
+                    </button>
+                    <button
+                      aria-current="false"
+                      class="HeaderLanguageSelector-module_item__3_I7N"
+                      lang="en"
+                      type="button"
+                    >
+                      <span>
+                        English
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <hr
+                  aria-hidden="true"
+                />
+                <button
+                  aria-label="nav.signin"
+                  class="HeaderActionBarItemButton-module_actionBarItemButton__2ALyH HeaderActionBarItemButton-module_fixedRightPosition__kBVLv"
+                  data-hds-header-error-usage="login"
+                  id="action-bar-login-action"
+                  type="button"
+                >
+                  <div
+                    class="HeaderActionBarItemButton-module_buttonContent__3JeY0"
+                  >
+                    <span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonIcon__1_1Cg"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="signin"
+                          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M21 2V22H8V17H10V20H19V4H10V7H8V2H21ZM12.5 7L17.5 12L12.5 17L11 15.5L13.5 12.999L2 13V11L13.499 10.999L11 8.5L12.5 7Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="HeaderActionBarItemButton-module_actionBarItemButtonLabel__12Iec"
+                      >
+                        nav.signin
+                      </span>
+                    </span>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main
+        class="content"
+        id="main-content"
+      >
+        <div
+          class="wrapper"
+        >
+          <div
+            class="common-content-area common-bottom-padding content"
+          >
+            <div
+              class="inner-content"
+            >
+              <h1
+                class="page-load-focus-element hide-focus-borders"
+                tabindex="-1"
+              >
+                Helsingforsprofilens hjälp
+              </h1>
+              <p>
+                Helsingforsprofilen är kundprofilen för en medborgare som använder stadens digitala tjänster. Den är det primära autentiseringsmedlet för stadens digitala tjänster. Helsingforsprofilen samlar kundens person- och kontaktuppgifter samt länkar till stadens olika tjänster på ett och samma ställe. Med hjälp av profilen kan användaren hantera sina egna uppgifter och deras synlighet i olika tjänster.
+              </p>
+              <a
+                class="Link-module_button__1hPh3 button_hds-button__3eV18 button_hds-button--primary__YFEUq download-link"
+                download="Helsingforsprofilens-hjalp.pdf"
+                href="/Helsingforsprofilens-hjalp.pdf"
+              >
+                <span
+                  aria-hidden="true"
+                  class="Link-module_iconLeft__3j0X3 link_hds-icon-left__1aufP"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="download"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5 15V20H19V15H21V22H3V15H5ZM13 2V14L16 11L17.5 12.5L12 18L6.5 12.5L8 11L11 14V2H13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="Link-module_buttonLabel__EFeWo button_hds-button__label__3Mm25"
+                >
+                  Helsingforsprofilens hjälp (.pdf)
+                </span>
+              </a>
+              <div
+                class="table-of-contents"
+              >
+                <div
+                  class="table-of-contents__container"
+                >
+                  <h2
+                    class="table-of-contents__title"
+                  >
+                    På den här sidan
+                  </h2>
+                  <nav
+                    class="table-of-contents__content"
+                    id="helfi-toc-table-of-contents-list"
+                  >
+                    <ul
+                      class="table-of-contents__list"
+                    >
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Create_a_Helsinki_profile"
+                        >
+                          Skapa en Helsingforsprofilen
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Login"
+                        >
+                          Logga in
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_viewing_and_editing"
+                        >
+                          Visa och redigera dina egna uppgifter
+                        </a>
+                      </li>
+                      <li
+                        class="table-of-contents__item"
+                      >
+                        <a
+                          class="table-of-contents__link"
+                          href="#_Deleting_your_information"
+                        >
+                          Radering av uppgifter
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+              </div>
+              <h2
+                id="_Create_a_Helsinki_profile"
+              >
+                Skapa en Helsingforsprofilen
+              </h2>
+              <p>
+                Helsingfors-profilen används för att logga in i Helsingfors stads tjänster. Första gången du loggar in blir du ombedd att skapa en Helsingforsprofilen och ge ditt samtycke till att de uppgifter som tjänsten kräver får användas.
+              </p>
+              <p>
+                Du kan också skapa en Helsingforsprofil på
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+                .
+              </p>
+              <p>
+                Du kan skapa en Helsingforsprofilen med din Suomi.fi-identifikation eller med din e-post och ditt lösenord. Du kan också logga in i Helsingfors stads digitala tjänster med Google eller Yle Konto, som tas ur bruk 2024.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-45"
+                id="_Suomi.fi_identifiering"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Suomi.fi_identifiering-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Suomi.fi_identifiering-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Suomi.fi identifiering
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Suomi.fi_identifiering-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Suomi.fi_identifiering-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Val av autentisering
+                  </h4>
+                  <p>
+                    Efter att ha tryckt på länken Logga in i kundtjänsten visas en skärm med olika inloggningsalternativ, där inloggningen till Suomi.fi väljs. Visningen av inloggningsalternativen varierar från en tjänst till en annan.
+                  </p>
+                  <div>
+                    <img
+                      alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+                      loading="lazy"
+                      src="/src/userGuide/assets/01-sisaankirjautuminen-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I autentiseringsfönstret väljer du Suomi.fi-identifikation.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="I autentiseringsfönstret väljer du Suomi.fi-identifikation."
+                      loading="lazy"
+                      src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I autentiseringsfönstret väljer du Suomi.fi-identifikation.
+                    </p>
+                  </div>
+                  <h4>
+                    Identifiering i tjänsten Suomi.fi
+                  </h4>
+                  <p>
+                    Efter att ha valt Suomi.fi-inloggning presenteras användaren med olika inloggningsalternativ. Alternativen är desamma som för andra myndighetstjänster som erbjuder stark autentisering.
+                  </p>
+                  <p>
+                    Efter autentiseringen ska du kontrollera att de uppgifter du använder är korrekta. Om du hittar fel i uppgifterna ska de korrigeras i Befolkningsregistercentralens tjänst.
+                  </p>
+                  <div>
+                    <img
+                      alt="Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi."
+                      loading="lazy"
+                      src="/src/userGuide/assets/03-vahvan-valinta-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Välj ditt bank- eller mobilkonto som autentiseringsalternativ på Suomi.fi.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta."
+                      loading="lazy"
+                      src="/src/userGuide/assets/04-vahvat-tiedot-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      När du byter tillbaka till Helsingfors stads tjänst, kontrollera att dina uppgifter är korrekta.
+                    </p>
+                  </div>
+                  <h4>
+                    Verifiering av e-postadress
+                  </h4>
+                  <p>
+                    Efter autentiseringen kommer du att bli ombedd att ange din e-postadress. Ett bekräftelsemeddelande skickas till e-postadressen för att verifiera att adressen är äkta.
+                  </p>
+                  <p>
+                    För att validera din e-post får du en sexsiffrig kod för den e-postadress du angav, som du måste ange i fältet på skärmen. I så fall kombineras de olika autentiseringsmetoderna och du kan se alla tjänster du använder på en gång.
+                     
+                    <b>
+                      Observera dock att du inte kommer att kunna koppla bort dem senare.
+                    </b>
+                  </p>
+                  <p>
+                    För att bekräfta din e-post får du en 6-siffrig kod till den e-postadress du angav. Om meddelandet inte kommer till din inbox nästan omedelbart, kontrollera din skräppostmapp.
+                  </p>
+                  <p>
+                    <b>
+                      Stäng inte webbläsarfönstret i din Helsingforsprofil när du hämtar bekräftelsemeddelandet från din e-post. I annat fall kommer systemet att anta att du har avbrutit autentiseringsprocessen.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret.
+                    </p>
+                  </div>
+                  <h4>
+                    Skapa en Helsingforsprofilen
+                  </h4>
+                  <p>
+                    När du har bekräftat e-postmeddelandet måste du fortfarande ge ditt samtycke till att dina uppgifter används. Utan samtycke kan Helsingforsprofilen inte skapas och tjänsterna kan inte använda dina uppgifter.
+                  </p>
+                  <p>
+                    Då har du Helsingforsprofilen och dina autentiseringsuppgifter för Suomi.fi sparas i din profil. Olika tjänster använder dina uppgifter på olika sätt, men de kommer alltid att berätta för dig hur de använder dem när du loggar in första gången. Informationen finns också alltid tillgänglig i din Helsingforsprofil.
+                  </p>
+                  <p>
+                    När du har skapat din Helsingforsprofil kommer du att vara inloggad på den tjänst där du inledde registreringsprocessen. Du hittar din Helsingforsprofil på adressen
+                     
+                    <a
+                      href="https://profiili.hel.fi"
+                    >
+                      https://profiili.hel.fi
+                    </a>
+                    .
+                  </p>
+                  <p>
+                    Nästa gång du loggar in på samma tjänst väljer du bara Suomi.fi, det autentiseringsalternativ du valt och du är inne i tjänsten.
+                  </p>
+                  <div>
+                    <img
+                      alt="Innan du kan använda den tjänst du vill ha eller innan du kan skapa Helsingforsprofilen måste du 
+          ge ditt samtycke till att dina uppgifter används. Utan samtycke kan dina uppgifter inte användas och 
+          därför kan ingen profil skapas."
+                      loading="lazy"
+                      src="/src/userGuide/assets/08-profiilin-luominen-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Innan du kan använda den tjänst du vill ha eller innan du kan skapa Helsingforsprofilen måste du 
+          ge ditt samtycke till att dina uppgifter används. Utan samtycke kan dina uppgifter inte användas och 
+          därför kan ingen profil skapas.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Suomi.fi identifiering"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Suomi.fi_identifiering-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-46"
+                id="_Identifiering_av_e-post"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Identifiering_av_e-post-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Identifiering_av_e-post-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Identifiering av e-post
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Identifiering_av_e-post-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Identifiering_av_e-post-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <h4>
+                    Val av autentisering
+                  </h4>
+                  <p>
+                    När du har tryckt på länken Logga in i kundtjänsten ser du olika inloggningsalternativ, där du kan välja Skapa Helsingforsprofil. Visningen av inloggningsalternativen varierar från en tjänst till en annan.
+                  </p>
+                  <div>
+                    <img
+                      alt="Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen."
+                      loading="lazy"
+                      src="/src/userGuide/assets/09-helsinki-tunnus-luonti-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Helsingfors ID består av en kombination av e-post och lösenord genom att klicka på knappen Skapa ny Helsingforsprofilen.
+                    </p>
+                  </div>
+                  <h4>
+                    Verifiering av e-postadress
+                  </h4>
+                  <p>
+                    Du kommer att bli ombedd att ange din e-postadress, till vilken ett bekräftelsemeddelande kommer att skickas för att verifiera adressens äkthet.
+                  </p>
+                  <p>
+                    Om du redan har skapat Helsingforsprofilen med Suomi.fi-autentisering, kan du skapa ett lösenord för din profil genom att klicka på länken Jag har glömt mitt lösenord. Mer information om hur du skapar ett lösenord finns under 
+                    <a
+                      href="#_Glömt_lösenord"
+                    >
+                      Glömt lösenord
+                    </a>
+                    . De olika autentiseringsmetoderna kommer sedan att slås samman och du kommer att kunna se all information om alla de tjänster du använder på en gång.
+                     
+                    <b>
+                      Observera dock att du inte kommer att kunna avbryta sammanslagningen senare.
+                    </b>
+                  </p>
+                  <p>
+                    För att validera din e-postadress får du en 6-siffrig kod till den e-postadress du angav. Om meddelandet inte kommer till din inkorg nästan omedelbart, kontrollera din skräppostmapp.
+                  </p>
+                  <p>
+                    <b>
+                      Stäng inte webbläsarfönstret i din Helsingforsprofil när du hämtar bekräftelsemeddelandet från din e-post.
+                    </b>
+                    <b>
+                      I annat fall kommer systemet att anta att du har avbrutit autentiseringsprocessen.
+                    </b>
+                  </p>
+                  <div>
+                    <img
+                      alt="Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare."
+                      loading="lazy"
+                      src="/src/userGuide/assets/05-10-sahkopostiosoite-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Din e-postadress kommer att fungera som din inloggning till Helsingfors stads tjänster. Genom att 
+            använda samma e-postadress för både Suomi.fi-autentiseringen och Helsingfors ID får du en 
+            Helsingfors-profil. Sammanslagningen kan inte tas bort senare.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta."
+                      loading="lazy"
+                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      E-postmeddelandet innehåller en 6-siffrig verifieringskod för att bekräfta att e-postadressen är äkta.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret."
+                      loading="lazy"
+                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Det 6-siffriga numret på e-postmeddelandet måste anges i fältet för bekräftelsekod i webbläsarfönstret.
+                    </p>
+                  </div>
+                  <h4>
+                    Skapa en Helsingforsprofilen
+                  </h4>
+                  <p>
+                    När du har bekräftat e-postmeddelandet fyller du i ditt namn och lösenord. Ditt lösenord måste vara minst 12 tecken långt och innehålla stora och små bokstäver, siffror och specialtecken.
+                  </p>
+                  <p>
+                    Bekräfta att du samtycker till användningen av dina uppgifter. Utan ditt samtycke kan din Helsingforsprofil inte skapas och dina uppgifter kan inte användas av tjänsterna.
+                  </p>
+                  <p>
+                    Nu har du Helsingforsprofilen. Det Helsingfors-ID du behöver för att autentisera dig till tjänsterna är denna kombination av e-postadress och lösenord.
+                  </p>
+                  <div>
+                    <img
+                      alt="När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
+            också ge ditt samtycke till att dina uppgifter används för att skapa Helsingforsprofilen."
+                      loading="lazy"
+                      src="/src/userGuide/assets/13-helsinki-tunnus-teko-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      När du skapar Helsingforsprofilen måste du fortfarande fylla i ditt namn och lösenord. Du måste 
+            också ge ditt samtycke till att dina uppgifter används för att skapa Helsingforsprofilen.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Identifiering av e-post"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Identifiering_av_e-post-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-47"
+                id="_Kombinera_identifieringsmetoder"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Kombinera_identifieringsmetoder-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Kombinera_identifieringsmetoder-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Kombinera identifieringsmetoder
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Kombinera_identifieringsmetoder-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Kombinera_identifieringsmetoder-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Om du vill kan du kombinera olika autentiseringsmetoder i en enda Helsingforsprofil, så att du kan se och hantera alla dina data och tjänster på en gång. Detta kan göras genom att först skapa ett Helsingfors-ID med en e-postadress/lösenordskombination och sedan använda samma e-postadress för den första Suomi.fi-inloggningen.
+                  </p>
+                  <p>
+                    <b>
+                      Observera dock att du inte kommer att kunna koppla bort dem senare.
+                    </b>
+                  </p>
+                  <p>
+                    Om din Helsingforsprofil skapades med en Suomi.fi-autentisering kan du klicka på länken 
+                    <i>
+                      Jag har glömt mitt lösenord 
+                    </i>
+                    på inloggningsskärmen. För instruktioner om hur du gör detta, se avsnittet 
+                    <a
+                      href="#_Glömt_lösenord"
+                    >
+                      Glömt lösenord
+                    </a>
+                     nedan.
+                  </p>
+                  <button
+                    aria-label="Stäng Kombinera identifieringsmetoder"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Kombinera_identifieringsmetoder-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Login"
+              >
+                Logga in
+              </h2>
+              <p>
+                Med din Helsingforsprofil kan du logga in på alla Helsingfors stads digitala tjänster. Du kan logga in med Suomi.fi-inloggningen eller med den e-postadress och det lösenord som du angav när du skapade din profil.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-48"
+                id="_Glömt_lösenord"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Glömt_lösenord-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Glömt_lösenord-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Glömt lösenord
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Glömt_lösenord-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Glömt_lösenord-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Om du inte kommer ihåg ditt lösenord kan du skapa ett nytt i inloggningsfönstret genom att klicka på länken
+                     
+                    <i>
+                      Jag har glömt mitt lösenord
+                    </i>
+                    . Du kan också ha "glömt" ditt lösenord eftersom du tidigare har loggat in i tjänsten via Suomi.fi autentisering och då inte behövt ange ett lösenord.
+                  </p>
+                  <p>
+                    När du har angett din e-postadress kommer du att få en länk för att ange ett nytt lösenord i din e-post. Länken kommer att vara giltig i 30 minuter.
+                  </p>
+                  <p>
+                    Lösenordet måste vara minst 12 tecken långt. Det måste innehålla både stora och små bokstäver, nummer och specialtecken.
+                  </p>
+                  <div>
+                    <img
+                      alt="I inloggningsfönstret klickar du på länken Jag har glömt mitt lösenord."
+                      loading="lazy"
+                      src="/src/userGuide/assets/14-salasanan-unohdus-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I inloggningsfönstret klickar du på länken Jag har glömt mitt lösenord.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post."
+                      loading="lazy"
+                      src="/src/userGuide/assets/15-sahkoposti-salasanalle-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Ange din e-postadress i rutan som visas för att få en länk till förnyat lösenord i din e-post.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord."
+                      loading="lazy"
+                      src="/src/userGuide/assets/16-salasanan-vaihtopyynto-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Du kommer att informeras om att ett e-postmeddelande kommer att skickas till dig för att förnya ditt lösenord.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
+            kommer att vara giltig i 30 minuter."
+                      loading="lazy"
+                      src="/src/userGuide/assets/17-salasanan-vaihtoviesti-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I det e-postmeddelande du får kommer det att finnas en länk för att ange ett nytt lösenord. Länken 
+            kommer att vara giltig i 30 minuter.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
+            12 tecken långt. Lösenordet måste innehålla både stora och små bokstäver, nummer och specialtecken."
+                      loading="lazy"
+                      src="/src/userGuide/assets/18-uusi-salasana-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I fönstret för lösenordsändring måste du ange samma lösenord två gånger. Lösenordet måste vara minst 
+            12 tecken långt. Lösenordet måste innehålla både stora och små bokstäver, nummer och specialtecken.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Glömt lösenord"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Glömt_lösenord-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-49"
+                id="_Problem_med_identifiering"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Problem_med_identifiering-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Problem_med_identifiering-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Problem med identifiering
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Problem_med_identifiering-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Problem_med_identifiering-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    När du flyttar från en tjänst till en annan kan autentiseringen vara olika för de olika tjänsterna. Du loggade t.ex. in på den första tjänsten med ditt Helsingforsprofil, dvs. en kombination av e-post och lösenord, men den andra tjänsten kräver att du identifierar dig med Suomi.fi. I så fall får du ett meddelande om att autentiseringsmetoden inte är kompatibel. Du måste logga ut från den tidigare tjänsten för att autentisera dig i den nya tjänsten. Två olika autentiseringsmetoder kan inte vara öppna samtidigt.
+                  </p>
+                  <div>
+                    <img
+                      alt="En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
+            kombination av e-post och lösenord och går vidare till nästa tjänst, som kräver en Suomi.fi-autentisering. 
+            I detta fall måste du logga ut från den första tjänsten för att kunna autentisera dig till den nya tjänsten."
+                      loading="lazy"
+                      src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      En inkompatibel inloggningsmetod innebär för exempel att du har loggat in på en tjänst med en 
+            kombination av e-post och lösenord och går vidare till nästa tjänst, som kräver en Suomi.fi-autentisering. 
+            I detta fall måste du logga ut från den första tjänsten för att kunna autentisera dig till den nya tjänsten.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Bekräfta din utloggning från en tidigare tjänst."
+                      loading="lazy"
+                      src="/src/userGuide/assets/20-kirjautumislogout-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Bekräfta din utloggning från en tidigare tjänst.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Problem med identifiering"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Problem_med_identifiering-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_viewing_and_editing"
+              >
+                Visa och redigera dina egna uppgifter
+              </h2>
+              <p>
+                Genom att logga in på din Helsingforsprofil på
+                 
+                <a
+                  href="https://profiili.hel.fi"
+                >
+                  https://profiili.hel.fi
+                </a>
+                kan du se och redigera dina uppgifter och hur de används av tjänsterna.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-50"
+                id="_Redigera_profilinformation"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Redigera_profilinformation-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Redigera_profilinformation-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Redigera profilinformation
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Redigera_profilinformation-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Redigera_profilinformation-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    De officiella uppgifterna läggs till i din profil och syns endast när du autentiserar dig med Suomi.fi. Uppdateringen av uppgifterna görs i Befolkningsregistercentralens tjänst.
+                  </p>
+                  <p>
+                    I avsnittet Personuppgifter i din Helsingforsprofil kan du lägga till ett telefonnummer, ändra din e-postadress och lägga till adressuppgifter. Om du uppdaterar dina namnuppgifter i din Helsingforsprofil, kommer de officiella uppgifterna att uppdateras nästa gång du autentiserar dig in med Suomi.fi.
+                  </p>
+                  <p>
+                    Du kan lägga till eller ändra information som du själv har lagt in genom att klicka på knappen Lägg till, eller på knappen Redigera om informationen redan finns. Tryck på knappen Spara för att spara uppgifterna i databasen.
+                  </p>
+                  <p>
+                    I Helsingforsprofilen bestämmer avsnittet om tjänstens kontaktspråk på vilket språk t.ex. e-post från tjänsten ska skickas. Du kan också se hur du är autentiserad dig på din Helsingforsprofil.
+                  </p>
+                  <div>
+                    <img
+                      alt="I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
+            Befolkningsregistercentralen och uppdateras också där."
+                      loading="lazy"
+                      src="/src/userGuide/assets/21-omat-tiedot-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I avsnittet Min information i Helsingforsprofilen kommer officiella uppgifter direkt från 
+            Befolkningsregistercentralen och uppdateras också där.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information."
+                      loading="lazy"
+                      src="/src/userGuide/assets/22-omat-nimitiedot-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I din Helsingforsprofil kan du uppdatera din basuppgifter i avsnittet Min information.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
+            Tjänstens kontaktspråk avgör på vilket språk du tar emot meddelanden från tjänsten. Den 
+            autentiseringsmetoden hur du är inloggad i tjänsten, dvs. Suomi.fi-autentisering eller en kombination 
+            av e-post och lösenord, dvs. Helsingfors-ID."
+                      loading="lazy"
+                      src="/src/userGuide/assets/23-omat-yhteystiedot-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Du kan lägga till och redigera dina andra adressuppgifter, ditt telefonnummer och din e-postadress. 
+            Tjänstens kontaktspråk avgör på vilket språk du tar emot meddelanden från tjänsten. Den 
+            autentiseringsmetoden hur du är inloggad i tjänsten, dvs. Suomi.fi-autentisering eller en kombination 
+            av e-post och lösenord, dvs. Helsingfors-ID.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Redigera profilinformation"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Redigera_profilinformation-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-51"
+                id="_Olika_tjänsters_bearbetning"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Olika_tjänsters_bearbetning-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Olika_tjänsters_bearbetning-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Olika tjänsters bearbetning av dina uppgifter
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Olika_tjänsters_bearbetning-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Olika_tjänsters_bearbetning-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Tjänsterna kommer att använda de uppgifter som hanteras av Helsingforsprofilen enligt vad som anges. Första gången du identifierar dig i en tjänst kan du se vilka uppgifter tjänsten använder.
+                  </p>
+                  <p>
+                    I din Helsingforsprofil kan du kontrollera denna information senare och, om du vill, radera dina uppgifter från tjänsten. Det är inte möjligt att radera dina uppgifter om du befinner dig mitt i serviceprocessen. Det är också tillrådligt att
+                     
+                    <a
+                      href="#_Ladda_ner_din"
+                    >
+                      ladda ner dina egna information
+                    </a>
+                     innan du raderar dem.
+                  </p>
+                  <div>
+                    <img
+                      alt="När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
+            dina uppgifter som tjänsten kräver. Du kan senare återvända till denna information på avsnittet Dina 
+            tjänster i din Helsingforsprofil."
+                      loading="lazy"
+                      src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      När du identifierar dig för en ny tjänst kommer du att bli ombedd att godkänna den användning av 
+            dina uppgifter som tjänsten kräver. Du kan senare återvända till denna information på avsnittet Dina 
+            tjänster i din Helsingforsprofil.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="I avsnittet Dina tjänster i din Helsingforsprofil kan du se alla tjänster som du är autentiserad 
+          dig på och vilka data de använder. Du kan också radera dina uppgifter från enskilda tjänster."
+                      loading="lazy"
+                      src="/src/userGuide/assets/25-kayttamasi-palvelut-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I avsnittet Dina tjänster i din Helsingforsprofil kan du se alla tjänster som du är autentiserad 
+          dig på och vilka data de använder. Du kan också radera dina uppgifter från enskilda tjänster.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Olika tjänsters bearbetning av dina uppgifter"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Olika_tjänsters_bearbetning-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-52"
+                id="_Ladda_ner_din"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Ladda_ner_din-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Ladda_ner_din-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Ladda ner din information
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Ladda_ner_din-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Ladda_ner_din-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Du kan ladda ner data som du har lagrat i olika tjänster som en enda json-fil. Mer information om
+                     
+                    <a
+                      href="https://sv.wikipedia.org/wiki/JSON"
+                    >
+                      filformatet json finns på Wikipedia (länken öppnas i ett nytt fönster)
+                    </a>
+                    .
+                  </p>
+                  <p>
+                    Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress + lösenord i samma Helsingforsprofil, måste datanerladdningen göras med Suomi.fi-autentiseringen.
+                  </p>
+                  <div>
+                    <img
+                      alt="I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil."
+                      loading="lazy"
+                      src="/src/userGuide/assets/26-tietojen-lataus-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I avsnittet Min information i din Helsingforsprofil kan du ladda ner din information för alla tjänster som en json-fil.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Ladda ner din information"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Ladda_ner_din-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <h2
+                id="_Deleting_your_information"
+              >
+                Radering av uppgifter
+              </h2>
+              <p>
+                Du kan radera dina uppgifter antingen för enskilda tjänster eller för hela din profil. Vid radering kommer alla dina uppgifter från tjänsten att raderas eller anonymiseras om tjänsten till exempel är skyldig enligt lag att behålla dem. Du kommer dock inte att ha tillgång till uppgifterna efter raderingen och de kommer inte att kunna kopplas till dig.
+              </p>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-53"
+                id="_Radera_dina_uppgifter"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Radera_dina_uppgifter-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Radera_dina_uppgifter-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Radering av uppgifter från en och samma tjänst
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Radera_dina_uppgifter-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Radera_dina_uppgifter-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress och lösenord i samma Helsingforsprofil, måste du radera tjänsten medan du är autentiserad dig med Suomi.fi.
+                  </p>
+                  <p>
+                    När du väljer den tjänst som du vill ta bort på fliken Dina tjänster får du ett popup-meddelande som bekräftar borttagningen.
+                  </p>
+                  <div>
+                    <img
+                      alt="Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster."
+                      loading="lazy"
+                      src="/src/userGuide/assets/27-tietojen-poisto-palvelusta-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Du kan radera dina uppgifter i din Helsingforsprofil för en enskild tjänst i avsnittet Dina tjänster.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
+            popup-bekräftelsemeddelande på skärmen för att förhindra oavsiktlig radering av dina uppgifter."
+                      loading="lazy"
+                      src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      När du klickar på knappen "Ta bort dina uppgifter från denna tjänst" får du ett 
+            popup-bekräftelsemeddelande på skärmen för att förhindra oavsiktlig radering av dina uppgifter.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Radering av uppgifter från en och samma tjänst"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Radera_dina_uppgifter-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="Accordion-module_accordion__2fPUT Accordion-module_card__1iRKx Accordion-module_l__gPzdT custom-theme-54"
+                id="_Radera_din_Helsingforsprofil"
+                style="max-width: 800px; border: 1px solid #ffffff;"
+              >
+                <div
+                  class="Accordion-module_accordionHeader__3_uK7"
+                >
+                  <div
+                    aria-level="3"
+                    id="_Radera_din_Helsingforsprofil-heading"
+                    role="heading"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-labelledby="_Radera_din_Helsingforsprofil-heading"
+                      class="Accordion-module_headingContainer__1DzX3"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="label"
+                      >
+                        Radera din Helsingforsprofil
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-down"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-labelledby="_Radera_din_Helsingforsprofil-heading"
+                  class="Accordion-module_accordionContent__1umso Accordion-module_card__1iRKx Accordion-module_contentWithCloseButton__-einM"
+                  id="_Radera_din_Helsingforsprofil-content"
+                  role="region"
+                  style="display: none;"
+                >
+                  <p>
+                    Om du vill radera hela din Helsingforsprofil kan du göra det genom att trycka på knappen 
+                    <i>
+                      Radera min information
+                    </i>
+                    . Du kommer då att se ett popup-fönster där du ombeds bekräfta att du vill radera din information. När du har bekräftat begäran raderas alla uppgifter från profilen och från alla tjänster, om ingen tjänst är på gång.
+                  </p>
+                  <p>
+                    Vissa lagstadgade tjänster kan kräva att uppgifter sparas under en begränsad eller permanent period. Beroende på transaktionen och tjänsten kan uppgifterna i vissa fall anonymiseras. Om en lagstadgad tjänst kräver att uppgifter sparas, kan profilen eller tjänstens tillgång till uppgifterna inte raderas.
+                  </p>
+                  <p>
+                    Om du har kombinerat din Suomi.fi-autentisering och inloggning med e-postadress och lösenord i samma Helsingforsprofil, måste du radera profilen medan du är autentiserad dig med Suomi.fi.
+                  </p>
+                  <p>
+                    Efter att du har raderat din Helsingforsprofil kan du alltid skapa en ny profil vid behov, men alla tidigare uppgifter försvinner.
+                  </p>
+                  <div>
+                    <img
+                      alt="I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
+            du kan radera hela din Helsingforsprofil och den information som du har använt i olika tjänster."
+                      loading="lazy"
+                      src="/src/userGuide/assets/29-tietojen-poisto-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      I avsnittet Min information i din Helsingforsprofil finns knappen Radera min information, med vilken 
+            du kan radera hela din Helsingforsprofil och den information som du har använt i olika tjänster.
+                    </p>
+                  </div>
+                  <div>
+                    <img
+                      alt="Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data."
+                      loading="lazy"
+                      src="/src/userGuide/assets/30-tietojen-poisto-popup-sv.png"
+                    />
+                    <p
+                      class="image-text"
+                    >
+                      Ett bekräftelsemeddelande visas också i ett popup-fönster för att förhindra oavsiktlig radering av data.
+                    </p>
+                  </div>
+                  <button
+                    aria-label="Stäng Radera din Helsingforsprofil"
+                    class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
+                    data-testid="_Radera_din_Helsingforsprofil-closeButton"
+                    type="button"
+                  >
+                    <span
+                      class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                    >
+                      Stäng
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      class="Button-module_icon__O-h7R button_hds-icon__17j8Z"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-label="angle-up"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ Accordion-module_accordionButtonIcon__MQu2J"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M12 11.5L17 16.5L18.5 15L12 8.5L5.5 15L7 16.5L12 11.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <footer
+        class="Footer-module_footer__1aD3T custom-theme-55"
+      >
+        <div
+          class="Koros-module_koros__1r3rg Footer-module_koros__Orx_W"
+          style="height: 15px;"
+        >
+          <svg
+            aria-hidden="true"
+            height="85"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <defs>
+              <pattern
+                height="85"
+                id="koros_basic-56"
+                patternUnits="userSpaceOnUse"
+                width="96"
+                x="0"
+                y="0"
+              >
+                <path
+                  d="m0 5v80h32v-80c-8 0-8-5-16-5s-8 5-16 5z"
+                  transform="scale(3)"
+                />
+              </pattern>
+            </defs>
+            <rect
+              fill="url(#koros_basic-56)"
+              height="85"
+              style="shape-rendering: crispEdges;"
+              width="100%"
+            />
+          </svg>
+        </div>
+        <div
+          class="Footer-module_footerContent__3MC14"
+        >
+          <div
+            class="Footer-module_footerSections__2nrr8"
+          >
+            <h2
+              class="Footer-module_title__269y7"
+            >
+              appName
+            </h2>
+            <div
+              class="FooterUtilities-module_utilities__10PzW"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterUtilities-module_divider__2VjbX"
+              />
+              <div
+                class="FooterUtilities-module_links__3P_Ga FooterUtilities-module_widerLinks__1h7MT"
+              >
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.needHelp
+                    </h3>
+                    <a
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="/guide"
+                    >
+                      <span>
+                        footer.userGuide
+                      </span>
+                    </a>
+                    <div
+                      variant="utility"
+                    >
+                      <span>
+                        footer.helsinkiProfileSupport
+                      </span>
+                      <ul
+                        class="contacts-list"
+                      >
+                        <li>
+                          footer.openingHours
+                        </li>
+                        <li>
+                          <a
+                            class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B link-with-icon"
+                            href="tel:0931088800"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label="phone"
+                              class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M4.88475 2.50597L3.04274 4.34798L3.00927 4.38311C0.572022 7.06914 2.78398 12.4521 7.19058 16.8176C11.6361 21.2216 16.9423 23.4177 19.6169 20.9908L21.4941 19.1153C22.1719 18.4375 22.1491 17.5519 21.5517 16.8429L21.4941 16.7801L17.3496 12.6356C16.6717 11.9577 15.7862 11.9805 15.0771 12.5779L15.0143 12.6356L13.968 13.6815L13.9315 13.6736C13.3458 13.53 12.6896 13.0718 11.8082 12.1904L11.6852 12.066C10.8843 11.2471 10.4629 10.6263 10.3263 10.0686L10.318 10.0315L11.3645 8.98572L11.4221 8.92294C12.0195 8.21389 12.0424 7.32836 11.3645 6.6505L7.21997 2.50597L7.15719 2.44833C6.44814 1.85093 5.56261 1.82812 4.88475 2.50597ZM6.05202 4.16653L9.70352 7.81803L8.27588 9.24591V9.66012C8.27588 11.015 8.96256 12.1732 10.394 13.6046C11.8259 15.0365 12.9851 15.7242 14.3399 15.7242H14.7541L16.182 14.2965L19.833 17.9475L18.2379 19.5431C16.7133 20.9249 12.3595 19.1231 8.59815 15.3968L8.44621 15.2448C4.87572 11.6383 3.13151 7.398 4.43358 5.7933L4.48102 5.73753L6.05202 4.16653Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                            <span>
+                              09 310 88800
+                            </span>
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="FooterUtilityGroup-module_utilityGroup__3Voeu utility-group"
+                >
+                  <div
+                    class="FooterUtilityGroup-module_utilityGroup__3Voeu"
+                  >
+                    <h3
+                      class="FooterGroupHeading-module_heading__2iPBU FooterGroupHeading-module_utility__2Nzq0 utility-group-heading"
+                    >
+                      footer.otherContactInformation
+                    </h3>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.contactUsLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.contactUs
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                    <a
+                      aria-label="opensInNewWindow"
+                      class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_utility__3jLSl"
+                      href="footer.feedbackLink"
+                      target="_blank"
+                    >
+                      <span>
+                        footer.feedback
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="link-external"
+                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="FooterBase-module_base__2f0eu"
+            >
+              <hr
+                aria-hidden="true"
+                class="FooterBase-module_divider__3sz3q"
+              />
+              <div
+                class="FooterBase-module_logoWrapper__3BI7d"
+              >
+                <a
+                  class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B"
+                  href="https://hel.fi/sv"
+                  tabindex="0"
+                >
+                  <img
+                    alt="cityOfHelsinki"
+                    class="Logo-module_logo__Y2mwP Logo-module_medium__1zyWm"
+                    src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2Zz4KPHN2ZyB2aWV3Qm94PSIwIDAgMTA0IDM2IiB0aXRsZT0iSGVsc2luZ2ZvcnMgc3RhZCIgcm9sZT0iaW1nIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgICBjbGFzcz0iTG9nby1tb2R1bGVfbG9nb19fWTJtd1AgTG9nby1tb2R1bGVfbWVkaXVtX18xenlXbSIgc3R5bGU9Im1hcmdpbi1yaWdodDogdmFyKC0tc3BhY2luZy14cyk7Ij4KICAgIDxwYXRoCiAgICAgICAgZD0iTTEwMy4xMDUgMHYyMi45MzVjMCA1LjE3OS00LjI2NiA5LjM5Ny05LjUyNCA5LjM5N2wtMzQuODY3LjAzMmE4LjQ2IDguNDYgMCAwMC01Ljk4MSAyLjQ3MUw1MS41NTMgMzZsLTEuMTgxLTEuMTY1YTguNDA1IDguNDA1IDAgMDAtNS45ODItMi40NzFIOS40NzZDNC4yNSAzMi4zNjQgMCAyOC4xNDUgMCAyMi45NjZWMGgxMDMuMTA1em0tMi4yMzYgMi4yMzVIMi4yNTF2MjAuNzMxYzAgMy45NTEgMy4yNDMgNy4xNjMgNy4yMjUgNy4xNjNINDQuMzljMi42NzYgMCA1LjE5NS45NiA3LjE2MiAyLjczOSAxLjk2OC0xLjc4IDQuNDg2LTIuNzQgNy4xNjItMi43NGwzNC44NjctLjAzYzQuMDE0IDAgNy4yODgtMy4yMTIgNy4yODgtNy4xNjN2LTIwLjd6TTYyLjAyIDEyLjA5bDIgMS4xNWMtLjAzMiAxLjAwNy0uNDg5IDEuNDc5LTEuMzU0IDEuNDc5LS4yMDUgMC0uNDczLS4wNDctLjYxNC0uMDk0di4wNjJjLjQyNS4zMzEuOTQ0Ljg4Mi45NDQgMS43NjMgMCAxLjUxMi0xLjQ2NCAyLjQ3Mi0zLjI3NCAyLjQ3Mi0uODM0IDAtMS41NTguMjY3LTEuNTU4LjY3NyAwIC4zMTUuMjY3LjQ1Ni45MTMuNDU2LjY0NSAwIDEuMzY5LS4xMjYgMi4yMDMtLjEyNiAxLjY1MyAwIDIuNzU1LjY2MSAyLjc1NSAyLjE1NyAwIDEuNzk0LTIuMDE1IDIuNTAzLTQuMjgyIDIuNTAzLTIuMTA5IDAtNC4wMy0uNTk4LTQuMDMtMS45NTIgMC0uODE5Ljg1LTEuMzA3IDEuNjIyLTEuNDQ4di0uMDQ4Yy0uNTgyLS4xNzMtMS4xMDItLjU1LTEuMTAyLTEuMjEyIDAtLjg2NS44ODItMS4zMzggMS43NzktMS41Mjd2LS4wNDdjLS44MzQtLjMzLTEuNTQzLTEuMDA3LTEuNTQzLTIuMTg4IDAtMS41MTEgMS4zMjItMi41NSAzLjEzMy0yLjU1LjY5MiAwIDEuMDg2LjE0MiAxLjYwNS4xNDIuNjQ2IDAgLjg4Mi0uMzYyLjg4Mi0uOTQ1IDAtLjI2Ny0uMDQ3LS41MzUtLjA3OS0uNzI0em0tMS43MzEgOS41NGMtLjkzIDAtMi43MjQuMDc4LTIuNzI0Ljc4NiAwIC41MzYuODk4Ljc4NyAyLjE1Ny44MDMgMS40MTcgMCAyLjIzNS0uMjY3IDIuMjM1LS45MTMgMC0uNTA0LS43NTUtLjY3Ny0xLjY2OC0uNjc3em0yOC45OTUtOC4wMTNjMS41MjcgMCAyLjkyOC43MjQgMy41MjYgMS43NDdsLTEuODQyIDEuMDRhMS42MjQgMS42MjQgMCAwMC0xLjYwNi0xLjIxM2MtLjU1IDAtMS4wMDcuMjM2LTEuMDA3LjY3NyAwIC41ODIgMS4wMDcuNjQ1IDIuMTU3IDEuMDA4IDEuMTk2LjM3NyAyLjI5OC45MjggMi4yOTggMi4zMyAwIDEuNTQyLTEuNDMzIDIuNDU1LTMuMTAxIDIuNDU1LTEuNzk1IDAtMy4yMTEtLjc3MS0zLjg0MS0xLjk4NGwxLjg3My0xLjA1NGMuMjUyLjgzNC45MTMgMS40NjQgMS45MzYgMS40NjQuNTk4IDAgMS4wMjMtLjI2OCAxLjAyMy0uNzQgMC0uNjE0LS44NS0uNzU2LTEuODQxLTEuMDIzLTEuMTY1LS4zMTUtMi42MTMtLjg4Mi0yLjYxMy0yLjM0NiAwLTEuNDQ4IDEuMzg1LTIuMzYgMy4wMzgtMi4zNnptLTE0LjY1NSAwYzIuMDc4IDAgMy42OTkgMS41MjcgMy42OTkgNC4wMTRzLTEuNjA2IDQuMDE0LTMuNyA0LjAxNGMtMi4xMDkgMC0zLjcxNC0xLjUyNy0zLjcxNC00LjAxNHMxLjYwNS00LjAxNCAzLjcxNS00LjAxNHptLTQ5LjY4IDBjMi4wNjMgMCAzLjQzMiAxLjQ2NCAzLjQzMiAzLjU0Mi4wMTYuNjE0LS4wOTQgMS4wMzktLjA5NCAxLjAzOWgtNC45NzRjLjA5NCAxLjI0My43ODcgMS44NTcgMS42ODQgMS44NTcuODAzIDAgMS4zNTQtLjUzNSAxLjQ4LTEuMjZsMS44MSAxLjAyNGMtLjUzNS45NzYtMS42ODQgMS44MjYtMy4yOSAxLjgyNi0yLjE0IDAtMy43MTUtMS40OTUtMy43MTUtNC4wMTQgMC0yLjQ4NyAxLjYwNi00LjAxNCAzLjY2OC00LjAxNHptMTMuMDY2LS4wMTZjMS41MjcgMCAyLjkyOC43MjQgMy41MjYgMS43NDhsLTEuODQyIDEuMDM5Yy0uMTg5LS42NzctLjc1NS0xLjIxMy0xLjYwNS0xLjIxMy0uNTUxIDAtMS4wMDguMjM3LTEuMDA4LjY3NyAwIC41ODMgMS4wMDguNjQ2IDIuMTQgMS4wMDggMS4xOTcuMzc4IDIuMy45MjggMi4zIDIuMzMgMCAxLjU0Mi0xLjQzMyAyLjQ0LTMuMDg2IDIuNDQtMS43OTUgMC0zLjIxMS0uNzU2LTMuODQxLTEuOTg0bDEuODczLTEuMDU1Yy4yMzYuODM1LjkxMyAxLjQ2NCAxLjkzNiAxLjQ2NC41ODMuMDE2IDEuMDA4LS4yMzYgMS4wMDgtLjcyNCAwLS42MTQtLjg1LS43NC0xLjg0Mi0xLjAyMy0xLjE2NS0uMy0yLjU5Ny0uODgyLTIuNTk3LTIuMzQ1IDAtMS40NDkgMS4zODUtMi4zNjIgMy4wMzgtMi4zNjJ6TTMyLjMgMTAuNTN2OC41MDFjMCAuMzYyLjA0Ny42MTQuMTU3Ljc1Ni4wOTUuMTU3LjIyLjIyLjUwNC4yMi4xNzMgMCAuMzMgMCAuNDU2LS4wMzFhMi4wMSAyLjAxIDAgMDAuNDU3LS4xMjZsLS4xODkgMS40NDhhMi41MzIgMi41MzIgMCAwMS0uNjQ1LjIzNmMtLjI1Mi4wNDctLjUyLjA3OS0uNzcyLjA3OS0uNzQgMC0xLjI3NS0uMTc0LTEuNjIxLS41MzYtLjMzLS4zNjItLjUwNC0uOTQ0LS41MDQtMS43MzFWMTAuNTNoMi4xNTd6bTE5LjgxOCAzLjA4NmMxLjQ4IDAgMi40MDggMS4wMjMgMi40MDggMi45Mjh2NC45MTFoLTIuMTU2VjE2Ljk3YzAtMS4wMDctLjM2Mi0xLjU0My0xLjE2NS0xLjU0M3MtMS4zMjIuNjE0LTEuMzIyIDEuNDk2djQuNTQ5aC0yLjE0MXYtNy42NjZoMi4xNGwtLjExIDEuMjZoLjA0OGMuMzc4LS43MSAxLjAzOS0xLjQ0OSAyLjI5OC0xLjQ0OXptMTYuNzMzLTMuMzM3YTMuMjcgMy4yNyAwIDAxMi43MzkgMS40bC0xLjg1OCAxLjEzNGMtLjAzMS0uNDU2LS4yNTItLjkyOC0uNzcxLS45MjgtLjUzNSAwLS43ODcuNDA5LS43ODcgMS4wODZ2LjgzNGgxLjY4NHYxLjYzN2gtMS42ODR2Ni4wMjloLTIuMTR2LTYuMDI5aC0xLjE4MXYtMS42MzdoMS4xOHYtLjgxOWMwLTEuNzk0IDEuMTgtMi43MDcgMi44MTgtMi43MDd6bTE0LjgxMiAzLjM4NGMxLjA4NiAwIDEuNjg0LjkxMyAxLjY4NCAyLjAzIDAgLjUwNS0uMDc4Ljg5OC0uMDc4Ljg5OGwtMS45MzYgMS4xMThjLjAzMS0uMjIuMTI2LS43NC4xMjYtMS4yNiAwLS41MDMtLjE5LS45NzUtLjcyNS0uOTc1LS42NzYgMC0uOTQ0LjYzLS45NDQgMS42MnY0LjM3N2gtMi4xNTd2LTcuNjVoMi4xNTdsLS4xMSAxLjI1OWguMDQ3Yy4zNzgtLjc0Ljk2LTEuNDE3IDEuOTM2LTEuNDE3em0tNzAuNTItMi43MjN2NC4xNzFoNC4yMDN2LTQuMTdoMi4yMzV2MTAuNTE0aC0yLjIzNXYtNC4zNmgtNC4yMDN2NC4zNmgtMi4yMzVWMTAuOTRoMi4yMzV6bTMyLjMzMiAyLjg1djcuNjY1SDQzLjMyVjEzLjc5aDIuMTU2em0yOS4xNTMgMS40NjNjLTEuMDcgMC0xLjU0MyAxLjAwOC0xLjU0MyAyLjM3NyAwIDEuMzcuNDcyIDIuMzc3IDEuNTQzIDIuMzc3IDEuMDU0IDAgMS41MjctMS4wMDcgMS41MjctMi4zNzcgMC0xLjM3LS40NzMtMi4zNzctMS41MjctMi4zNzd6bS0xNC44OTEtLjE4OWMtLjcyNCAwLTEuMzA3LjQ3My0xLjMwNyAxLjE5NyAwIC43NC41ODMgMS4yMTIgMS4zMDcgMS4xOTYuNzI0IDAgMS4zMDYtLjQ3MiAxLjMwNi0xLjE5NnMtLjU4Mi0xLjE5Ny0xLjMwNi0xLjE5N3ptLTM0Ljc3My4wOTVjLS43ODcgMC0xLjQzMi41NjYtMS42MDUgMS42MDVoMy4wMzhjMC0uOTEzLS41OTgtMS42MDUtMS40MzMtMS42MDV6bTE5LjQ0LTQuNjc1Yy42OTMgMCAxLjI0NC41MDMgMS4yNDQgMS4xOTZzLS41NSAxLjE5Ni0xLjI0MyAxLjE5NmMtLjcwOSAwLTEuMjQ0LS41MDMtMS4yNDQtMS4xOTZzLjU1MS0xLjE5NiAxLjI0NC0xLjE5NnoiCiAgICAgICAgZmlsbD0id2hpdGUiPjwvcGF0aD4KPC9zdmc+"
+                  />
+                </a>
+              </div>
+              <div
+                class="FooterBase-module_copyright__2iiev"
+              >
+                <span>
+                  © 
+                  cityOfHelsinki
+                   
+                  2024
+                </span>
+                <span
+                  class="FooterBase-module_copyrightDot__2AfS6"
+                >
+                  •
+                </span>
+                <span>
+                  footer.reserveRights
+                </span>
+              </div>
+              <div
+                class="FooterBase-module_baseActions__1hCiR"
+              >
+                <div
+                  class="FooterBase-module_links__3lfLo"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <a
+                    aria-label="opensInNewWindow"
+                    class="Link-module_link__TeBQo link_hds-link__5Oxo- Link-module_linkM__30gsY link_hds-link--medium__xEU_F FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj"
+                    href="profileForm.termsFileDescriptionLink"
+                    target="_blank"
+                  >
+                    <span>
+                      footer.privacy
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      aria-label="link-external"
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_xs__3kAOj icon_hds-icon--size-xs__3dAMZ FooterLink-module_icon__3KZCE link_icon__1UA7k"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                  <span
+                    aria-hidden="true"
+                    class="FooterBase-module_separator__cwQTe"
+                  >
+                    |
+                  </span>
+                  <div />
+                </div>
+                <button
+                  class="FooterBase-module_backToTopButton__hXTHm"
+                  role="link"
+                  type="button"
+                >
+                  footer.backToTop
+                  <svg
+                    aria-hidden="true"
+                    aria-label="arrow-up"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M12 3.5L18.5 10L17 11.5L13 7.5V20H11V7.5L7 11.5L5.5 10L12 3.5Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`User guide > renders UserGuide without errors 1`] = `
 <div>
   <div
@@ -331,34 +12884,30 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Suomi.fi-tunnistautuminen. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
-                      loading="lazy"
-                      src="/src/userGuide/assets/01-sisaankirjautuminen.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen.
-                    </p>
+                <div>
+                  <img
+                    alt="Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen."
+                    loading="lazy"
+                    src="/src/userGuide/assets/01-sisaankirjautuminen.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Tunnistautumisikkunassa valitaan Suomi.fi-tunnistautuminen.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
-                      loading="lazy"
-                      src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen."
+                    loading="lazy"
+                    src="/src/userGuide/assets/02-sisaankirjautuminen-tunnistamo.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Tunnistautumistavaksi valitaan Suomi.fi-tunnistautuminen.
                   </p>
-                </p>
+                </div>
                 <h4>
                   Tunnistautuminen Suomi.fi-palvelussa
                 </h4>
@@ -368,34 +12917,30 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Tunnistautumisen jälkeen tarkista, että käytettävät tiedot ovat oikein. Mikäli havaitset tiedoissa virheitä, ne tulee korjata väestörekisterikeskuksen palvelussa.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
-                      loading="lazy"
-                      src="/src/userGuide/assets/03-vahvan-valinta.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona.
-                    </p>
+                <div>
+                  <img
+                    alt="Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona."
+                    loading="lazy"
+                    src="/src/userGuide/assets/03-vahvan-valinta.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Valitse oma pankkisi tai mobiilivarmenne Suomi.fi-tunnistautumisvaihtoehtona.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
-                      loading="lazy"
-                      src="/src/userGuide/assets/04-vahvat-tiedot.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun."
+                    loading="lazy"
+                    src="/src/userGuide/assets/04-vahvat-tiedot.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Tarkista, että tietosi ovat oikein, kun siirryt takaisin Helsingin kaupungin palveluun.
                   </p>
-                </p>
+                </div>
                 <h4>
                   Sähköpostiosoitteen vahvistus
                 </h4>
@@ -417,50 +12962,44 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                     Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
                   </b>
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+                <div>
+                  <img
+                    alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
   Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
-                      loading="lazy"
-                      src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+                    loading="lazy"
+                    src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
   Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
-                    </p>
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
-                      loading="lazy"
-                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                    loading="lazy"
+                    src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
-                      loading="lazy"
-                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                    loading="lazy"
+                    src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
                   </p>
-                </p>
+                </div>
                 <h4>
                   Helsinki-profiilin luonti
                 </h4>
@@ -483,20 +13022,18 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Kun kirjaudut seuraavan kerran samaan palveluun, valitse tunnistautumisvaihtoehdoksi Suomi.fi.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
-                      loading="lazy"
-                      src="/src/userGuide/assets/08-profiilin-luominen.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda.
-                    </p>
+                <div>
+                  <img
+                    alt="Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda."
+                    loading="lazy"
+                    src="/src/userGuide/assets/08-profiilin-luominen.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Ennen kuin voit käyttää haluamaasi palvelua tai luoda Helsinki-profiilin, sinun pitää antaa suostumus tietojesi käyttöön. Ilman suostumusta tietojasi ei voida käyttää eikä profiilia voida luoda.
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Suomi.fi-tunnistautuminen"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -587,20 +13124,18 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Asiointipalvelussa Kirjaudu-linkin painamisen jälkeen näet erilaisia kirjautumisvaihtoehtoja, joista valitaan Luo Helsinki-profiili. Kirjautumisvaihtoehtojen näkymä vaihtelee eri asiointipalveluissa.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
-                      loading="lazy"
-                      src="/src/userGuide/assets/09-helsinki-tunnus-luonti.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta.
-                    </p>
+                <div>
+                  <img
+                    alt="Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta."
+                    loading="lazy"
+                    src="/src/userGuide/assets/09-helsinki-tunnus-luonti.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-tunnus koostuu sähköposti ja salasana -yhdistelmästä klikkaamalla Luo uusi Helsinki-profiili-painiketta.
                   </p>
-                </p>
+                </div>
                 <h4>
                   Sähköpostiosoitteen vahvistus
                 </h4>
@@ -629,50 +13164,44 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                     Älä sulje Helsinki-profiilin selainikkunaa, kun haet vahvistusviestin sähköpostistasi. Muuten järjestelmä olettaa sinun keskeyttäneen tunnistautumisprosessin.
                   </b>
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+                <div>
+                  <img
+                    alt="Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
   Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin."
-                      loading="lazy"
-                      src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
+                    loading="lazy"
+                    src="/src/userGuide/assets/05-10-sahkopostiosoite.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostiosoite toimii tunnuksenasi Helsingin kaupungin palveluihin. Käyttämällä samaa sähköpostiosoitetta sekä
   Suomi.fi-tunnistautumisessa että Helsinki-tunnuksella, saat yhden Helsinki-profiilin. Yhdistämistä ei voi purkaa myöhemmin.
-                    </p>
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
-                      loading="lazy"
-                      src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito."
+                    loading="lazy"
+                    src="/src/userGuide/assets/06-11-sahkopostin-vahvistuskoodi.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostiviestissä on 6-numeroinen vahvistuskoodi, jolla varmennetaan, että sähköpostiosoite on aito.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
-                      loading="lazy"
-                      src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään."
+                    loading="lazy"
+                    src="/src/userGuide/assets/07-12-sahkopostin-vahvistus.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Sähköpostin 6-numeroinen luku pitää kirjata selainikkunan vahvistuskoodi-kenttään.
                   </p>
-                </p>
+                </div>
                 <h4>
                   Helsinki-profiilin luonti
                 </h4>
@@ -685,22 +13214,20 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Nyt sinulle on luotu Helsinki-profiili. Palveluihin tunnistautumiseen tarvitsemasi Helsinki-tunnus on tämä sähköpostiosoite-salasana-yhdistelmä.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+                <div>
+                  <img
+                    alt="Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
             salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda."
-                      loading="lazy"
-                      src="/src/userGuide/assets/13-helsinki-tunnus-teko.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
+                    loading="lazy"
+                    src="/src/userGuide/assets/13-helsinki-tunnus-teko.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-profiilin luomisen yhteydessä pitää vielä täyttää nimitiedot ja antaa
             salasana. Sinun pitää myös antaa suostumus tietojesi käyttöön, jotta Helsinki-profiili voidaan luoda.
-                    </p>
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Sähköposti-tunnistautuminen"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -913,78 +13440,68 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Salasanan pitää olla vähintään 12 merkkiä pitkä. Siinä pitää käyttää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
-                      loading="lazy"
-                      src="/src/userGuide/assets/14-salasanan-unohdus.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä.
-                    </p>
+                <div>
+                  <img
+                    alt="Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä."
+                    loading="lazy"
+                    src="/src/userGuide/assets/14-salasanan-unohdus.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Klikkaa kirjautumisikkunassa Olen unohtanut salasanani -linkkiä.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
-                      loading="lazy"
-                      src="/src/userGuide/assets/15-sahkoposti-salasanalle.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi."
+                    loading="lazy"
+                    src="/src/userGuide/assets/15-sahkoposti-salasanalle.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Syötä sähköpostiosoitteesi avautuvaan kenttään, jotta saat salasanan uusimislinkin sähköpostiisi.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
-                      loading="lazy"
-                      src="/src/userGuide/assets/16-salasanan-vaihtopyynto.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten."
+                    loading="lazy"
+                    src="/src/userGuide/assets/16-salasanan-vaihtopyynto.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Saat tiedon, että sinulle lähetetään sähköpostiviesti salasanan uusimista varten.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
-                      loading="lazy"
-                      src="/src/userGuide/assets/17-salasanan-vaihtoviesti.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. 
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. "
+                    loading="lazy"
+                    src="/src/userGuide/assets/17-salasanan-vaihtoviesti.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Saamassasi sähköpostiviestissä on linkki uuden salasanan antamista varten. Linkki on voimassa 30 minuuttia. 
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+                </div>
+                <div>
+                  <img
+                    alt="Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
             vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä."
-                      loading="lazy"
-                      src="/src/userGuide/assets/18-uusi-salasana.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
+                    loading="lazy"
+                    src="/src/userGuide/assets/18-uusi-salasana.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Salasanan vaihtoikkunassa sinun pitää syöttää sama salasana kahteen kertaan. Salasanassa pitää olla
             vähintään 12 merkkiä. Salasanan pitää sisältää sekä isoja että pieniä kirjaimia, numeroita ja erikoismerkkejä.
-                    </p>
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Unohtunut salasana"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1072,34 +13589,30 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Kun siirryt palvelusta toiseen, tunnistautumistapa voi olla erilainen eri palveluissa. Esimerkiksi olit kirjautuneena ensimmäiseen palveluun Helsinki-tunnuksella eli sähköpostin ja salasanan yhdistelmällä, mutta toinen palvelu tarvitsee Suomi.fi-tunnistautumisen. Tällöin saat ilmoituksen, ettei tunnistautumistapa ole yhteensopiva. Sinun tulee kirjautua ulos aiemmasta palvelusta, jotta voit tunnistautua uuteen palveluun. Kahta eri tunnistautumistapaa ei voi olla samaan aikaa avoinna.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
-                      loading="lazy"
-                      src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun.
-                    </p>
+                <div>
+                  <img
+                    alt="Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun."
+                    loading="lazy"
+                    src="/src/userGuide/assets/19-yhteensopimaton-kirjautuminen.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Yhteensopimaton kirjautumistapa tarkoittaa, että olet kirjautunut esimerkiksi yhteen palveluun sähköposti-salasana-yhdistelmällä ja siirryt käyttämään seuraavaa palvelua, joka tarvitseekin Suomi.fi-tunnistautumisen. Tällöin sinun pitää kirjautua ulos ensimmäisestä palvelusta voidaksesi kirjautua uuteen palveluun.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
-                      loading="lazy"
-                      src="/src/userGuide/assets/20-kirjautumislogout.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Vahvista uloskirjautuminen aiemmasta palvelusta.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Vahvista uloskirjautuminen aiemmasta palvelusta."
+                    loading="lazy"
+                    src="/src/userGuide/assets/20-kirjautumislogout.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Vahvista uloskirjautuminen aiemmasta palvelusta.
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Ongelma kirjautumisessa"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1211,7 +13724,7 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Helsinki-profiilin asiointikieli-kohta määrittää, millä kielellä esimerkiksi palvelun sähköpostit lähetetään. Näet myös miten olet tunnistautunut Helsinki-profiiliin.
                 </p>
-                <p>
+                <div>
                   <img
                     alt="Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä."
                     loading="lazy"
@@ -1222,35 +13735,31 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                   >
                     Helsinki-profiilissa Omat tiedot -osiossa Viralliset tiedot tulevat suoraan väestörekisterikeskuksesta ja niiden päivittäminen tehdään myös siellä.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
-                      loading="lazy"
-                      src="/src/userGuide/assets/22-omat-nimitiedot.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä."
+                    loading="lazy"
+                    src="/src/userGuide/assets/22-omat-nimitiedot.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-profiilissa Omat tiedot -osiossa Perustiedot ovat itse päivitettävissä.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
-                      loading="lazy"
-                      src="/src/userGuide/assets/23-omat-yhteystiedot.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella."
+                    loading="lazy"
+                    src="/src/userGuide/assets/23-omat-yhteystiedot.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Voit lisätä ja muokata muita osoitetietojasi, puhelinnumerosi ja sähköpostiosoitteesi. Asiointikieli määrittää, millä kielellä saat viestejä palvelusta. Tunnistautumistapa kertoo, millä tavalla olet kirjautunut palveluun eli Suomi.fi-tunnistautuen tai sähköposti-salasana-yhdistelmällä eli Helsinki-tunnuksella.
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Profiili-tietojen muokkaaminen"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1348,38 +13857,34 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                   </a>
                    ennen poistoa.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+                <div>
+                  <img
+                    alt="Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
             Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä."
-                      loading="lazy"
-                      src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
+                    loading="lazy"
+                    src="/src/userGuide/assets/24-olemassa-olevan-profiilin-kirjautuminen.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Tunnistautuessasi uuteen palveluun sinulta pyydetään suostumus palvelun tarvitsemien tietojesi käyttöön.
             Voit myöhemmin palata näihin tietoihin Helsinki-profiilin Käyttämäsi palvelut -välilehdellä.
-                    </p>
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+                </div>
+                <div>
+                  <img
+                    alt="Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
             tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista."
-                      loading="lazy"
-                      src="/src/userGuide/assets/25-kayttamasi-palvelut.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
+                    loading="lazy"
+                    src="/src/userGuide/assets/25-kayttamasi-palvelut.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-profiilin Käyttämäsi palvelut -osiossa näet kaikki palvelut, joihin olet tunnistautunut ja mitä
             tietojasi ne käyttävät. Voit myös poistaa tietosi yksittäisistä palveluista.
-                    </p>
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Tietojen käsittely eri palveluissa"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1473,21 +13978,19 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                     json-tiedostomuodosta Wikipediassa (linkki avautuu uuteen ikkunaan)
                   </a>
                   . Jos olet yhdistänyt Suomi.fi-tunnistautumisen ja sähköpostiosoite-salasana-kirjautumisen samaan Helsinki-profiiliin, tietojen lataus pitää tehdä Suomi.fi-tunnistautuneena.
-                  <p>
-                    <p>
-                      <img
-                        alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
-                        loading="lazy"
-                        src="/src/userGuide/assets/26-tietojen-lataus.png"
-                      />
-                      <p
-                        class="image-text"
-                      >
-                        Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona.
-                      </p>
-                    </p>
-                  </p>
                 </p>
+                <div>
+                  <img
+                    alt="Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona."
+                    loading="lazy"
+                    src="/src/userGuide/assets/26-tietojen-lataus.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-profiilin Omat tiedot -osiossa voit ladata tietosi kaikista palveluista json-tiedostona.
+                  </p>
+                </div>
                 <button
                   aria-label="Sulje Tietojesi lataaminen"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1586,34 +14089,30 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Kun valitset poistettavan palvelun Käyttämäsi palvelut -välilehdellä, saat ponnahdusikkunaan vahvistusviestin poistosta.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
-                      loading="lazy"
-                      src="/src/userGuide/assets/27-tietojen-poisto-palvelusta.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa.
-                    </p>
+                <div>
+                  <img
+                    alt="Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa."
+                    loading="lazy"
+                    src="/src/userGuide/assets/27-tietojen-poisto-palvelusta.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Voit poistaa tietosi Helsinki-profiilissa yksittäisen palvelun kohdalla Käyttämäsi palvelut -osiossa.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa."
-                      loading="lazy"
-                      src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa."
+                    loading="lazy"
+                    src="/src/userGuide/assets/28-tietojen-poisto-palvelusta-pop-up.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Klikattuasi "Poista tietosi tästä palvelusta"-painiketta saat vielä ponnahdusikkunaan vahvistusviestin ruudulle, jotta tietoja ei poisteta vahingossa.
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Tietojesi poisto yksittäisestä palvelusta"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"
@@ -1710,34 +14209,30 @@ exports[`User guide > renders UserGuide without errors 1`] = `
                 <p>
                   Helsinki-profiilin poistamisen jälkeen voit aina tarvittaessa tehdä uuden profiilin, mutta kaikki aiemmat tiedot on menetetty.
                 </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
-                      loading="lazy"
-                      src="/src/userGuide/assets/29-tietojen-poisto.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi.
-                    </p>
+                <div>
+                  <img
+                    alt="Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi."
+                    loading="lazy"
+                    src="/src/userGuide/assets/29-tietojen-poisto.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Helsinki-profiilin Omat tiedot -osiossa on painike Poista omat tiedot, jolla voit poistaa koko Helsinki-profiilin ja eri palveluissa käytetyt tietosi.
                   </p>
-                </p>
-                <p>
-                  <p>
-                    <img
-                      alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
-                      loading="lazy"
-                      src="/src/userGuide/assets/30-tietojen-poisto-popup.png"
-                    />
-                    <p
-                      class="image-text"
-                    >
-                      Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa.
-                    </p>
+                </div>
+                <div>
+                  <img
+                    alt="Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa."
+                    loading="lazy"
+                    src="/src/userGuide/assets/30-tietojen-poisto-popup.png"
+                  />
+                  <p
+                    class="image-text"
+                  >
+                    Ruudulle tulee vielä varmistusviesti ponnahdusikkunaan, jotta tietoja ei poisteta vahingossa.
                   </p>
-                </p>
+                </div>
                 <button
                   aria-label="Sulje Helsinki-profiilin poisto"
                   class="Button-module_button__1msFE button_hds-button__2A0je Button-module_supplementary__3YKiS button_hds-button--supplementary__GcHcV Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4 Button-module_size-small__3lizH button_hds-button--small__2NFef Accordion-module_closeButton__1Qt8U"


### PR DESCRIPTION
- Remove nested `<p>` tags ins user guide hat cause warnings in browser console.
- Add two missing space characters
- Expand snapshot tests


https://helsinkisolutionoffice.atlassian.net/browse/HP-2656