### PR TITLE
fix: e2e test logout timing

### DIFF
--- a/e2e/tests/login-methods.spec.ts
+++ b/e2e/tests/login-methods.spec.ts
@@ -19,7 +19,9 @@ test('Login and logout - Swedish', async ({ page }) => {
   await fillSSNAndContinue(page, TEST_SSN);
   await page.getByRole('button', { name: 'Fortsätt till tjänsten' }).click();
   await page.getByTestId('user-menu-button').click();
-  await page.getByRole('button', { name: 'Logga ut' }).click();
+  const logoutButton = page.getByRole('button', { name: 'Logga ut' });
+  await expect(logoutButton).toBeVisible();
+  await logoutButton.click({ timeout: 500 });
   await expect(
     page.getByText('Din profilinformation på en adress!')
   ).toBeVisible();
@@ -33,7 +35,9 @@ test('Login and logout - English', async ({ page }) => {
   await fillSSNAndContinue(page, TEST_SSN);
   await page.getByRole('button', { name: 'Continue to service' }).click();
   await page.getByTestId('user-menu-button').click();
-  await page.getByRole('button', { name: 'Log out' }).click();
+  const logoutButton = page.getByRole('button', { name: 'Log out' });
+  await expect(logoutButton).toBeVisible();
+  await logoutButton.click({ timeout: 500 });
   await expect(
     page.getByText('Your profile information at one address!')
   ).toBeVisible();

--- a/e2e/tests/login-methods.spec.ts
+++ b/e2e/tests/login-methods.spec.ts
@@ -18,10 +18,14 @@ test('Login and logout - Swedish', async ({ page }) => {
   await page.getByRole('link', { name: 'Test IdP' }).click();
   await fillSSNAndContinue(page, TEST_SSN);
   await page.getByRole('button', { name: 'Fortsätt till tjänsten' }).click();
+  // Wait that the page has loaded
+  await expect(
+    page.getByTestId('profile-information-explanation')
+  ).toBeVisible();
   await page.getByTestId('user-menu-button').click();
   const logoutButton = page.getByRole('button', { name: 'Logga ut' });
   await expect(logoutButton).toBeVisible();
-  await logoutButton.click({ timeout: 500 });
+  await logoutButton.click();
   await expect(
     page.getByText('Din profilinformation på en adress!')
   ).toBeVisible();
@@ -34,10 +38,14 @@ test('Login and logout - English', async ({ page }) => {
   await page.getByRole('link', { name: 'Test IdP' }).click();
   await fillSSNAndContinue(page, TEST_SSN);
   await page.getByRole('button', { name: 'Continue to service' }).click();
+  // Wait that the page has loaded
+  await expect(
+    page.getByTestId('profile-information-explanation')
+  ).toBeVisible();
   await page.getByTestId('user-menu-button').click();
   const logoutButton = page.getByRole('button', { name: 'Log out' });
   await expect(logoutButton).toBeVisible();
-  await logoutButton.click({ timeout: 500 });
+  await logoutButton.click();
   await expect(
     page.getByText('Your profile information at one address!')
   ).toBeVisible();


### PR DESCRIPTION
Sometimes the logout fails when the playwright tests are ran in ci. 
Locally this happens randomly and so rarely that it's hard to see what goes wrong. 
This change hopefully makes the logout part of these test cases more robust.

Example of the failing test:
<img width="718" alt="Screenshot 2025-05-06 at 10 41 31" src="https://github.com/user-attachments/assets/f37c214c-683d-4432-a33c-0fa38725fe21" />

https://dev.azure.com/City-of-Helsinki/helsinki-profile-ui/_build/results?buildId=241509&view=logs&j=4c762496-d062-5bcf-ac84-7dee6baea34e&t=3d41c5bd-9b4e-5049-13f9-2caa3a221b50