### PR TITLE
fix: unit test snapshots year number

### DIFF
--- a/src/userGuide/__tests__/__snapshots__/UserGuide.test.tsx.snap
+++ b/src/userGuide/__tests__/__snapshots__/UserGuide.test.tsx.snap
@@ -2003,7 +2003,7 @@ exports[`User guide > renders UserGuide component in English 1`] = `
                     © 
                     cityOfHelsinki
                      
-                    2024
+                    2025
                   </span>
                   <span
                     class="FooterBase-module_copyrightDot__2AfS6"
@@ -4102,7 +4102,7 @@ exports[`User guide > renders UserGuide component in English 1`] = `
                   © 
                   cityOfHelsinki
                    
-                  2024
+                  2025
                 </span>
                 <span
                   class="FooterBase-module_copyrightDot__2AfS6"
@@ -6187,7 +6187,7 @@ exports[`User guide > renders UserGuide component in Finnish 1`] = `
                     © 
                     cityOfHelsinki
                      
-                    2024
+                    2025
                   </span>
                   <span
                     class="FooterBase-module_copyrightDot__2AfS6"
@@ -8215,7 +8215,7 @@ exports[`User guide > renders UserGuide component in Finnish 1`] = `
                   © 
                   cityOfHelsinki
                    
-                  2024
+                  2025
                 </span>
                 <span
                   class="FooterBase-module_copyrightDot__2AfS6"
@@ -10336,7 +10336,7 @@ exports[`User guide > renders UserGuide component in Swedish 1`] = `
                     © 
                     cityOfHelsinki
                      
-                    2024
+                    2025
                   </span>
                   <span
                     class="FooterBase-module_copyrightDot__2AfS6"
@@ -12400,7 +12400,7 @@ exports[`User guide > renders UserGuide component in Swedish 1`] = `
                   © 
                   cityOfHelsinki
                    
-                  2024
+                  2025
                 </span>
                 <span
                   class="FooterBase-module_copyrightDot__2AfS6"


### PR DESCRIPTION
Year number in footer changed from 2024 to 2025 and the unit test snapshots need to be refreshed.