### PR TITLE
ci: remove .spec pattern Refs: KEH-189

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,10 +9,6 @@ sonar.exclusions= \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \
-  **/*.test.js, \
-  **/*.test.ts, \
-  **/*.test.jsx, \
-  **/*.test.tsx, \
   src/setupTests.js, \
   src/setupTests.ts
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,6 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 sonar.sources=src
 sonar.exclusions= \
-  **/__tests__/**/*, \
   **/__mocks__/**/*, \
   **/__snapshots__/*, \
   **/*.d.ts, \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,10 +13,6 @@ sonar.exclusions= \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx, \
-  **/*.spec.js, \
-  **/*.spec.ts, \
-  **/*.spec.jsx, \
-  **/*.spec.tsx, \
   src/setupTests.js, \
   src/setupTests.ts
 
@@ -37,8 +33,4 @@ sonar.test.inclusions= \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
-  **/*.test.tsx, \
-  **/*.spec.js, \
-  **/*.spec.ts, \
-  **/*.spec.jsx, \
-  **/*.spec.tsx
+  **/*.test.tsx

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,21 +11,13 @@ sonar.exclusions= \
   src/setupTests.js, \
   src/setupTests.ts
 
-sonar.coverage.exclusions= \
-  **/*.stories.js, \
-  **/*.stories.ts, \
-  **/*.stories.jsx, \
-  **/*.stories.tsx, \
-  src/index.js, \
-  src/index.jsx, \
-  src/index.ts, \
-  src/index.tsx, \
-  src/serviceWorker.js, \
-  src/serviceWorker.ts
-
 sonar.test.inclusions= \
-  **/__tests__/**/*, \
+  **/__tests__/**/*,  \
   **/*.test.js, \
   **/*.test.ts, \
   **/*.test.jsx, \
   **/*.test.tsx
+
+sonar.coverage.exclusions= \
+  src/index.tsx, \
+  src/serviceWorker.ts


### PR DESCRIPTION
- Remove dead patterns
- No need to exclude test file patterns, they are excluded automatically.