### PR TITLE
fix: change aluehallintovirasto to traficom

### DIFF
--- a/src/accessibilityStatement/AccessibilityStatementEn.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementEn.tsx
@@ -52,14 +52,12 @@ function AccessibilityStatementEn(): ReactElement {
       </p>
       <h2>Accessibility monitoring</h2>
       <p>
-        The Regional State Administrative Agency for Southern Finland enforces
-        compliance with accessibility requirements. If you are dissatisfied with
-        the reply you received from us about a detected accessibility
-        shortcoming or you did not receive a reply within 14 days, you may
-        submit a complaint or request for information to the Regional State
-        Administrative Agency for Southern Finland. The website of the Regional
-        State Administrative Agency of Southern Finland has information on
-        submitting a complaint and how complaints are processed.
+        Finnish Transport and Communication Agency Traficom enforces compliance
+        with accessibility requirements. If you are dissatisfied with the reply
+        you received from us about a detected accessibility shortcoming or you
+        did not receive a reply within 14 days, you may submit a complaint or
+        request for information to Traficom. The website of Traficom has
+        information on submitting a complaint and how complaints are processed.
       </p>
       <p>
         Finnish Transport and Communication Agency Traficom <br />

--- a/src/accessibilityStatement/AccessibilityStatementFi.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementFi.tsx
@@ -53,12 +53,11 @@ function AccessibilityStatementFi(): ReactElement {
       </p>
       <h2>Saavutettavuuden valvonta</h2>
       <p>
-        Etelä-Suomen aluehallintovirasto valvoo saavutettavuusvaatimusten
+        Liikenne- ja viestintävirasto Traficom valvoo saavutettavuusvaatimusten
         toteutumista. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa
         vastausta lainkaan kahden viikon aikana, voit tehdä ilmoituksen
-        Etelä-Suomen aluehallintovirastoon. Etelä-Suomen aluehallintoviraston
-        sivulla kerrotaan tarkasti, miten ilmoituksen voi tehdä ja miten asia
-        käsitellään.
+        Traficomiin. Traficomin sivulla kerrotaan tarkasti, miten ilmoituksen
+        voi tehdä ja miten asia käsitellään.
       </p>
       <p>
         Liikenne- ja viestintävirasto Traficom <br />

--- a/src/accessibilityStatement/AccessibilityStatementSv.tsx
+++ b/src/accessibilityStatement/AccessibilityStatementSv.tsx
@@ -59,12 +59,11 @@ function AccessibilityStatementSv(): React.ReactElement {
 
       <h2>Tillgänglighetstillsyn</h2>
       <p>
-        Regionförvaltningsverket i Södra Finland övervakar att
+        Transport- och kommunikationsverket Traficom övervakar att
         tillgänglighetskraven följs. Om du är missnöjd med svaret eller om du
         inte fått något svar inom två veckor, kan du göra en anmälan till
-        Regionförvaltningsverket i Södra Finland. Regionförvaltningsverket i
-        Södra Finland meddelar detaljerat på sin webbplats hur man går till väga
-        för att lämna in en anmälan och hur den handläggs.
+        Traficom. Traficom meddelar detaljerat på sin webbplats hur man går till
+        väga för att lämna in en anmälan och hur den handläggs.
       </p>
       <p>
         Transport- och kommunikationsverket Traficom


### PR DESCRIPTION
Noticed that some of the text in accessibility statement were still not updated to Traficom.
Fixed now.
