### PR TITLE
fix: enable skipped unit tests HP-3060

### DIFF
--- a/e2e/tests/example-app.spec.ts
+++ b/e2e/tests/example-app.spec.ts
@@ -43,8 +43,7 @@ test.describe('Example app tests', () => {
     expect(jwtValidTime).toBe(validTimeValue);
   });
 
-  // Enable again when backend issue is solved or when sentry is ok
-  test.skip('Change pet name', async ({ page }) => {
+  test('Change pet name', async ({ page }) => {
     await page.locator('[data-test-id="header-link-backend"]').click();
     await page.getByLabel('Uusi lemmikin nimi').fill('nodelete');
     await page.getByRole('button', { name: 'Tallenna' }).click();
@@ -54,8 +53,7 @@ test.describe('Example app tests', () => {
   });
 });
 
-// Enable again when backend issue is solved or when sentry is ok
-test.describe.skip('Profile tests', () => {
+test.describe('Profile tests', () => {
   test.beforeEach(async ({ page }) => {
     await acceptCookies(page);
     await loginToProfileWithSuomiFi(page, TEST_SSN);


### PR DESCRIPTION

Kaksi playwright e2e testiä on ollut jonkin aikaa disabloituna koska backendissä oli virhe (lemmikin nimeä ei voinut tallentaa example appissa).
Testit disabloitiin tässä: [feat: skip failing e2e tests temporarily by Riippi · Pull Request #473 · City-of-Helsinki/open-city-profile-ui](https://github.com/City-of-Helsinki/open-city-profile-ui/pull/473) 

Tuo vika on sittemmin korjattu backendissa ja testit toimivat jälleen. 
Kyseessä on nykyään turha toiminnallisuus profiilissa ja vika ei ole sen oikeaan käyttöön vaikuttanut. Mutta laitetaan testit takaisin päälle.


https://helsinkisolutionoffice.atlassian.net/browse/HP-3060

Refs: HP-3060