### PR TITLE
feat: require strong auth for hybrid email/password/2FA edits

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -226,6 +226,7 @@
     "noEmail": "You have not entered an email address.",
     "verifyEmailText": "We have sent a verification email to the email address you have entered. If you did not receive the verification email, please check your junk mail folder.",
     "verifyEmailTitle": "Verify email",
+    "explanationForStrongAuthentication": "You can edit your email address, password and two-factor authentication only when you are strongly authenticated. Log out and log back in using Suomi.fi authentication.",
     "contact": "Contact",
     "emailInUse": "The email address you entered is already in use.",
     "contactInformation": "My contact information"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -226,6 +226,7 @@
     "noEmail": "Et ole antanut sähköpostiosoitetta",
     "verifyEmailText": "Olemme lähettäneet lisäämääsi sähköpostiosoitteeseen vahvistusviestin. Jos et saanut viestiä, tarkasta myös sähköpostin roskapostikansio.",
     "verifyEmailTitle": "Vahvista sähköpostiosoite",
+    "explanationForStrongAuthentication": "Voit muokata sähköpostiosoitetta, salasanaa ja kaksivaiheista tunnistautumista vain, jos olet vahvasti tunnistautunut. Kirjaudu ulos ja takaisin sisään käyttäen Suomi.fi-tunnistautumista.",
     "contact": "Yhteystiedot",
     "emailInUse": "Antamasi sähköpostiosoite on jo käytössä.",
     "contactInformation": "Omat yhteystiedot"

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -226,6 +226,7 @@
     "noEmail": "Du har inte upgett en e-postadress",
     "verifyEmailText": "Vi har skickat en bekräftelse till e-postadressen som du angett. Om du inte har fått meddelandet, vänligen kontrollera skräpkorgen för e-post.",
     "verifyEmailTitle": "Bekräfta e-postadressen",
+    "explanationForStrongAuthentication": "Du kan redigera din e-postadress, ditt lösenord och tvåfaktorsautentisering endast när du är starkt autentiserad. Logga ut och logga in igen med Suomi.fi-autentisering.",
     "contact": "Kontaktinformation",
     "emailInUse": "E-postadressen du uppgett används redan.",
     "contactInformation": "Min kontaktinformation"

--- a/src/profile/components/emailEditor/EmailEditor.tsx
+++ b/src/profile/components/emailEditor/EmailEditor.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Field, Formik, FormikProps, Form } from 'formik';
-import { TextInput, Notification, useOidcClient } from 'hds-react';
+import {
+  TextInput,
+  Notification,
+  NotificationSize,
+  useOidcClient,
+} from 'hds-react';
 import classNames from 'classnames';
 
 import styles from './emailEditor.module.css';
@@ -26,9 +31,11 @@ import AccessibilityFieldHelpers from '../../../common/accessibilityFieldHelpers
 import {
   hasHelsinkiAccountAMR,
   hasTunnistusSuomiFiAmr,
+  requiresStrongAuthenticationForHybrid,
 } from '../profileInformation/authenticationProviderUtil';
 import { useCommonEditHandling } from '../../hooks/useCommonEditHandling';
 import AddButton from '../addButton/AddButton';
