### PR TITLE
fix: reminder for oics-client-ts changes HP-2910

### DIFF
--- a/public/silent_renew.html
+++ b/public/silent_renew.html
@@ -4,6 +4,7 @@
     <title>Silent renewal</title>
   </head>
   <body>
+    <!-- Remember to update sha in CSP if oidc-client-ts import changes -->
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/oidc-client-ts/2.2.2/browser/oidc-client-ts.min.js"
       integrity="sha512-pt8b5O4w5Y9/xZpIhPN8Soo/YbC95SxHn0P/Mu39iYB2Ih/09TMS3Id5XPqve2f8DPC6voXOzgQNojCuqO6A4w=="


### PR DESCRIPTION
Reminder if/when  oics-client-ts is updated to also update it's SHA in content security policy

Actual fix is done in this PR: https://dev.azure.com/City-of-Helsinki/helsinki-profile-ui/_git/helsinki-profile-ui-aok/pullrequest/11813 

Ticket: https://helsinkisolutionoffice.atlassian.net/browse/HP-2910