### PR TITLE
feat: skip failing e2e tests temporarily

### DIFF
--- a/e2e/tests/example-app.spec.ts
+++ b/e2e/tests/example-app.spec.ts
@@ -43,7 +43,8 @@ test.describe('Example app tests', () => {
     expect(jwtValidTime).toBe(validTimeValue);
   });
 
-  test('Change pet name', async ({ page }) => {
+  // Enable again when backend issue is solved or when sentry is ok
+  test.skip('Change pet name', async ({ page }) => {
     await page.locator('[data-test-id="header-link-backend"]').click();
     await page.getByLabel('Uusi lemmikin nimi').fill('nodelete');
     await page.getByRole('button', { name: 'Tallenna' }).click();
@@ -53,7 +54,8 @@ test.describe('Example app tests', () => {
   });
 });
 
-test.describe('Profile tests', () => {
+// Enable again when backend issue is solved or when sentry is ok
+test.describe.skip('Profile tests', () => {
   test.beforeEach(async ({ page }) => {
     await acceptCookies(page);
     await loginToProfileWithSuomiFi(page, TEST_SSN);


### PR DESCRIPTION
Temporarily disable example app related e2e tests that currently fail because there is a backend issue.
