### PR TITLE
fix: React 18 related error modal fixes HP-2886

### DIFF
--- a/src/profile/components/errorPage/ErrorPage.tsx
+++ b/src/profile/components/errorPage/ErrorPage.tsx
@@ -76,14 +76,14 @@ function ErrorPage(props?: ErrorPageProps): React.ReactElement {
         ])}
       >
         <Notification
-          type={'error'}
+          type="error"
           label={notificationTitle}
-          data-testid={'error-page-notification'}
+          data-testid="error-page-notification"
         >
           <p>{notificationMessage}</p>
           {hideFrontPageLink !== true && (
             <p>
-              <Link to="/" data-testid={'error-page-frontpage-link'}>
+              <Link to="/" data-testid="error-page-frontpage-link">
                 {t('nav.goToHomePage')}
               </Link>
             </p>
@@ -94,7 +94,7 @@ function ErrorPage(props?: ErrorPageProps): React.ReactElement {
             <LoginButton
               data-testid={'error-page-login-button'}
               errorText={t('authentication.genericError.message')}
-              loggingInText="Logging in"
+              loggingInText={t('nav.loggingIn')}
             >
               {t('login.login')}
             </LoginButton>

--- a/src/profile/components/profile/Profile.module.css
+++ b/src/profile/components/profile/Profile.module.css
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: row;
   padding: var(--spacing-m) 0;
+  gap: var(--spacing-m);
 }
 
 .error-button-wrapper > * {


### PR DESCRIPTION
This should fix issues with delete account and delete service error modals.
Changes in rendering with React 18 caused error dialogs to sometimes to fail appearing. Very randomly when running in browser, but playwright tests fail always. 

Also adjust a bit the error dialog code and styling.

https://helsinkisolutionoffice.atlassian.net/browse/HP-2886