### PR TITLE
RATY-312 | Add authentication related cookies to consent settings

### DIFF
--- a/src/cookieConsents/siteSettings.json
+++ b/src/cookieConsents/siteSettings.json
@@ -82,6 +82,51 @@
             "sv": "Session",
             "en": "Session"
           }
+        },
+        {
+          "name": "oidc.user:*",
+          "host": "profiili.hel.fi",
+          "storageType": 3,
+          "description": {
+            "fi": "Käyttäjän kirjautumistiedot tallennetaan selaimen muistiin (session storage).",
+            "sv": "Användarens inloggningsuppgifter lagras i webbläsarens minne (session storage).",
+            "en": "Authentication information of the user is saved to browser's memory (session storage)."
+          },
+          "expiration": {
+            "fi": "Istunto",
+            "sv": "Session",
+            "en": "Session"
+          }
+        },
+        {
+          "name": "hds_login_api_token_storage_key",
+          "host": "profiili.hel.fi",
+          "storageType": 3,
+          "description": {
+            "fi": "Kirjautuneen käyttäjän rajanpinta-avaimet (api tokens) tallennetaan selaimen muistiin (session storage).",
+            "sv": "Api-token för en autentiserad användare sparas i webbläsarens minne (session storage).",
+            "en": "Api tokens of an authenticated user is saved to browser's memory (session storage)."
+          },
+          "expiration": {
+            "fi": "Istunto",
+            "sv": "Session",
+            "en": "Session"
+          }
+        },
+        {
+          "name": "hds_login_api_token_user_reference",
+          "host": "profiili.hel.fi",
+          "storageType": 3,
+          "description": {
+            "fi": "Kirjautuneen käyttäjän pääsyoikeudet tallennetaan selaimen muistiin, jotta tunnistetaan kenen rajapinta-avaimet on tallessa.",
+            "sv": "Den inloggade användarens åtkomsträttigheter lagras i webbläsarens minne för att identifiera vems token som lagras.",
+            "en": "Access token of an authenticated user is saved to browser's memory (session storage) to identify whose api tokens are stored."
+          },
+          "expiration": {
+            "fi": "Istunto",
+            "sv": "Session",
+            "en": "Session"
+          }
         }
       ]
     },


### PR DESCRIPTION
### Description
Add authentication cookies to consent settings to avoid user to be logged out when only required cookies are accepted

- Add authentication cookies:
  - oidc.user:* for authentication data
  - hds_login_api_token_storage_key for API tokens
  - hds_login_api_token_user_reference for user identification