### PR TITLE
ci: use GITHUB_TOKEN in publish-image worflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,8 +25,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GHCR_CONTAINER_REGISTRY_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Container metadata
         id: meta


### PR DESCRIPTION
Old secrets are no longer compatible with organization authentication requirements. Also this is the correct way to log in to GHCR anyway.

refs: HP-2964