### PR TITLE
feat: skip tunnistamo auth code checks HP-2818

### DIFF
--- a/src/gdprApi/actions/deleteProfile.ts
+++ b/src/gdprApi/actions/deleteProfile.ts
@@ -48,15 +48,13 @@ const deleteProfileExecutor: ActionExecutor = async (
   action,
   queueController
 ) => {
-  // Use keycloak for both auth codes until we properly clean up tunnistamo
-  const authorizationCode = getStoredKeycloakAuthCode(queueController);
+  // TODO: Use keycloak for both auth codes until we properly clean up tunnistamo
   const authorizationCodeKeycloak = getStoredKeycloakAuthCode(queueController);
-  if (!authorizationCode) {
-    return Promise.reject('No keycloak authorization code');
-  }
+
   const language = getData(action, 'language') as TranslationLanguage;
   const input: Mutable<DeleteMyProfileMutationInput> = {
-    authorizationCode,
+    authorizationCode: authorizationCodeKeycloak || 'dummy',
+    authorizationCodeKeycloak: authorizationCodeKeycloak || 'dummy',
     dryRun: false,
   };
   if (typeof authorizationCodeKeycloak === 'string') {

--- a/src/gdprApi/actions/getDownloadData.ts
+++ b/src/gdprApi/actions/getDownloadData.ts
@@ -43,11 +43,13 @@ const getDownloadDataExecutor: ActionExecutor = async (
 ) => {
   const authorizationCode = getStoredKeycloakAuthCode(queueController);
   const authorizationCodeKeycloak = getStoredKeycloakAuthCode(queueController);
+
   if (!authorizationCode) {
-    return Promise.reject('No keycloak authorization code');
+    // TODO: in tunnistamo cleanup add some error handling here ?
+    // return Promise.reject('No keycloak authorization code for download');
   }
   const variables: Mutable<DownloadMyProfileQueryVariables> = {
-    authorizationCode,
+    authorizationCode: authorizationCode || 'dummy',
   };
   if (typeof authorizationCodeKeycloak === 'string') {
     variables.authorizationCodeKeycloak = authorizationCodeKeycloak;


### PR DESCRIPTION
Tunnistamo auth code checks were preventing calls. 
Should be better now. Using dummy text in cases when auth code is not needed. 