### PR TITLE
fix: allow root in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Allow: /
-Disallow: /*
+Allow: /$
+Disallow: /


### PR DESCRIPTION
Previous version accidentally blocked root.

Refs: HP-3034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawler access directives to refine path-level access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->