+import { ProfileContext } from '../../context/ProfileContext';
 
 function EmailEditor(): React.ReactElement | null {
   const dataType: EditDataType = 'emails';
@@ -51,6 +58,7 @@ function EmailEditor(): React.ReactElement | null {
 
   const { content } = notificationContent;
   const { getAmr } = useOidcClient();
+  const { data } = useContext(ProfileContext);
 
   const editData = getEmailEditDataForUI(hasData() ? [getData()] : []);
   const { value, saving } = editData;
@@ -58,8 +66,13 @@ function EmailEditor(): React.ReactElement | null {
   const formFields = getFormFields(dataType);
   const ariaLabels = createActionAriaLabels(dataType, email, t);
   const amrArray = getAmr();
+  const strongAuthenticationRequired = requiresStrongAuthenticationForHybrid(
+    data,
+    amrArray
+  );
   const willSendEmailVerificationCode =
-    hasTunnistusSuomiFiAmr(amrArray) || hasHelsinkiAccountAMR(amrArray);
+    !strongAuthenticationRequired &&
+    (hasTunnistusSuomiFiAmr(amrArray) || hasHelsinkiAccountAMR(amrArray));
   const { hasFieldError, getFieldErrorMessage } =
     createFormFieldHelpers<EmailValue>(t, true);
   const containerStyle = commonFormStyles['responsive-flex-box-columns-rows'];
@@ -165,24 +178,37 @@ function EmailEditor(): React.ReactElement | null {
             commonFormStyles['last-item']
           )}
         >
-          {email ? (
-            <EditButtons
-              handler={actionChecker}
-              actions={{
-                removable: false,
-                setPrimary: false,
-              }}
-              editButtonId={editButtonId}
-              testId={dataType}
-              ariaLabels={ariaLabels}
-            />
-          ) : (
-            <AddButton editHandler={editHandler} />
-          )}
+          {!strongAuthenticationRequired &&
+            (email ? (
+              <EditButtons
+                handler={actionChecker}
+                actions={{
+                  removable: false,
+                  setPrimary: false,
+                }}
+                editButtonId={editButtonId}
+                testId={dataType}
+                ariaLabels={ariaLabels}
+              />
+            ) : (
+              <AddButton editHandler={editHandler} />
+            ))}
         </div>
       </div>
 
       <EditingNotifications content={content} dataType={dataType} />
+
+      {strongAuthenticationRequired && (
+        <div className={styles['notification-wrapper']}>
+          <Notification
+            size={NotificationSize.Small}
+            type={'error'}
+            data-testid="email-strong-authentication-required"
+          >
+            {t('profileInformation.explanationForStrongAuthentication')}
+          </Notification>
+        </div>
+      )}
 
       {showVerifyEmailInfo && (
         <div className={styles['notification-wrapper']}>

--- a/src/profile/components/profileInformation/AuthenticationProviderInformation.tsx
+++ b/src/profile/components/profileInformation/AuthenticationProviderInformation.tsx
@@ -1,9 +1,18 @@
 import React, { Fragment, useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, useOidcClient } from 'hds-react';
+import {
+  Button,
+  Notification,
+  NotificationSize,
+  useOidcClient,
+} from 'hds-react';
 import classNames from 'classnames';
 
-import { getAmrStatic, hasPasswordLogin } from './authenticationProviderUtil';
+import {
+  getAmrStatic,
+  hasPasswordLogin,
+  requiresStrongAuthenticationForHybrid,
+} from './authenticationProviderUtil';
 import OtpInformation from './OtpInformation';
 import ProfileSection from '../../../common/profileSection/ProfileSection';
 import commonFormStyles from '../../../common/cssHelpers/form.module.css';
@@ -22,7 +31,12 @@ function AuthenticationProviderInformation(): React.ReactElement | null {
 
   const hasPassword = hasPasswordLogin(data);
   const { getAmr } = useOidcClient();
-  const amr = getAmrStatic(getAmr());
+  const amrArray = getAmr();
+  const amr = getAmrStatic(amrArray);
+  const strongAuthenticationRequired = requiresStrongAuthenticationForHybrid(
+    data,
+    amrArray
+  );
   const showSuccess = passwordUpdateState;
   const { content, setSuccessMessage } = useNotificationContent();
   const { changePassword } = useAuth();
@@ -84,17 +98,28 @@ function AuthenticationProviderInformation(): React.ReactElement | null {
               </div>
               <div className={commonFormStyles['edit-buttons']}>
                 <div className={commonFormStyles['edit-buttons-container']}>
-                  <Button
-                    data-testid={'change-password-button'}
-                    onClick={() => {
-                      changePassword();
-                    }}
-                  >
-                    {t('profileInformation.changePassword')}
-                  </Button>
+                  {!strongAuthenticationRequired && (
+                    <Button
+                      data-testid={'change-password-button'}
+                      onClick={() => {
+                        changePassword();
+                      }}
+                    >
+                      {t('profileInformation.changePassword')}
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>
+            {strongAuthenticationRequired && (
+              <Notification
+                size={NotificationSize.Small}
+                type={'error'}
+                data-testid="login-method-strong-authentication-required"
+              >
+                {t('profileInformation.explanationForStrongAuthentication')}
+              </Notification>
+            )}
             <EditingNotifications
               ref={notificationRef}
               content={content}
@@ -102,7 +127,9 @@ function AuthenticationProviderInformation(): React.ReactElement | null {
               bottomSpacing
             />
 
-            {config.mfa && <OtpInformation />}
+            {config.mfa && (
+              <OtpInformation disableActions={strongAuthenticationRequired} />
+            )}
           </Fragment>
         )}
       </div>

--- a/src/profile/components/profileInformation/OtpInformation.tsx
+++ b/src/profile/components/profileInformation/OtpInformation.tsx
@@ -17,7 +17,13 @@ import useNotificationContent from '../editingNotifications/useNotificationConte
 import EditingNotifications from '../editingNotifications/EditingNotifications';
 import useAuth from '../../../auth/useAuth';
 
-function OtpInformation(): React.ReactElement | null {
+type Props = {
+  disableActions?: boolean;
+};
+
+function OtpInformation({
+  disableActions = false,
+}: Props): React.ReactElement | null {
   const { t } = useTranslation();
   const notificationRef = useRef<HTMLDivElement>(null);
 
@@ -103,7 +109,7 @@ function OtpInformation(): React.ReactElement | null {
         </div>
         <div className={commonFormStyles['edit-buttons']}>
           <div className={commonFormStyles['edit-buttons-container']}>
-            {!MFALoginMethod && (
+            {!MFALoginMethod && !disableActions && (
               <Button
                 data-testid={'enable-totp-button'}
                 onClick={() => {
@@ -113,7 +119,7 @@ function OtpInformation(): React.ReactElement | null {
                 {t('mfa.enable')}
               </Button>
             )}
-            {MFALoginMethod && (
+            {MFALoginMethod && !disableActions && (
               <Button
                 data-testid={'disable-totp-button'}
                 iconStart={<IconCrossCircle />}

--- a/src/profile/components/profileInformation/__tests__/authenticationProviderUtil.test.ts
+++ b/src/profile/components/profileInformation/__tests__/authenticationProviderUtil.test.ts
@@ -1,8 +1,62 @@
-import { formatDate } from '../authenticationProviderUtil';
+import { LoginMethodType } from '../../../../graphql/typings';
+import { getMyProfile } from '../../../../common/test/myProfileMocking';
+import { MyLoginMethodNodeFragment } from '../../../../graphql/generatedTypes';
+import {
+  formatDate,
+  requiresStrongAuthenticationForHybrid,
+} from '../authenticationProviderUtil';
 
 describe('formatDate', () => {
   it('should return formatted date', () => {
     const dateString = '2025-01-17T12:49:12.518000+00:00';
     expect(formatDate(dateString)).toEqual('17.1.2025');
+  });
+});
+
+describe('requiresStrongAuthenticationForHybrid', () => {
+  const suomiFiLoginMethod: MyLoginMethodNodeFragment = {
+    __typename: 'LoginMethodNode',
+    method: LoginMethodType.SUOMI_FI,
+    createdAt: '2025-01-24T11:27:45.637Z',
+    credentialId: null,
+    userLabel: null,
+  };
+
+  const getHybridProfile = () => {
+    const profile = getMyProfile();
+    if (!profile.myProfile) {
+      return profile;
+    }
+
+    return {
+      ...profile,
+      myProfile: {
+        ...profile.myProfile,
+        availableLoginMethods: [
+          ...(profile.myProfile.availableLoginMethods || []),
+          suomiFiLoginMethod,
+        ],
+      },
+    };
+  };
+
+  it('returns true for hybrid account when current session is weakly authenticated', () => {
+    expect(
+      requiresStrongAuthenticationForHybrid(getHybridProfile(), [
+        'helsinki_tunnus',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false for hybrid account when current session is strongly authenticated', () => {
+    expect(
+      requiresStrongAuthenticationForHybrid(getHybridProfile(), ['suomi_fi'])
+    ).toBe(false);
+  });
+
+  it('returns false when account is not hybrid', () => {
+    expect(
+      requiresStrongAuthenticationForHybrid(getMyProfile(), ['helsinki_tunnus'])
+    ).toBe(false);
   });
 });

--- a/src/profile/components/profileInformation/authenticationProviderUtil.ts
+++ b/src/profile/components/profileInformation/authenticationProviderUtil.ts
@@ -53,6 +53,25 @@ export function hasPasswordLogin(data: ProfileRoot | undefined): boolean {
   );
 }
 
+export function hasStrongLoginMethod(data: ProfileRoot | undefined): boolean {
+  return (
+    data?.myProfile?.availableLoginMethods?.some(
+      (item) => item && item.method === LoginMethodType.SUOMI_FI
+    ) ?? false
+  );
+}
+
+export function hasHybridLoginMethods(data: ProfileRoot | undefined): boolean {
+  return hasPasswordLogin(data) && hasStrongLoginMethod(data);
+}
+
+export function requiresStrongAuthenticationForHybrid(
+  data: ProfileRoot | undefined,
+  amrArray: Amr | undefined
+): boolean {
+  return hasHybridLoginMethods(data) && !hasTunnistusSuomiFiAmr(amrArray);
+}
+
 export function getMFALoginMethod(
   data: ProfileRoot | undefined
 ): MyLoginMethodNodeFragment | undefined {


### PR DESCRIPTION
feat: require strong auth for hybrid email/password/2FA edits

Screenshot:
<img width="1907" height="1526" alt="image" src="https://github.com/user-attachments/assets/04cd0227-cbe2-4169-9cbd-8858027d6bbc" />


Refs: HP-2898