### PR TITLE
feat: e2e test update HP-2818

### DIFF
--- a/e2e/tests/connected-profiles.spec.ts
+++ b/e2e/tests/connected-profiles.spec.ts
@@ -58,7 +58,6 @@ test.skip('2 - Connect profile to Linked Events', async ({ page }) => {
   // Check that the connected profile is visible
   await page.goto(PROFILE_URL);
   await clickProfileLoginButton(page);
-  await page.getByRole('link', { name: 'Helsinki-tunnus' }).click();
   const valuesThatShouldBeInJson = ['linkedevents-test', mailbox.emailAddress];
   await checkDownloadedJson(page, valuesThatShouldBeInJson);
   await clickServiceConnectionsLink(page);
@@ -104,7 +103,6 @@ test('3 - Delete profile', async ({ page }) => {
   // Try to login after deleting the profile
   await page.goto(PROFILE_URL + '/login');
   await clickProfileLoginButton(page);
-  await page.getByRole('link', { name: 'Helsinki-tunnus' }).click();
   await page.getByLabel('Sähköposti').fill(mailbox.emailAddress);
   await page.getByLabel('Salasana', { exact: true }).fill(USER_PASSWORD);
   await clickKeycloakLoginButton(page);

--- a/e2e/tests/modify-profile-info.spec.ts
+++ b/e2e/tests/modify-profile-info.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { USER_PASSWORD } from '../utils/constants';
 import { loginToProfileWithSuomiFi } from '../utils/utils';
 
-const TEST_SSN = '210281-9988';
+const TEST_SSN = '240499-999F';
 const SAVE_SUCCESS = 'Tallennus onnistui';
 
 test.describe.configure({ mode: 'serial' });

--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -2,7 +2,7 @@ import { User } from 'oidc-client-ts';
 import React from 'react';
 import { useOidcClient } from 'hds-react';
 
-export const tunnistusSuomifiAMR = 'heltunnistussuomifi';
+export const tunnistusSuomifiAMR = 'suomi_fi';
 
 export type AMRStatic =
   | 'github'

--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -2,7 +2,7 @@ import { User } from 'oidc-client-ts';
 import React from 'react';
 import { useOidcClient } from 'hds-react';
 
-export const tunnistusSuomifiAMR = 'suomi_fi';
+export const tunnistusSuomifiAMR = 'heltunnistussuomifi';
 
 export type AMRStatic =
   | 'github'


### PR DESCRIPTION
One more PR for removing Tunnistamo.
Fixes for e2e tests and wrong AMR name found by e2e tests.