### PR TITLE
fix: Empty keycloak code HP-2818

### DIFF
--- a/src/gdprApi/actions/__tests__/authCodeParser.test.ts
+++ b/src/gdprApi/actions/__tests__/authCodeParser.test.ts
@@ -89,7 +89,7 @@ describe('authCodeParser.ts', () => {
       expect(resultForKeycloak2).toBeUndefined();
     });
 
-    it('Resolves empty string when keycloak auth code is not needed', async () => {
+    it('Resolves dummy code when keycloak auth code is not needed', async () => {
       const { runner, getKeycloadAction } = initTests({
         noKeycloakScopes: true,
       });
@@ -99,12 +99,7 @@ describe('authCodeParser.ts', () => {
       const [, resultForKeycloak] = await to(
         getKeycloadAction().executor(getKeycloadAction(), runner)
       );
-      expect(resultForKeycloak).toBe('');
-
-      const [, resultForKeycloak2] = await to(
-        getKeycloadAction().executor(getKeycloadAction(), runner)
-      );
-      expect(resultForKeycloak2).toBe('');
+      expect(resultForKeycloak).toBe('dummyKeycloakAuthCode');
     });
 
     it('Rejects if the stored state does not match the one in the callback url', async () => {

--- a/src/gdprApi/actions/authCodeParser.ts
+++ b/src/gdprApi/actions/authCodeParser.ts
@@ -14,6 +14,7 @@ import {
 import { getAuthCodeRedirectionInitializationResult } from './authCodeRedirectionInitialization';
 
 const keycloakAuthCodeParserType = 'keycloakAuthCodeParser';
+const dummyKeycloakAuthCode = 'dummyKeycloakAuthCode';
 
 export const getStoredKeycloakAuthCode = (queueController: QueueController) =>
   getActionResultAndErrorMessage<string>(
@@ -23,7 +24,7 @@ export const getStoredKeycloakAuthCode = (queueController: QueueController) =>
 
 const authCodeParserExecutor: ActionExecutor = async (action, controller) => {
   if (!isAuthCodeActionNeeded(action, controller)) {
-    return Promise.resolve('');
+    return Promise.resolve(dummyKeycloakAuthCode);
   }
 
   const rejector = (message: string) =>


### PR DESCRIPTION
Instead of empty string use dummy when kc auth code is not needed. Works now similar way that it was when tunnistamo code was not needed. Maybe fixes issues on dev.