### PR TITLE
fix: update suomi.fi amr HP-2818

### DIFF
--- a/src/auth/useProfile.ts
+++ b/src/auth/useProfile.ts
@@ -2,7 +2,7 @@ import { User } from 'oidc-client-ts';
 import React from 'react';
 import { useOidcClient } from 'hds-react';
 
-export const tunnistusSuomifiAMR = 'heltunnistussuomifi';
+export const tunnistusSuomifiAMR = 'suomi_fi';
 
 export type AMRStatic =
   | 'github'


### PR DESCRIPTION
Update old tunnistamo amr name for suomi.fi to the name that keycloak uses.